### PR TITLE
fix(signing): update Account field names after refactor

### DIFF
--- a/src/tools/signing.tools.ts
+++ b/src/tools/signing.tools.ts
@@ -411,7 +411,7 @@ export function registerSigningTools(server: McpServer): void {
           success: true,
           signature,
           signatureFormat: "RSV (65 bytes hex)",
-          signer: account.stacksAddress,
+          signer: account.address,
           network: NETWORK,
           chainId,
           hashes: {
@@ -619,7 +619,7 @@ export function registerSigningTools(server: McpServer): void {
           success: true,
           signature,
           signatureFormat: "RSV (65 bytes hex)",
-          signer: account.stacksAddress,
+          signer: account.address,
           network: NETWORK,
           message: {
             original: message,
@@ -785,7 +785,7 @@ export function registerSigningTools(server: McpServer): void {
           signature: signatureHex,
           signatureBase64,
           signatureFormat: "BIP-137 (65 bytes: 1 header + 32 r + 32 s)",
-          signer: account.bitcoinAddress,
+          signer: account.btcAddress,
           network: NETWORK,
           addressType: "P2WPKH (native SegWit)",
           message: {


### PR DESCRIPTION
## Summary

Fixes build failure after merging #49 and #50 in quick succession.

PR #50 renamed Account fields while #49 was being merged:
- `stacksAddress` → `address`
- `bitcoinAddress` → `btcAddress`

This PR updates the signing tools to use the new field names.

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 176 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)