### PR TITLE
fix: make release publish resilient to already-published versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,7 +46,13 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@aibtc/mcp-server@${VERSION}" version 2>/dev/null; then
+            echo "::notice::@aibtc/mcp-server@${VERSION} already published to npm, skipping"
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -60,7 +66,7 @@ jobs:
       - name: Publish to GitHub Packages
         run: |
           npm pkg set name="@aibtcdev/aibtc-mcp-server"
-          npm publish --access public
+          npm publish --access public || echo "::warning::GitHub Packages publish failed, may already exist"
           npm pkg set name="@aibtc/mcp-server"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,6 +80,7 @@ jobs:
 
       - name: Publish to ClawHub
         if: ${{ !contains(needs.release-please.outputs.tag_name, '-') }}
+        continue-on-error: true
         run: |
           VERSION="${{ needs.release-please.outputs.version }}"
 

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.aibtcdev/mcp-server",
-  "description": "Bitcoin-native MCP server for AI agents: BTC/STX wallets, DeFi yield, sBTC peg, NFTs, and x402 payments.",
+  "description": "Bitcoin-native MCP server for AI agents: BTC/STX wallets, DeFi yield, sBTC peg, NFTs, x402 payments.",
   "repository": {
     "url": "https://github.com/aibtcdev/aibtc-mcp-server",
     "source": "github"
   },
-  "version": "1.14.0",
+  "version": "1.14.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aibtc/mcp-server",
-      "version": "1.14.0",
+      "version": "1.14.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
npm publish fails with E403 when a version already exists, which cascades and blocks GitHub Packages and ClawHub from publishing. Check if the version exists on npm before attempting publish, and add continue-on-error for ClawHub.