### PR TITLE
fix(api): document HIRO_API_KEY and complete rate limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,8 +441,9 @@ Or use any SIP-010 token by contract ID: `SP2X...::token-name`
 | `NETWORK` | `mainnet` or `testnet` | `mainnet` |
 | `API_URL` | Default x402 API base URL | `https://x402.biwas.xyz` |
 | `CLIENT_MNEMONIC` | (Optional) Pre-configured mnemonic | - |
+| `HIRO_API_KEY` | (Optional) Hiro API key for higher rate limits | - |
 
-**Note:** `CLIENT_MNEMONIC` is optional. The recommended approach is to let Claude create its own wallet.
+**Note:** `CLIENT_MNEMONIC` is optional. The recommended approach is to let Claude create its own wallet. `HIRO_API_KEY` is optional but recommended for production use — without it, you may hit Hiro's public rate limits (429 responses). Get a key at [platform.hiro.so](https://platform.hiro.so).
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Add `HIRO_API_KEY` to README configuration table with link to platform.hiro.so
- Closes #114 — all acceptance criteria met across this PR and the prior squash merge (#115)

## What was done (across #115 + this PR)

- HiroApiService detects 429 responses with custom `HiroApiRateLimitError`
- NaN-safe `Retry-After` header parsing with 60s fallback
- 60s cache on `getMempoolFees()` to reduce API load
- Ordinal indexer updated with same 429 pattern
- `HIRO_API_KEY` documented in README

## Test plan

- [ ] `npm run build` passes
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)