### PR TITLE
fix(wallet): add divider before mnemonic in wallet_create response

### DIFF
--- a/src/tools/wallet-management.tools.ts
+++ b/src/tools/wallet-management.tools.ts
@@ -45,6 +45,7 @@ IMPORTANT: Save the mnemonic securely - it will only be shown once!`,
           address: result.address,
           btcAddress: result.btcAddress,
           network: network || NETWORK,
+          "---": "",
           mnemonic: result.mnemonic,
           warning:
             "CRITICAL: Save this mnemonic phrase securely! It will NOT be shown again. " +


### PR DESCRIPTION
## Summary
- Add a visual separator (`"---": ""`) between address fields and mnemonic/warning fields
- Improves display consistency when rendering wallet creation output

## Test plan
- [x] Restart MCP server after merge
- [x] Create a new wallet with `wallet_create`
- [x] Verify the `"---": ""` field appears between `network` and `mnemonic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)