### PR TITLE
fix: correct contract call arguments in sbtc_transfer, give_feedback, and get_reputation

### DIFF
--- a/src/services/erc8004.service.ts
+++ b/src/services/erc8004.service.ts
@@ -8,6 +8,7 @@
 import {
   ClarityValue,
   uintCV,
+  intCV,
   stringUtf8CV,
   bufferCV,
   principalCV,
@@ -34,9 +35,9 @@ export interface IdentityInfo {
 
 export interface ReputationSummary {
   agentId: number;
-  averageRatingWad: string;
   totalFeedback: number;
-  sumWadValue: string;
+  summaryValue: string;
+  summaryValueDecimals: number;
 }
 
 export interface FeedbackEntry {
@@ -251,7 +252,7 @@ export class Erc8004Service {
 
     const functionArgs = [
       uintCV(agentId),
-      uintCV(value),
+      intCV(value),
       uintCV(valueDecimals),
       stringUtf8CV(tag1 || ""),
       stringUtf8CV(tag2 || ""),
@@ -281,7 +282,7 @@ export class Erc8004Service {
   async getReputation(agentId: number, callerAddress: string): Promise<ReputationSummary> {
     const result = await this.hiro.callReadOnlyFunction(
       this.contracts.reputationRegistry,
-      "get-agent-reputation",
+      "get-summary",
       [uintCV(agentId)],
       callerAddress
     );
@@ -302,9 +303,9 @@ export class Erc8004Service {
     const rep = data.value.value;
     return {
       agentId,
-      averageRatingWad: rep["avg-rating"].value,
       totalFeedback: parseInt(rep.count.value, 10),
-      sumWadValue: rep["sum-wad-value"].value,
+      summaryValue: rep["summary-value"].value,
+      summaryValueDecimals: parseInt(rep["summary-value-decimals"].value, 10),
     };
   }
 

--- a/src/services/sbtc.service.ts
+++ b/src/services/sbtc.service.ts
@@ -1,4 +1,4 @@
-import { ClarityValue, uintCV, principalCV } from "@stacks/transactions";
+import { ClarityValue, uintCV, principalCV, someCV, noneCV, bufferCV } from "@stacks/transactions";
 import { HiroApiService, getHiroApi } from "./hiro-api.js";
 import { getContracts, parseContractId, type Network } from "../config/index.js";
 import { callContract, type Account, type TransferResult } from "../transactions/builder.js";
@@ -78,13 +78,8 @@ export class SbtcService {
       uintCV(amount),
       principalCV(account.address),
       principalCV(recipient),
+      memo ? someCV(bufferCV(Buffer.from(memo).subarray(0, 34))) : noneCV(),
     ];
-
-    // Add memo if provided
-    if (memo) {
-      // sBTC transfer typically has an optional memo parameter
-      // Implementation depends on the specific sBTC contract version
-    }
 
     const contractCallOptions = {
       contractAddress,

--- a/src/tools/erc8004.tools.ts
+++ b/src/tools/erc8004.tools.ts
@@ -274,8 +274,9 @@ export function registerErc8004Tools(server: McpServer): void {
           return createJsonResponse({
             success: true,
             agentId,
-            averageRatingWad: "0",
             totalFeedback: 0,
+            summaryValue: "0",
+            summaryValueDecimals: 0,
             message: "No feedback yet for this agent",
             network: NETWORK,
           });
@@ -284,9 +285,9 @@ export function registerErc8004Tools(server: McpServer): void {
         return createJsonResponse({
           success: true,
           agentId: reputation.agentId,
-          averageRatingWad: reputation.averageRatingWad,
           totalFeedback: reputation.totalFeedback,
-          sumWadValue: reputation.sumWadValue,
+          summaryValue: reputation.summaryValue,
+          summaryValueDecimals: reputation.summaryValueDecimals,
           network: NETWORK,
         });
       } catch (error) {


### PR DESCRIPTION
## Summary

Fixes three bugs where MCP tools build contract calls with incorrect arguments, causing `BadFunctionArgument` rejections from the Stacks network.

- **`sbtc_transfer`**: Add missing 4th `memo` argument (`(optional (buff 34))`) required by the sBTC token contract
- **`give_feedback`**: Change `value` argument from `uintCV` to `intCV` to match the contract's `int128` parameter type
- **`get_reputation`**: Call the correct `get-summary` function (was calling non-existent `get-agent-reputation`) and update response parsing to match the contract's return tuple (`count`, `summary-value`, `summary-value-decimals`)

Closes #102

## Test plan

- [ ] Verify `sbtc_transfer` succeeds with and without memo
- [ ] Verify `give_feedback` succeeds with positive and negative values
- [ ] Verify `get_reputation` returns correct summary fields from the contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)