### PR TITLE
feat: add native BTC → sBTC bridge deposit

### DIFF
--- a/src/services/sbtc-deposit.service.ts
+++ b/src/services/sbtc-deposit.service.ts
@@ -229,15 +229,14 @@ export class SbtcDepositService {
   }
 
   /**
-   * Build a signed sBTC deposit transaction
+   * Build an sBTC deposit transaction, optionally signed
    *
    * This method:
    * 1. Fetches UTXOs for the Bitcoin address
    * 2. Builds a deposit address with deposit/reclaim scripts
    * 3. Constructs a transaction that sends BTC to the deposit address
-   * 4. Returns the unsigned transaction and deposit details
-   *
-   * The transaction must be signed by the user before broadcasting.
+   * 4. If `privateKey` is provided, signs and finalizes the transaction
+   * 5. Returns the transaction hex (signed or unsigned), txid, and deposit details
    *
    * @param amountSats - Amount to deposit in satoshis
    * @param stacksAddress - Stacks L2 address to receive sBTC

--- a/src/services/wallet-manager.ts
+++ b/src/services/wallet-manager.ts
@@ -278,6 +278,14 @@ class WalletManager {
    */
   lock(): void {
     this.clearAutoLockTimer();
+    // Zero out sensitive key buffers before dropping references
+    if (this.session?.account) {
+      const acct = this.session.account;
+      if (acct.btcPrivateKey) acct.btcPrivateKey.fill(0);
+      if (acct.btcPublicKey) acct.btcPublicKey.fill(0);
+      if (acct.taprootPrivateKey) acct.taprootPrivateKey.fill(0);
+      if (acct.taprootPublicKey) acct.taprootPublicKey.fill(0);
+    }
     this.session = null;
   }
 

--- a/src/tools/sbtc.tools.ts
+++ b/src/tools/sbtc.tools.ts
@@ -239,7 +239,7 @@ Set includeOrdinals=true to allow spending ordinal UTXOs (advanced users only).`
           );
         }
 
-        if (!account.btcAddress || !account.taprootAddress || !account.taprootPrivateKey || !account.taprootPublicKey) {
+        if (!account.btcAddress || !account.taprootAddress || !account.taprootPublicKey) {
           throw new Error(
             "Bitcoin or Taproot keys not available. Please unlock your wallet again."
           );


### PR DESCRIPTION
## Summary

Adds programmatic BTC-to-sBTC conversion directly from the MCP server. Agents can now swap their BTC for sBTC without needing a browser or manual bridge UI.

### How it works

1. User calls `sbtc_deposit` with an amount in satoshis
2. Server fetches the signers' aggregate public key from the `sbtc-registry` contract
3. Builds a Taproot (P2TR) deposit transaction with deposit and reclaim script leaves using the `sbtc` npm package
4. Signs the transaction with the wallet's BTC private key
5. Broadcasts to Bitcoin network via mempool.space
6. Notifies the Emily API so signers can process the deposit
7. sBTC is minted to the user's Stacks address after ~3 Bitcoin block confirmations

### New MCP Tools

| Tool | Description |
|------|-------------|
| `sbtc_deposit` | Deposit BTC to receive sBTC. Accepts amount (sats), feeRate, maxSignerFee, reclaimLockTime |
| `sbtc_deposit_status` | Check deposit status from Emily API by txid |

### Updated Tools

- `sbtc_get_deposit_info` — Now returns a real Taproot deposit address when wallet is unlocked (previously returned static placeholder data)

### New Files

- `src/services/sbtc-deposit.service.ts` — Full deposit lifecycle: address generation, transaction building, signing, broadcasting, Emily notification, status polling

### Modified Files

- `src/services/mempool-api.ts` — Added `getTxHex()` for raw transaction hex (required by sbtc package for UTXO inputs)
- `src/utils/bitcoin.ts` — Added `deriveTaprootKeyPair()` for BIP86 (m/86'/0'/0'/0/0) key derivation
- `src/transactions/builder.ts` — Added `taprootPrivateKey` and `taprootPublicKey` to Account interface
- `src/services/wallet-manager.ts` — Derives and stores Taproot keys during wallet unlock
- `src/tools/sbtc.tools.ts` — Registered `sbtc_deposit`, `sbtc_deposit_status`, updated `sbtc_get_deposit_info`

### Dependencies

- Added `sbtc@0.3.2` — Official Stacks sBTC package for deposit transaction construction and Emily API client

### Technical Notes

- **@scure/btc-signer version mismatch**: The `sbtc` package uses v1.4.0 while aibtc-mcp uses v2.0.1. Solved by passing the private key into the service and signing internally using the sbtc package's own btc-signer instance, avoiding cross-package Transaction type incompatibility.
- **Reclaim safety**: Every deposit includes a reclaim script allowing the depositor to recover BTC after 950 blocks if signers fail to process.
- **Ordinal safety**: Deposit tool uses the wallet's P2WPKH UTXOs (same as `transfer_btc`), inheriting existing cardinal-only UTXO selection.

## Test plan

- [ ] `npm run build` passes cleanly
- [ ] Verify `sbtc_deposit` tool appears in MCP tool listing
- [ ] Verify `sbtc_deposit_status` tool appears in MCP tool listing
- [ ] Verify `sbtc_get_deposit_info` returns real deposit address when wallet is unlocked
- [ ] Test deposit flow on testnet with small amount
- [ ] Verify Emily API notification succeeds after broadcast
- [ ] Verify deposit status polling returns correct lifecycle states