### PR TITLE
feat: add name-claim-fast for single-tx BNS V2 registration

### DIFF
--- a/src/services/bns.service.ts
+++ b/src/services/bns.service.ts
@@ -1,4 +1,5 @@
-import { ClarityValue, bufferCV, uintCV, stringUtf8CV, hexToCV, cvToJSON, tupleCV, standardPrincipalCV } from "@stacks/transactions";
+import { ClarityValue, bufferCV, uintCV, stringUtf8CV, hexToCV, cvToJSON, tupleCV, principalCV, Pc } from "@stacks/transactions";
+import { asciiToBytes } from "@stacks/common";
 import { HiroApiService, getHiroApi, BnsName, getBnsV2Api, BnsV2ApiService } from "./hiro-api.js";
 import { getContracts, parseContractId, type Network } from "../config/index.js";
 import { callContract, type Account, type TransferResult } from "../transactions/builder.js";
@@ -305,10 +306,10 @@ export class BnsService {
 
   /**
    * Claim a BNS V2 name in a single transaction using name-claim-fast.
-   * This is the recommended method for .btc names — no preorder/register dance needed.
+   * This is the recommended method for BNS names — no preorder/register dance needed.
    * Burns the name price in STX and mints the BNS NFT in one atomic step.
    *
-   * Only works for .btc namespace (BNS V2).
+   * Works for all open namespaces (BNS V2).
    */
   async claimNameFast(
     account: Account,
@@ -317,10 +318,6 @@ export class BnsService {
   ): Promise<TransferResult> {
     const fullName = name.includes(".") ? name : `${name}.btc`;
     const [baseName, namespace] = fullName.split(".");
-
-    if (namespace !== "btc") {
-      throw new Error("name-claim-fast is only available for .btc names (BNS V2)");
-    }
 
     const { address: contractAddress, name: contractName } = this.getBnsContract(namespace);
 
@@ -331,17 +328,13 @@ export class BnsService {
     const recipient = sendTo || account.address;
 
     const functionArgs: ClarityValue[] = [
-      bufferCV(Buffer.from(baseName)),
-      bufferCV(Buffer.from(namespace)),
-      standardPrincipalCV(recipient),
+      bufferCV(asciiToBytes(baseName)),
+      bufferCV(asciiToBytes(namespace)),
+      principalCV(recipient),
     ];
 
     // Post condition: sender burns STX for the name price
-    const postCondition = createStxPostCondition(
-      account.address,
-      "eq",
-      stxToBurn
-    );
+    const postCondition = Pc.principal(account.address).willSendEq(stxToBurn).ustx();
 
     return callContract(account, {
       contractAddress,
@@ -357,7 +350,7 @@ export class BnsService {
    * Creates a commitment with hashed name+salt to prevent front-running
    * Auto-detects V1/V2 based on namespace (.btc uses V2, others use V1)
    *
-   * NOTE: For .btc names, consider using claimNameFast() instead —
+   * NOTE: For name registration, consider using claimNameFast() instead —
    * it registers in a single transaction without the preorder/register wait.
    */
   async preorderName(

--- a/src/tools/bns.tools.ts
+++ b/src/tools/bns.tools.ts
@@ -194,10 +194,10 @@ export function registerBnsTools(server: McpServer): void {
     "claim_bns_name_fast",
     {
       description:
-        "Register a .btc BNS domain name in a single transaction using name-claim-fast. " +
-        "This is the RECOMMENDED method for .btc names — no preorder/register wait needed. " +
+        "Register a BNS domain name in a single transaction using name-claim-fast. " +
+        "This is the RECOMMENDED method — no preorder/register wait needed. " +
         "Burns the name price in STX and mints the BNS NFT atomically. " +
-        "Only works for .btc namespace (BNS V2).",
+        "Works for all open namespaces (BNS V2).",
       inputSchema: {
         name: z
           .string()


### PR DESCRIPTION
## What

Adds `claim_bns_name_fast` tool and `claimNameFast()` service method that uses the BNS-V2 `name-claim-fast` function to register `.btc` names in a **single transaction** instead of the current 2-step preorder + register flow.

## Why

The existing `preorder_bns_name` + `register_bns_name` workflow requires:
1. Submit preorder tx
2. Wait ~10 minutes for confirmation
3. Submit register tx
4. Wait again for confirmation

`name-claim-fast` does it all in one atomic transaction — burns STX, mints the BNS NFT, done. Much better UX for agents and users.

## How it works

Calls `SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF.BNS-V2.name-claim-fast` with:
- `name`: (buff 48) — the name to register
- `namespace`: (buff 20) — always `btc`
- `send-to`: principal — recipient of the BNS NFT

Includes an STX burn post-condition matching the name price.

## Reference

Successful `name-claim-fast` tx: [0xcfda37…239bb](https://explorer.hiro.so/txid/0xcfda3765aa6ea296ecb7069b9bd6d7afb0f5a61142dfb2e1e5a283b7e12239bb?chain=mainnet)

## Changes

- `src/services/bns.service.ts`: Added `claimNameFast()` method, added note to `preorderName()` recommending claim-fast
- `src/tools/bns.tools.ts`: Added `claim_bns_name_fast` tool, updated `preorder_bns_name` description to recommend claim-fast for .btc names

The 2-step preorder/register flow is preserved for non-.btc namespaces and backward compatibility.