### PR TITLE
fix: remove double-encoding in sponsored transaction serialization

### DIFF
--- a/src/transactions/sponsor-builder.ts
+++ b/src/transactions/sponsor-builder.ts
@@ -83,7 +83,7 @@ export async function sponsoredContractCall(
     fee: 0n,
   });
 
-  const serializedTx = Buffer.from(transaction.serialize()).toString("hex");
+  const serializedTx = transaction.serialize();
   const response = await submitToSponsorRelay(serializedTx, network, apiKey);
 
   if (!response.success) {
@@ -112,7 +112,7 @@ export async function transferStxSponsored(
     fee: 0n,
   });
 
-  const serializedTx = Buffer.from(transaction.serialize()).toString("hex");
+  const serializedTx = transaction.serialize();
   return submitToSponsorRelay(serializedTx, options.network, apiKey);
 }
 


### PR DESCRIPTION
## Summary

- Fix double-encoding bug in `sponsor-builder.ts` that causes all sponsored transactions to fail
- `serialize()` in stacks.js v7 returns a hex string directly — wrapping in `Buffer.from().toString("hex")` re-encodes hex digits as ASCII bytes (`"00000001..."` becomes `"30303030..."`)
- Relay receives garbage hex and returns "Could not deserialize transaction hex"

## Details

Two lines changed in `src/transactions/sponsor-builder.ts`:
- `sponsoredContractCall()` line 86
- `transferStxSponsored()` line 115

Both changed from:
```typescript
const serializedTx = Buffer.from(transaction.serialize()).toString("hex");
```
to:
```typescript
const serializedTx = transaction.serialize();
```

The x402-sponsor-relay already fixed this same pattern in commit `1619570`.

**Note:** The same `Buffer.from(serialize())` pattern exists in `wallet.ts` and `builder.ts` but only affects the `rawTx` metadata field — actual broadcasting uses the transaction object directly. Only `sponsor-builder.ts` sends the serialized hex over the wire.

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] Test sponsored `give_feedback` with `sponsored: true` on mainnet
- [ ] Test sponsored `sbtc_transfer` with `sponsored: true` on mainnet

Fixes the serialization issue blocking #95 verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)