### PR TITLE
feat: add unified swap router with Velar DEX integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@stacks/network": "^7.3.1",
     "@stacks/transactions": "^7.3.1",
     "@stacks/wallet-sdk": "^7.2.0",
+    "@velarprotocol/velar-sdk": "^0.7.6",
     "alex-sdk": "^3.2.1",
     "axios": "^1.13.2",
     "dotenv": "^17.2.3",

--- a/src/services/swap-router.service.ts
+++ b/src/services/swap-router.service.ts
@@ -1,0 +1,449 @@
+import { type Network, getContracts } from "../config/index.js";
+import type { Account, TransferResult } from "../transactions/builder.js";
+import { getAlexDexService, type SwapQuote as AlexSwapQuote } from "./defi.service.js";
+import { getBitflowService, type BitflowSwapQuote } from "./bitflow.service.js";
+import { getVelarService, type VelarSwapQuote } from "./velar.service.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type TokenSymbol = "BTC" | "sBTC" | "STX" | "ALEX" | "VELAR" | string;
+
+export interface SwapRoute {
+  dex: "alex" | "bitflow" | "velar";
+  tokenIn: string;
+  tokenOut: string;
+  amountIn: string;
+  amountOut: string;
+  priceImpact?: string;
+  route: string[];
+  available: boolean;
+  error?: string;
+}
+
+export interface CompareQuotesResult {
+  tokenIn: string;
+  tokenOut: string;
+  amountIn: string;
+  quotes: SwapRoute[];
+  bestQuote: SwapRoute | null;
+  recommendation: string;
+}
+
+export interface SwapExecuteResult {
+  success: boolean;
+  dex: string;
+  txid: string;
+  tokenIn: string;
+  tokenOut: string;
+  amountIn: string;
+  expectedAmountOut: string;
+  explorerUrl: string;
+}
+
+// ============================================================================
+// Token Mapping
+// ============================================================================
+
+// Common token identifiers across DEXes
+const TOKEN_ALIASES: Record<string, Record<string, string>> = {
+  alex: {
+    STX: "STX",
+    WSTX: "STX",
+    sBTC: "token-sbtc",
+    SBTC: "token-sbtc",
+    ALEX: "ALEX",
+  },
+  bitflow: {
+    STX: "SP1Y5YSTAHZ88XYK1VPDH24GY0HPX5J4JECTMY4A1.wstx",
+    sBTC: "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token",
+  },
+  velar: {
+    STX: "STX",
+    sBTC: "sBTC",
+  },
+};
+
+function resolveToken(dex: string, symbol: string): string {
+  const aliases = TOKEN_ALIASES[dex] || {};
+  return aliases[symbol.toUpperCase()] || symbol;
+}
+
+// ============================================================================
+// Swap Router Service
+// ============================================================================
+
+export class SwapRouterService {
+  private contracts: ReturnType<typeof getContracts>;
+
+  constructor(private network: Network) {
+    this.contracts = getContracts(network);
+  }
+
+  private ensureMainnet(): void {
+    if (this.network !== "mainnet") {
+      throw new Error("Swap router is only available on mainnet");
+    }
+  }
+
+  /**
+   * Get quotes from all available DEXes and compare
+   */
+  async compareQuotes(
+    tokenIn: TokenSymbol,
+    tokenOut: TokenSymbol,
+    amountIn: string,
+    userAddress?: string
+  ): Promise<CompareQuotesResult> {
+    this.ensureMainnet();
+
+    const quotes: SwapRoute[] = [];
+    const amount = parseFloat(amountIn);
+
+    // Get ALEX quote
+    try {
+      const alexService = getAlexDexService(this.network);
+      const alexTokenIn = resolveToken("alex", tokenIn);
+      const alexTokenOut = resolveToken("alex", tokenOut);
+      const amountBigInt = BigInt(Math.floor(amount));
+      const senderAddress = userAddress || "SP000000000000000000002Q6VF78";
+
+      const alexQuote = await alexService.getSwapQuote(alexTokenIn, alexTokenOut, amountBigInt, senderAddress);
+      quotes.push({
+        dex: "alex",
+        tokenIn: alexTokenIn,
+        tokenOut: alexTokenOut,
+        amountIn: alexQuote.amountIn,
+        amountOut: alexQuote.amountOut,
+        priceImpact: alexQuote.priceImpact,
+        route: alexQuote.route,
+        available: true,
+      });
+    } catch (error) {
+      quotes.push({
+        dex: "alex",
+        tokenIn,
+        tokenOut,
+        amountIn,
+        amountOut: "0",
+        route: [],
+        available: false,
+        error: (error as Error).message,
+      });
+    }
+
+    // Get Bitflow quote (if API key configured)
+    try {
+      const bitflowService = getBitflowService(this.network);
+      if (bitflowService.isSdkAvailable()) {
+        const bitflowTokenIn = resolveToken("bitflow", tokenIn);
+        const bitflowTokenOut = resolveToken("bitflow", tokenOut);
+
+        const bitflowQuote = await bitflowService.getSwapQuote(
+          bitflowTokenIn,
+          bitflowTokenOut,
+          amount
+        );
+        quotes.push({
+          dex: "bitflow",
+          tokenIn: bitflowTokenIn,
+          tokenOut: bitflowTokenOut,
+          amountIn: bitflowQuote.amountIn,
+          amountOut: bitflowQuote.expectedAmountOut,
+          route: bitflowQuote.route,
+          available: true,
+        });
+      } else {
+        quotes.push({
+          dex: "bitflow",
+          tokenIn,
+          tokenOut,
+          amountIn,
+          amountOut: "0",
+          route: [],
+          available: false,
+          error: "Bitflow API key not configured",
+        });
+      }
+    } catch (error) {
+      quotes.push({
+        dex: "bitflow",
+        tokenIn,
+        tokenOut,
+        amountIn,
+        amountOut: "0",
+        route: [],
+        available: false,
+        error: (error as Error).message,
+      });
+    }
+
+    // Get Velar quote
+    try {
+      const velarService = getVelarService(this.network);
+      const velarTokenIn = resolveToken("velar", tokenIn);
+      const velarTokenOut = resolveToken("velar", tokenOut);
+
+      const velarQuote = await velarService.getQuote(
+        userAddress || "SP000000000000000000002Q6VF78", // Placeholder if no address
+        velarTokenIn,
+        velarTokenOut,
+        amount
+      );
+
+      if (velarQuote.valid) {
+        quotes.push({
+          dex: "velar",
+          tokenIn: velarTokenIn,
+          tokenOut: velarTokenOut,
+          amountIn: velarQuote.amountIn,
+          amountOut: velarQuote.amountOut,
+          route: velarQuote.route,
+          available: true,
+        });
+      } else {
+        quotes.push({
+          dex: "velar",
+          tokenIn,
+          tokenOut,
+          amountIn,
+          amountOut: "0",
+          route: [],
+          available: false,
+          error: velarQuote.errorMessage || "No route found",
+        });
+      }
+    } catch (error) {
+      quotes.push({
+        dex: "velar",
+        tokenIn,
+        tokenOut,
+        amountIn,
+        amountOut: "0",
+        route: [],
+        available: false,
+        error: (error as Error).message,
+      });
+    }
+
+    // Find best quote (highest output)
+    const availableQuotes = quotes.filter((q) => q.available);
+    let bestQuote: SwapRoute | null = null;
+
+    if (availableQuotes.length > 0) {
+      bestQuote = availableQuotes.reduce((best, current) => {
+        const bestOut = parseFloat(best.amountOut);
+        const currentOut = parseFloat(current.amountOut);
+        return currentOut > bestOut ? current : best;
+      });
+    }
+
+    // Generate recommendation
+    let recommendation: string;
+    if (!bestQuote) {
+      recommendation = "No swap routes available for this pair";
+    } else if (availableQuotes.length === 1) {
+      recommendation = `Only ${bestQuote.dex.toUpperCase()} has liquidity for this pair`;
+    } else {
+      const savings = availableQuotes
+        .filter((q) => q !== bestQuote)
+        .map((q) => {
+          const diff = parseFloat(bestQuote!.amountOut) - parseFloat(q.amountOut);
+          const pct = (diff / parseFloat(q.amountOut)) * 100;
+          return `${pct.toFixed(2)}% better than ${q.dex}`;
+        })
+        .join(", ");
+      recommendation = `${bestQuote.dex.toUpperCase()} offers best rate (${savings})`;
+    }
+
+    return {
+      tokenIn,
+      tokenOut,
+      amountIn,
+      quotes,
+      bestQuote,
+      recommendation,
+    };
+  }
+
+  /**
+   * Execute swap through specified DEX
+   */
+  async executeSwap(
+    account: Account,
+    dex: "alex" | "bitflow" | "velar",
+    tokenIn: TokenSymbol,
+    tokenOut: TokenSymbol,
+    amountIn: string,
+    minAmountOut?: string,
+    slippage: number = 0.5
+  ): Promise<SwapExecuteResult> {
+    this.ensureMainnet();
+
+    const amount = parseFloat(amountIn);
+    let result: TransferResult;
+    let expectedAmountOut: string;
+
+    switch (dex) {
+      case "alex": {
+        const alexService = getAlexDexService(this.network);
+        const alexTokenIn = resolveToken("alex", tokenIn);
+        const alexTokenOut = resolveToken("alex", tokenOut);
+        const amountBigInt = BigInt(Math.floor(amount));
+
+        // Get quote first for expected output
+        const quote = await alexService.getSwapQuote(alexTokenIn, alexTokenOut, amountBigInt, account.address);
+        expectedAmountOut = quote.amountOut;
+
+        // Check min output if specified
+        if (minAmountOut && parseFloat(expectedAmountOut) < parseFloat(minAmountOut)) {
+          throw new Error(
+            `Output ${expectedAmountOut} is less than minimum ${minAmountOut}`
+          );
+        }
+
+        // Calculate minAmountOut from slippage (default 0.5%)
+        const expectedOut = BigInt(quote.amountOut);
+        const slippageFactor = BigInt(Math.floor((1 - slippage / 100) * 10000));
+        const minOut = minAmountOut
+          ? BigInt(minAmountOut)
+          : (expectedOut * slippageFactor) / 10000n;
+
+        result = await alexService.swap(account, alexTokenIn, alexTokenOut, amountBigInt, minOut);
+        break;
+      }
+
+      case "bitflow": {
+        const bitflowService = getBitflowService(this.network);
+        if (!bitflowService.isSdkAvailable()) {
+          throw new Error("Bitflow API key not configured");
+        }
+
+        const bitflowTokenIn = resolveToken("bitflow", tokenIn);
+        const bitflowTokenOut = resolveToken("bitflow", tokenOut);
+
+        // Get quote first
+        const quote = await bitflowService.getSwapQuote(bitflowTokenIn, bitflowTokenOut, amount);
+        expectedAmountOut = quote.expectedAmountOut;
+
+        // Check min output
+        if (minAmountOut && parseFloat(expectedAmountOut) < parseFloat(minAmountOut)) {
+          throw new Error(
+            `Output ${expectedAmountOut} is less than minimum ${minAmountOut}`
+          );
+        }
+
+        result = await bitflowService.swap(
+          account,
+          bitflowTokenIn,
+          bitflowTokenOut,
+          amount,
+          slippage
+        );
+        break;
+      }
+
+      case "velar": {
+        const velarService = getVelarService(this.network);
+        const velarTokenIn = resolveToken("velar", tokenIn);
+        const velarTokenOut = resolveToken("velar", tokenOut);
+
+        // Get quote first
+        const quote = await velarService.getQuote(
+          account.address,
+          velarTokenIn,
+          velarTokenOut,
+          amount,
+          slippage
+        );
+
+        if (!quote.valid) {
+          throw new Error(quote.errorMessage || "No route found");
+        }
+
+        expectedAmountOut = quote.amountOut;
+
+        // Check min output
+        if (minAmountOut && parseFloat(expectedAmountOut) < parseFloat(minAmountOut)) {
+          throw new Error(
+            `Output ${expectedAmountOut} is less than minimum ${minAmountOut}`
+          );
+        }
+
+        result = await velarService.swap(
+          account,
+          velarTokenIn,
+          velarTokenOut,
+          amount,
+          slippage
+        );
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown DEX: ${dex}`);
+    }
+
+    return {
+      success: true,
+      dex,
+      txid: result.txid,
+      tokenIn,
+      tokenOut,
+      amountIn,
+      expectedAmountOut,
+      explorerUrl: `https://explorer.hiro.so/txid/${result.txid}?chain=mainnet`,
+    };
+  }
+
+  /**
+   * Execute swap through best available DEX
+   */
+  async executeBestSwap(
+    account: Account,
+    tokenIn: TokenSymbol,
+    tokenOut: TokenSymbol,
+    amountIn: string,
+    minAmountOut?: string,
+    slippage: number = 0.5
+  ): Promise<SwapExecuteResult> {
+    // Get quotes from all DEXes
+    const comparison = await this.compareQuotes(tokenIn, tokenOut, amountIn, account.address);
+
+    if (!comparison.bestQuote) {
+      throw new Error("No swap routes available for this pair");
+    }
+
+    // Check min output against best quote
+    if (minAmountOut && parseFloat(comparison.bestQuote.amountOut) < parseFloat(minAmountOut)) {
+      throw new Error(
+        `Best output ${comparison.bestQuote.amountOut} is less than minimum ${minAmountOut}`
+      );
+    }
+
+    // Execute through best DEX
+    return this.executeSwap(
+      account,
+      comparison.bestQuote.dex,
+      tokenIn,
+      tokenOut,
+      amountIn,
+      minAmountOut,
+      slippage
+    );
+  }
+}
+
+// ============================================================================
+// Service Singleton
+// ============================================================================
+
+let _swapRouterInstance: SwapRouterService | null = null;
+
+export function getSwapRouterService(network: Network): SwapRouterService {
+  if (!_swapRouterInstance || _swapRouterInstance["network"] !== network) {
+    _swapRouterInstance = new SwapRouterService(network);
+  }
+  return _swapRouterInstance;
+}

--- a/src/services/velar.service.ts
+++ b/src/services/velar.service.ts
@@ -1,0 +1,175 @@
+import {
+  VelarSDK,
+  type SwapConfig,
+  type SwapResponse,
+  type AmountOutResponse,
+} from "@velarprotocol/velar-sdk";
+import {
+  makeContractCall,
+  broadcastTransaction,
+} from "@stacks/transactions";
+import { STACKS_MAINNET, STACKS_TESTNET } from "@stacks/network";
+import { type Network } from "../config/index.js";
+import type { Account, TransferResult } from "../transactions/builder.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface VelarSwapQuote {
+  tokenIn: string;
+  tokenOut: string;
+  amountIn: string;
+  amountOut: string;
+  route: string[];
+  valid: boolean;
+  errorMessage?: string;
+}
+
+export interface VelarToken {
+  id: string;
+  symbol: string;
+  name: string;
+  contractAddress: string;
+  decimals: number;
+}
+
+// ============================================================================
+// Velar Service
+// ============================================================================
+
+export class VelarService {
+  private sdk: VelarSDK;
+  private initialized = false;
+
+  constructor(private network: Network) {
+    this.sdk = new VelarSDK();
+  }
+
+  private ensureMainnet(): void {
+    if (this.network !== "mainnet") {
+      throw new Error("Velar DEX is only available on mainnet");
+    }
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) {
+      await this.sdk.init();
+      this.initialized = true;
+    }
+  }
+
+  /**
+   * Get available trading pairs for a token
+   */
+  async getPairs(symbol: string): Promise<string[]> {
+    this.ensureMainnet();
+    await this.ensureInitialized();
+    return this.sdk.getPairs(symbol);
+  }
+
+  /**
+   * Get swap quote
+   */
+  async getQuote(
+    account: string,
+    inToken: string,
+    outToken: string,
+    amount: number,
+    slippage: number = 0.5
+  ): Promise<VelarSwapQuote> {
+    this.ensureMainnet();
+    await this.ensureInitialized();
+
+    const swapConfig: SwapConfig = {
+      account,
+      inToken,
+      outToken,
+    };
+
+    const swapService = await this.sdk.getSwapInstance(swapConfig);
+    const result: AmountOutResponse = await swapService.getComputedAmount({
+      amount,
+      slippage,
+    });
+
+    return {
+      tokenIn: inToken,
+      tokenOut: outToken,
+      amountIn: amount.toString(),
+      amountOut: result.value?.toString() || "0",
+      route: result.route || [],
+      valid: result.valid ?? false,
+      errorMessage: result.errorMessage,
+    };
+  }
+
+  /**
+   * Execute swap
+   */
+  async swap(
+    account: Account,
+    inToken: string,
+    outToken: string,
+    amount: number,
+    slippage: number = 0.5,
+    fee?: bigint
+  ): Promise<TransferResult> {
+    this.ensureMainnet();
+    await this.ensureInitialized();
+
+    const swapConfig: SwapConfig = {
+      account: account.address,
+      inToken,
+      outToken,
+    };
+
+    const swapService = await this.sdk.getSwapInstance(swapConfig);
+    const swapResponse: SwapResponse = await swapService.swap({
+      amount,
+      slippage,
+    });
+
+    // Build and sign the transaction
+    const network = this.network === "mainnet" ? STACKS_MAINNET : STACKS_TESTNET;
+
+    const transaction = await makeContractCall({
+      contractAddress: swapResponse.contractAddress,
+      contractName: swapResponse.contractName,
+      functionName: swapResponse.functionName,
+      functionArgs: swapResponse.functionArgs,
+      postConditions: swapResponse.postConditions,
+      postConditionMode: swapResponse.postConditionMode,
+      senderKey: account.privateKey,
+      network,
+      ...(fee !== undefined && { fee }),
+    });
+
+    const broadcastResult = await broadcastTransaction({
+      transaction,
+      network,
+    });
+
+    if ("error" in broadcastResult) {
+      throw new Error(`Broadcast failed: ${broadcastResult.error} - ${broadcastResult.reason}`);
+    }
+
+    return {
+      txid: broadcastResult.txid,
+      rawTx: Buffer.from(transaction.serialize()).toString("hex"),
+    };
+  }
+}
+
+// ============================================================================
+// Service Singleton
+// ============================================================================
+
+let _velarServiceInstance: VelarService | null = null;
+
+export function getVelarService(network: Network): VelarService {
+  if (!_velarServiceInstance || _velarServiceInstance["network"] !== network) {
+    _velarServiceInstance = new VelarService(network);
+  }
+  return _velarServiceInstance;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,8 @@ import { registerBnsTools } from "./bns.tools.js";
 // Layer 2b: DeFi (Advanced)
 import { registerDefiTools } from "./defi.tools.js";
 import { registerStackingTools } from "./stacking.tools.js";
+import { registerVelarTools } from "./velar.tools.js";
+import { registerSwapRouterTools } from "./swap-router.tools.js";
 // TODO: Re-enable when Bitflow API key integration is complete
 // import { registerBitflowTools } from "./bitflow.tools.js";
 
@@ -70,6 +72,8 @@ export function registerAllTools(server: McpServer): void {
   // =========================================================================
   registerDefiTools(server);
   registerStackingTools(server);
+  registerVelarTools(server);
+  registerSwapRouterTools(server);
   // registerBitflowTools(server); // Disabled until API key integration
 
   // =========================================================================

--- a/src/tools/swap-router.tools.ts
+++ b/src/tools/swap-router.tools.ts
@@ -1,0 +1,243 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getAccount, getWalletAddress, NETWORK } from "../services/x402.service.js";
+import { getSwapRouterService } from "../services/swap-router.service.js";
+import { createJsonResponse, createErrorResponse, resolveFee } from "../utils/index.js";
+
+export function registerSwapRouterTools(server: McpServer): void {
+  // Compare quotes across DEXes
+  server.registerTool(
+    "swap_compare",
+    {
+      description: `Compare swap quotes across multiple DEXes (ALEX, Bitflow, Velar).
+
+Returns quotes from all available DEXes and recommends the best rate.
+Helps agents find optimal swap routes.
+Only available on mainnet.
+
+Example tokens: STX, sBTC, ALEX, VELAR, or contract IDs`,
+      inputSchema: {
+        tokenIn: z.string().describe("Input token symbol or contract ID"),
+        tokenOut: z.string().describe("Output token symbol or contract ID"),
+        amount: z.string().describe("Amount to swap (in token's smallest unit)"),
+      },
+    },
+    async ({ tokenIn, tokenOut, amount }) => {
+      try {
+        const swapRouter = getSwapRouterService(NETWORK);
+        let userAddress: string | undefined;
+
+        try {
+          userAddress = await getWalletAddress();
+        } catch {
+          // Wallet not configured, will use placeholder
+        }
+
+        const comparison = await swapRouter.compareQuotes(
+          tokenIn,
+          tokenOut,
+          amount,
+          userAddress
+        );
+
+        return createJsonResponse({
+          network: NETWORK,
+          tokenIn: comparison.tokenIn,
+          tokenOut: comparison.tokenOut,
+          amountIn: comparison.amountIn,
+          quotes: comparison.quotes.map((q) => ({
+            dex: q.dex,
+            amountOut: q.amountOut,
+            available: q.available,
+            route: q.route,
+            ...(q.priceImpact && { priceImpact: q.priceImpact }),
+            ...(q.error && { error: q.error }),
+          })),
+          bestQuote: comparison.bestQuote
+            ? {
+                dex: comparison.bestQuote.dex,
+                amountOut: comparison.bestQuote.amountOut,
+                route: comparison.bestQuote.route,
+              }
+            : null,
+          recommendation: comparison.recommendation,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // Execute swap through specific DEX
+  server.registerTool(
+    "swap_execute",
+    {
+      description: `Execute a swap through a specific DEX.
+
+Use swap_compare first to find the best rate, then execute through chosen DEX.
+Includes slippage protection via minAmountOut.
+Only available on mainnet.`,
+      inputSchema: {
+        dex: z
+          .enum(["alex", "bitflow", "velar"])
+          .describe("DEX to use for the swap"),
+        tokenIn: z.string().describe("Input token symbol or contract ID"),
+        tokenOut: z.string().describe("Output token symbol or contract ID"),
+        amount: z.string().describe("Amount to swap"),
+        minAmountOut: z
+          .string()
+          .optional()
+          .describe("Minimum output amount (slippage protection)"),
+        slippage: z
+          .number()
+          .optional()
+          .default(0.5)
+          .describe("Slippage tolerance in percent (default: 0.5)"),
+      },
+    },
+    async ({ dex, tokenIn, tokenOut, amount, minAmountOut, slippage }) => {
+      try {
+        const swapRouter = getSwapRouterService(NETWORK);
+        const account = await getAccount();
+
+        const result = await swapRouter.executeSwap(
+          account,
+          dex,
+          tokenIn,
+          tokenOut,
+          amount,
+          minAmountOut,
+          slippage
+        );
+
+        return createJsonResponse({
+          success: result.success,
+          network: NETWORK,
+          dex: result.dex,
+          txid: result.txid,
+          swap: {
+            tokenIn: result.tokenIn,
+            tokenOut: result.tokenOut,
+            amountIn: result.amountIn,
+            expectedAmountOut: result.expectedAmountOut,
+          },
+          slippage: `${slippage}%`,
+          ...(minAmountOut && { minAmountOut }),
+          explorerUrl: result.explorerUrl,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // Execute swap through best available DEX
+  server.registerTool(
+    "swap_best",
+    {
+      description: `Execute a swap through the DEX offering the best rate.
+
+Automatically compares quotes from ALEX, Bitflow, and Velar,
+then executes through the one with highest output.
+Includes slippage protection.
+Only available on mainnet.`,
+      inputSchema: {
+        tokenIn: z.string().describe("Input token symbol or contract ID"),
+        tokenOut: z.string().describe("Output token symbol or contract ID"),
+        amount: z.string().describe("Amount to swap"),
+        minAmountOut: z
+          .string()
+          .optional()
+          .describe("Minimum output amount (slippage protection)"),
+        slippage: z
+          .number()
+          .optional()
+          .default(0.5)
+          .describe("Slippage tolerance in percent (default: 0.5)"),
+      },
+    },
+    async ({ tokenIn, tokenOut, amount, minAmountOut, slippage }) => {
+      try {
+        const swapRouter = getSwapRouterService(NETWORK);
+        const account = await getAccount();
+
+        const result = await swapRouter.executeBestSwap(
+          account,
+          tokenIn,
+          tokenOut,
+          amount,
+          minAmountOut,
+          slippage
+        );
+
+        return createJsonResponse({
+          success: result.success,
+          network: NETWORK,
+          dex: result.dex,
+          note: `Executed through ${result.dex.toUpperCase()} (best rate)`,
+          txid: result.txid,
+          swap: {
+            tokenIn: result.tokenIn,
+            tokenOut: result.tokenOut,
+            amountIn: result.amountIn,
+            expectedAmountOut: result.expectedAmountOut,
+          },
+          slippage: `${slippage}%`,
+          ...(minAmountOut && { minAmountOut }),
+          explorerUrl: result.explorerUrl,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // Get supported DEXes and their status
+  server.registerTool(
+    "swap_dexes",
+    {
+      description: `List available DEXes and their status.
+
+Shows which DEXes are configured and available for swapping.`,
+    },
+    async () => {
+      try {
+        const { getBitflowService } = await import("../services/bitflow.service.js");
+        const bitflowService = getBitflowService(NETWORK);
+
+        return createJsonResponse({
+          network: NETWORK,
+          dexes: [
+            {
+              name: "ALEX",
+              id: "alex",
+              available: NETWORK === "mainnet",
+              apiKeyRequired: false,
+              note: "Primary Stacks DEX, no API key needed",
+            },
+            {
+              name: "Bitflow",
+              id: "bitflow",
+              available: NETWORK === "mainnet" && bitflowService.isSdkAvailable(),
+              apiKeyRequired: true,
+              note: bitflowService.isSdkAvailable()
+                ? "DEX aggregator with best routes"
+                : "Set BITFLOW_API_KEY to enable",
+            },
+            {
+              name: "Velar",
+              id: "velar",
+              available: NETWORK === "mainnet",
+              apiKeyRequired: false,
+              note: "Velar Dharma - powers Xverse swaps",
+            },
+          ],
+          recommendation:
+            "Use swap_compare to find best rates across all DEXes, then swap_best for automatic execution",
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+}

--- a/src/tools/velar.tools.ts
+++ b/src/tools/velar.tools.ts
@@ -1,0 +1,155 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getAccount, getWalletAddress, NETWORK } from "../services/x402.service.js";
+import { getVelarService } from "../services/velar.service.js";
+import { getExplorerTxUrl } from "../config/networks.js";
+import { createJsonResponse, createErrorResponse, resolveFee } from "../utils/index.js";
+
+export function registerVelarTools(server: McpServer): void {
+  // Get trading pairs for a token
+  server.registerTool(
+    "velar_get_pairs",
+    {
+      description: `Get available trading pairs for a token on Velar DEX.
+
+Velar is a DEX aggregator used by Xverse wallet.
+Only available on mainnet.`,
+      inputSchema: {
+        symbol: z.string().describe("Token symbol (e.g., 'STX', 'sBTC', 'ALEX')"),
+      },
+    },
+    async ({ symbol }) => {
+      try {
+        const velarService = getVelarService(NETWORK);
+        const pairs = await velarService.getPairs(symbol);
+
+        return createJsonResponse({
+          token: symbol,
+          pairs,
+          pairCount: pairs.length,
+          network: NETWORK,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // Get swap quote
+  server.registerTool(
+    "velar_get_quote",
+    {
+      description: `Get a swap quote from Velar DEX.
+
+Returns expected output amount and route for the swap.
+Only available on mainnet.`,
+      inputSchema: {
+        inToken: z.string().describe("Input token symbol (e.g., 'STX')"),
+        outToken: z.string().describe("Output token symbol (e.g., 'sBTC')"),
+        amount: z.string().describe("Amount to swap (in token's smallest unit)"),
+        slippage: z
+          .number()
+          .optional()
+          .default(0.5)
+          .describe("Slippage tolerance in percent (default: 0.5)"),
+      },
+    },
+    async ({ inToken, outToken, amount, slippage }) => {
+      try {
+        const velarService = getVelarService(NETWORK);
+        const walletAddress = await getWalletAddress();
+
+        const quote = await velarService.getQuote(
+          walletAddress,
+          inToken,
+          outToken,
+          parseFloat(amount),
+          slippage
+        );
+
+        return createJsonResponse({
+          ...quote,
+          slippage: `${slippage}%`,
+          network: NETWORK,
+          valid: quote.valid,
+          ...(quote.errorMessage && { error: quote.errorMessage }),
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // Execute swap
+  server.registerTool(
+    "velar_swap",
+    {
+      description: `Execute a token swap on Velar DEX.
+
+Swaps tokens using Velar's liquidity pools.
+Only available on mainnet.`,
+      inputSchema: {
+        inToken: z.string().describe("Input token symbol (e.g., 'STX')"),
+        outToken: z.string().describe("Output token symbol (e.g., 'sBTC')"),
+        amount: z.string().describe("Amount to swap (in token's smallest unit)"),
+        slippage: z
+          .number()
+          .optional()
+          .default(0.5)
+          .describe("Slippage tolerance in percent (default: 0.5)"),
+        fee: z
+          .string()
+          .optional()
+          .describe("Optional fee: 'low' | 'medium' | 'high' preset or micro-STX amount"),
+      },
+    },
+    async ({ inToken, outToken, amount, slippage, fee }) => {
+      try {
+        const velarService = getVelarService(NETWORK);
+        const account = await getAccount();
+        const resolvedFee = await resolveFee(fee, NETWORK, "contract_call");
+
+        // Get quote first to show expected output
+        const quote = await velarService.getQuote(
+          account.address,
+          inToken,
+          outToken,
+          parseFloat(amount),
+          slippage
+        );
+
+        if (!quote.valid) {
+          return createErrorResponse(new Error(quote.errorMessage || "No route found"));
+        }
+
+        // Execute swap
+        const result = await velarService.swap(
+          account,
+          inToken,
+          outToken,
+          parseFloat(amount),
+          slippage,
+          resolvedFee
+        );
+
+        return createJsonResponse({
+          success: true,
+          txid: result.txid,
+          dex: "velar",
+          swap: {
+            from: inToken,
+            to: outToken,
+            amountIn: amount,
+            expectedAmountOut: quote.amountOut,
+            route: quote.route,
+          },
+          slippage: `${slippage}%`,
+          network: NETWORK,
+          explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary

- Adds **Velar DEX** integration using `@velarprotocol/velar-sdk` (powers Xverse wallet swaps)
- Creates **unified swap router** that compares quotes across ALEX, Bitflow, and Velar
- Automatically routes swaps to the DEX offering the best rate

## New Tools

### Swap Router (cross-DEX)
| Tool | Description |
|------|-------------|
| `swap_compare` | Compare quotes across all DEXes |
| `swap_execute` | Execute swap through specific DEX |
| `swap_best` | Auto-route to best available rate |
| `swap_dexes` | List DEXes and their availability |

### Velar DEX
| Tool | Description |
|------|-------------|
| `velar_get_pairs` | Get trading pairs for a token |
| `velar_get_quote` | Get swap quote |
| `velar_swap` | Execute swap |

## Architecture

```
swap_best
    ↓
swap_compare (parallel quotes)
    ├── ALEX SDK
    ├── Bitflow SDK (if API key set)
    └── Velar SDK
    ↓
Execute through best DEX
```

## Test Plan

- [ ] Verify build passes (`bun run build`)
- [ ] Test `swap_dexes` returns correct availability
- [ ] Test `swap_compare` with STX/sBTC pair
- [ ] Test `velar_get_quote` returns valid quote
- [ ] Test `swap_best` executes through highest-output DEX

🤖 Generated with [Claude Code](https://claude.com/claude-code)