### PR TITLE
docs: update README and skill for Bitcoin-first branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 [![npm version](https://img.shields.io/npm/v/@aibtc/mcp-server.svg)](https://www.npmjs.com/package/@aibtc/mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-An MCP (Model Context Protocol) server that gives Claude its own Stacks wallet to interact with the blockchain and x402 paid API endpoints.
+A Bitcoin-first MCP (Model Context Protocol) server that gives agents their own wallet for Bitcoin L1 operations, with Stacks L2 support for DeFi and x402 paid API endpoints.
 
 ## Features
 
-- **Agent's Own Wallet** - Claude gets its own wallet to perform blockchain transactions
+- **Bitcoin L1** - Check balances, send BTC, manage UTXOs via mempool.space
+- **Agent's Own Wallet** - Agents get their own wallet to perform blockchain transactions
 - **Secure Storage** - Wallets encrypted with AES-256-GCM and stored locally
-- **50+ Tools** - Comprehensive Stacks blockchain operations
+- **60+ Tools** - Bitcoin L1 + comprehensive Stacks L2 operations
 - **sBTC Support** - Native Bitcoin on Stacks operations
 - **Token Operations** - SIP-010 fungible token transfers and queries
 - **NFT Support** - SIP-009 NFT holdings, transfers, and metadata

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -4,7 +4,7 @@ description: Bitcoin L1 wallet for agents - check balances, send BTC, manage UTX
 license: MIT
 metadata:
   author: aibtcdev
-  version: 1.7.0
+  version: 1.9.0
   npm: "@aibtc/mcp-server"
   github: https://github.com/aibtcdev/aibtc-mcp-server
 ---


### PR DESCRIPTION
## Summary

Update documentation to reflect Bitcoin-first positioning before 1.9.0 release.

## Changes

- **README.md**: Update description from "Stacks wallet" to "Bitcoin-first MCP server"
- **README.md**: Add "Bitcoin L1" as first feature, update tool count to 60+
- **skill/SKILL.md**: Bump version from 1.7.0 to 1.9.0

## Context

Follows up on #36 (Bitcoin-first wallet experience) to ensure all docs reflect the new positioning.

🤖 Generated with [Claude Code](https://claude.ai/code)