### PR TITLE
feat: add MCP registry configuration for modelcontextprotocol.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@aibtc/mcp-server",
   "version": "1.13.1",
-  "description": "Claude Code MCP server for x402 endpoint discovery and execution with Stacks wallet integration",
+  "description": "Bitcoin-first MCP server for BTC/STX wallets, DeFi, sBTC, NFTs, and x402 paid APIs.",
+  "mcpName": "io.github.aibtcdev/mcp-server",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.aibtcdev/mcp-server",
+  "description": "Bitcoin-first MCP server for BTC/STX wallets, DeFi, sBTC, NFTs, and x402 paid APIs.",
+  "repository": {
+    "url": "https://github.com/aibtcdev/aibtc-mcp-server",
+    "source": "github"
+  },
+  "version": "1.13.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@aibtc/mcp-server",
+      "version": "1.13.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add server.json and mcpName to package.json for publishing to the MCP Registry. Updated description to be concise and consistent.