### PR TITLE
fix: use backend API URL as default for Pillar tools

### DIFF
--- a/src/config/pillar.ts
+++ b/src/config/pillar.ts
@@ -1,3 +1,3 @@
 // Pillar API configuration
-export const PILLAR_API_URL = process.env.PILLAR_API_URL || "https://pillarbtc.com";
+export const PILLAR_API_URL = process.env.PILLAR_API_URL || "https://pillar-be.vercel.app";
 export const PILLAR_API_KEY = process.env.PILLAR_API_KEY || "";


### PR DESCRIPTION
## Summary
- Default `PILLAR_API_URL` was pointing to `pillarbtc.com` (the frontend SPA), causing 405 errors when MCP tools called `/api/mcp/*` endpoints
- Changed default to `pillar-be.vercel.app` (the actual backend API)
- Users can still override via `PILLAR_API_URL` env var

## Test plan
- [x] Verified `POST /api/mcp/create-op` returns 200 on `pillar-be.vercel.app`
- [x] Verified same endpoint returns 405 on `pillarbtc.com` (frontend doesn't serve API routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)