### PR TITLE
fix(ci): pass token explicitly to clawhub CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
             --name "AIBTC Bitcoin Wallet" \
             --version "$VERSION" \
             --changelog "$CHANGELOG" \
-            --tags latest
+            --tags latest \
+            --token "$CLAWHUB_API_TOKEN"
         env:
           CLAWHUB_API_TOKEN: ${{ secrets.CLAWHUB_API_TOKEN }}


### PR DESCRIPTION
The CLAWHUB_API_TOKEN env var wasn't being picked up by the CLI. Pass it explicitly via --token flag.