### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stx402-agent",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stx402-agent",
-      "version": "1.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stx402-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Claude Code MCP server for x402 endpoint discovery and execution with Stacks wallet integration",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
- feat(bns): add BNS V2 API service
- fix(bns): correct availability check for V2 names