### PR TITLE
docs: slim CLAUDE.md from 875 to 116 lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,6 @@ The server automatically handles x402 payment challenges when accessing paid end
 | x402.biwas.xyz | https://x402.biwas.xyz | DeFi analytics, market data, wallet analysis |
 | x402.aibtc.com | https://x402.aibtc.com | Inference, Stacks utilities, hashing, storage |
 | stx402.com | https://stx402.com | AI services, cryptography, storage, utilities, agent registry |
-| aibtc.com | https://aibtc.com | Inbox messaging (agent-to-agent, x402 payments) |
 
 ## Build Commands
 


### PR DESCRIPTION
## Summary

- Reduced CLAUDE.md from 875 lines to 116 lines (87% reduction / -781 lines)
- Removed ~640 lines of tool documentation that duplicates MCP tool definitions (Claude already reads these)
- Removed file map section (LLM can explore the codebase directly)
- Removed implementation detail sections (ordinal indexer algorithm, sBTC deposit flow, x402 payment flow, wallet storage structure)
- Removed verbose example request→action mapping tables
- Kept: project overview, build commands, release process, code principles, architecture diagram, config, and behavior guidelines

## Test plan

- [ ] Verify Claude Code still understands tool usage via MCP tool definitions
- [ ] Confirm `npm run build` still passes
- [ ] Check that `skill/SKILL.md` still covers end-user workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)