### PR TITLE
fix(version): add version detection to identify stale NPX cache

### DIFF
--- a/src/tools/settings.tools.ts
+++ b/src/tools/settings.tools.ts
@@ -261,21 +261,32 @@ If your version is outdated, clear the npx cache and reinstall: npx clear-npx-ca
 
         // Fetch latest version from npm registry
         let latestVersion = "unknown";
-        let isLatest = true;
-        let updateAvailable = false;
 
         try {
           const response = await fetch("https://registry.npmjs.org/@aibtc/mcp-server/latest");
           if (response.ok) {
             const data = await response.json() as { version: string };
             latestVersion = data.version;
-            isLatest = currentVersion === latestVersion;
-            updateAvailable = currentVersion !== latestVersion;
           }
         } catch (fetchError) {
           // Network error or npm registry unavailable - non-fatal
           console.error("Failed to fetch latest version from npm:", fetchError);
         }
+
+        // Compare versions numerically (handles dev > published correctly)
+        const compare = (a: string, b: string): number => {
+          const pa = a.split(".").map(Number);
+          const pb = b.split(".").map(Number);
+          for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+            const na = pa[i] ?? 0, nb = pb[i] ?? 0;
+            if (na !== nb) return na - nb;
+          }
+          return 0;
+        };
+
+        const fetched = latestVersion !== "unknown";
+        const updateAvailable = fetched && compare(currentVersion, latestVersion) < 0;
+        const isLatest = fetched && compare(currentVersion, latestVersion) >= 0;
 
         return createJsonResponse({
           currentVersion,
@@ -285,7 +296,7 @@ If your version is outdated, clear the npx cache and reinstall: npx clear-npx-ca
           package: "@aibtc/mcp-server",
           hint: updateAvailable
             ? "⚠️  Update available! Clear npx cache and reinstall: npx clear-npx-cache && npx @aibtc/mcp-server@latest --install"
-            : isLatest
+            : fetched
               ? "✅ Running the latest version"
               : "Unable to verify latest version (network error)",
         });


### PR DESCRIPTION
## Summary

Adds `get_server_version` tool to help agents detect when they're running stale cached code from npx, addressing the root cause of issue #113.

## Problem

Issue #113 (sbtc_transfer post-condition failures) was caused by agents running pre-post-condition code cached by npx, despite using `@aibtc/mcp-server@latest` in their config. NPX caches packages locally and may serve stale versions even when `@latest` is specified.

## Solution

New tool: `get_server_version`
- Reports currently running version
- Fetches latest version from npm registry
- Detects version mismatches
- Provides clear upgrade instructions

## Example Output

```json
{
  "currentVersion": "1.21.1",
  "latestVersion": "1.22.0",
  "isLatest": false,
  "updateAvailable": true,
  "package": "@aibtc/mcp-server",
  "hint": "⚠️  Update available! Clear npx cache and reinstall: npx clear-npx-cache && npx @aibtc/mcp-server@latest --install"
}
```

## Testing

- ✅ `npm run build` passes cleanly
- ✅ Tool added to settings layer (appropriate for system info)
- ✅ Non-blocking: network failures return safe fallback response

## Related

- Closes #113 (root cause: NPX cache, not code bug)
- Post-conditions ARE working correctly in current code
- This provides proactive detection for future caching issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)