### PR TITLE
fix(inbox): handle nonce conflicts for rapid send_inbox_message calls

### DIFF
--- a/src/tools/inbox.tools.ts
+++ b/src/tools/inbox.tools.ts
@@ -9,6 +9,7 @@ import {
 import { decodePaymentRequired, encodePaymentPayload, X402_HEADERS } from "x402-stacks";
 import { getAccount, NETWORK } from "../services/x402.service.js";
 import { getSbtcService } from "../services/sbtc.service.js";
+import { getHiroApi } from "../services/hiro-api.js";
 import { getStacksNetwork, getExplorerTxUrl } from "../config/networks.js";
 import { getContracts, parseContractId } from "../config/contracts.js";
 import { createFungiblePostCondition } from "../transactions/post-conditions.js";
@@ -17,6 +18,85 @@ import { InsufficientBalanceError } from "../utils/errors.js";
 import { formatSbtc } from "../utils/formatting.js";
 
 const INBOX_BASE = "https://aibtc.com/api/inbox";
+const NONCE_CACHE_TTL_MS = 120_000;
+const NONCE_RETRY_MAX_ATTEMPTS = 2;
+const nonceReservationCache = new Map<string, { nextNonce: number; updatedAt: number }>();
+
+function readNonceCache(address: string): number | null {
+  const cached = nonceReservationCache.get(address);
+  if (!cached) {
+    return null;
+  }
+  if (Date.now() - cached.updatedAt > NONCE_CACHE_TTL_MS) {
+    nonceReservationCache.delete(address);
+    return null;
+  }
+  return cached.nextNonce;
+}
+
+export function reserveInboxNonce(
+  address: string,
+  accountNonce: number,
+  mempoolNonces: number[]
+): number {
+  const highestMempoolNonce =
+    mempoolNonces.length > 0 ? Math.max(...mempoolNonces) : accountNonce - 1;
+  const nextChainNonce = Math.max(accountNonce, highestMempoolNonce + 1);
+  const cachedNext = readNonceCache(address);
+  const selectedNonce = cachedNext === null
+    ? nextChainNonce
+    : Math.max(cachedNext, nextChainNonce);
+  nonceReservationCache.set(address, {
+    nextNonce: selectedNonce + 1,
+    updatedAt: Date.now(),
+  });
+  return selectedNonce;
+}
+
+export function isNonceConflictSettlementFailure(
+  statusCode: number,
+  parsedBody: Record<string, unknown>,
+  rawBody: string
+): boolean {
+  if (statusCode < 400) {
+    return false;
+  }
+
+  const fields = [
+    String(parsedBody.error || ""),
+    String(parsedBody.code || ""),
+    String(parsedBody.details || ""),
+    rawBody,
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    fields.includes("conflictingnonceinmempool") ||
+    fields.includes("nonce too low") ||
+    (fields.includes("unexpected_settle_error") && fields.includes("nonce"))
+  );
+}
+
+export async function getSuggestedInboxNonce(address: string): Promise<number> {
+  const hiro = getHiroApi(NETWORK);
+  const [accountNonce, mempoolTxs] = await Promise.all([
+    hiro.getAccountNonce(address),
+    hiro
+      .getMempoolTransactions({ sender_address: address, limit: 50 })
+      .catch(() => ({ limit: 0, offset: 0, total: 0, results: [] })),
+  ]);
+
+  const mempoolNonces = mempoolTxs.results
+    .map((tx) => tx.nonce)
+    .filter((nonce) => Number.isInteger(nonce) && nonce >= 0);
+
+  return reserveInboxNonce(address, accountNonce, mempoolNonces);
+}
+
+export function clearInboxNonceCacheForTests(): void {
+  nonceReservationCache.clear();
+}
 
 /**
  * Build a sponsored sBTC transfer transaction (signed, not broadcast).
@@ -26,7 +106,8 @@ async function buildSponsoredSbtcTransfer(
   senderKey: string,
   senderAddress: string,
   recipient: string,
-  amount: bigint
+  amount: bigint,
+  nonce?: number
 ): Promise<string> {
   const contracts = getContracts(NETWORK);
   const { address: contractAddress, name: contractName } = parseContractId(
@@ -57,6 +138,7 @@ async function buildSponsoredSbtcTransfer(
     postConditions: [postCondition],
     sponsored: true,
     fee: 0n,
+    ...(nonce !== undefined ? { nonce } : {}),
   });
 
   // serialize() returns Hex string (no 0x prefix) in @stacks/transactions v7+
@@ -155,91 +237,111 @@ Use this instead of execute_x402_endpoint for inbox messages — the generic too
           );
         }
 
-        // Step 3: Build sponsored sBTC transfer
-        const txHex = await buildSponsoredSbtcTransfer(
-          account.privateKey,
-          account.address,
-          accept.payTo,
-          amount
-        );
-
-        // Step 4: Encode PaymentPayloadV2
         const resourceUrl = paymentRequired.resource?.url || inboxUrl;
-        const paymentSignature = encodePaymentPayload({
-          x402Version: 2,
-          resource: {
-            url: resourceUrl,
-            description: paymentRequired.resource?.description || "",
-            mimeType: paymentRequired.resource?.mimeType || "application/json",
-          },
-          accepted: {
-            scheme: accept.scheme || "exact",
-            network: accept.network,
-            asset: accept.asset,
-            amount: accept.amount,
-            payTo: accept.payTo,
-            maxTimeoutSeconds: accept.maxTimeoutSeconds || 300,
-            extra: accept.extra || {},
-          },
-          payload: {
-            transaction: txHex,
-          },
-        } as Parameters<typeof encodePaymentPayload>[0]);
+        let lastStatus = 0;
+        let lastResponseData = "";
 
-        // Step 5: Retry with payment
-        const finalRes = await fetch(inboxUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            [X402_HEADERS.PAYMENT_SIGNATURE]: paymentSignature,
-          },
-          body: JSON.stringify(body),
-        });
+        for (let attempt = 0; attempt <= NONCE_RETRY_MAX_ATTEMPTS; attempt++) {
+          // Step 3: Build sponsored sBTC transfer with reserved nonce
+          const nonce = await getSuggestedInboxNonce(account.address).catch(
+            () => undefined
+          );
+          const txHex = await buildSponsoredSbtcTransfer(
+            account.privateKey,
+            account.address,
+            accept.payTo,
+            amount,
+            nonce
+          );
 
-        const responseData = await finalRes.text();
-        let parsed: Record<string, unknown>;
-        try {
-          parsed = JSON.parse(responseData);
-        } catch {
-          parsed = { raw: responseData };
-        }
+          // Step 4: Encode PaymentPayloadV2
+          const paymentSignature = encodePaymentPayload({
+            x402Version: 2,
+            resource: {
+              url: resourceUrl,
+              description: paymentRequired.resource?.description || "",
+              mimeType: paymentRequired.resource?.mimeType || "application/json",
+            },
+            accepted: {
+              scheme: accept.scheme || "exact",
+              network: accept.network,
+              asset: accept.asset,
+              amount: accept.amount,
+              payTo: accept.payTo,
+              maxTimeoutSeconds: accept.maxTimeoutSeconds || 300,
+              extra: accept.extra || {},
+            },
+            payload: {
+              transaction: txHex,
+            },
+          } as Parameters<typeof encodePaymentPayload>[0]);
 
-        if (finalRes.status === 201 || finalRes.status === 200) {
-          // Extract payment response header for txid
-          const paymentResponse = finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE);
-          let txid: string | undefined;
-          if (paymentResponse) {
-            try {
-              const decoded = JSON.parse(
-                Buffer.from(paymentResponse, "base64").toString()
-              );
-              txid = decoded.transaction;
-            } catch {
-              // ignore parse errors
-            }
+          // Step 5: Retry with payment
+          const finalRes = await fetch(inboxUrl, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              [X402_HEADERS.PAYMENT_SIGNATURE]: paymentSignature,
+            },
+            body: JSON.stringify(body),
+          });
+
+          const responseData = await finalRes.text();
+          let parsed: Record<string, unknown>;
+          try {
+            parsed = JSON.parse(responseData);
+          } catch {
+            parsed = { raw: responseData };
           }
 
-          return createJsonResponse({
-            success: true,
-            message: "Message delivered",
-            recipient: {
-              btcAddress: recipientBtcAddress,
-              stxAddress: recipientStxAddress,
-            },
-            contentLength: content.length,
-            inbox: parsed,
-            ...(txid && {
-              payment: {
-                txid,
-                amount: accept.amount + " sats sBTC",
-                explorer: getExplorerTxUrl(txid, NETWORK),
+          if (finalRes.status === 201 || finalRes.status === 200) {
+            // Extract payment response header for txid
+            const paymentResponse = finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE);
+            let txid: string | undefined;
+            if (paymentResponse) {
+              try {
+                const decoded = JSON.parse(
+                  Buffer.from(paymentResponse, "base64").toString()
+                );
+                txid = decoded.transaction;
+              } catch {
+                // ignore parse errors
+              }
+            }
+
+            return createJsonResponse({
+              success: true,
+              message: "Message delivered",
+              recipient: {
+                btcAddress: recipientBtcAddress,
+                stxAddress: recipientStxAddress,
               },
-            }),
-          });
+              contentLength: content.length,
+              inbox: parsed,
+              ...(txid && {
+                payment: {
+                  txid,
+                  amount: accept.amount + " sats sBTC",
+                  explorer: getExplorerTxUrl(txid, NETWORK),
+                },
+              }),
+            });
+          }
+
+          lastStatus = finalRes.status;
+          lastResponseData = responseData;
+
+          const canRetry =
+            attempt < NONCE_RETRY_MAX_ATTEMPTS &&
+            isNonceConflictSettlementFailure(finalRes.status, parsed, responseData);
+
+          if (!canRetry) {
+            break;
+          }
         }
 
         throw new Error(
-          `Message delivery failed (${finalRes.status}): ${responseData}`
+          `Message delivery failed (${lastStatus}): ${lastResponseData}`
         );
       } catch (error) {
         return createErrorResponse(error);

--- a/tests/tools/inbox-nonce.test.ts
+++ b/tests/tools/inbox-nonce.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockGetAccountNonce = vi.fn();
+const mockGetMempoolTransactions = vi.fn();
+
+vi.mock("../../src/services/hiro-api.js", () => ({
+  getHiroApi: () => ({
+    getAccountNonce: mockGetAccountNonce,
+    getMempoolTransactions: mockGetMempoolTransactions,
+  }),
+}));
+
+vi.mock("../../src/services/x402.service.js", () => ({
+  NETWORK: "mainnet",
+  getAccount: vi.fn(),
+}));
+
+const {
+  reserveInboxNonce,
+  isNonceConflictSettlementFailure,
+  getSuggestedInboxNonce,
+  clearInboxNonceCacheForTests,
+} = await import("../../src/tools/inbox.tools.js");
+
+describe("inbox nonce reservation", () => {
+  beforeEach(() => {
+    clearInboxNonceCacheForTests();
+    mockGetAccountNonce.mockReset();
+    mockGetMempoolTransactions.mockReset();
+  });
+
+  it("reserves sequential nonces from local cache to avoid reuse", () => {
+    const first = reserveInboxNonce("SP123", 50, []);
+    const second = reserveInboxNonce("SP123", 50, []);
+    const third = reserveInboxNonce("SP123", 50, []);
+
+    expect(first).toBe(50);
+    expect(second).toBe(51);
+    expect(third).toBe(52);
+  });
+
+  it("uses the next mempool nonce when mempool is ahead of account nonce", () => {
+    const selected = reserveInboxNonce("SPABC", 20, [20, 21, 22]);
+    expect(selected).toBe(23);
+  });
+});
+
+describe("nonce-conflict detection", () => {
+  it("detects conflicting nonce settlement failures", () => {
+    expect(
+      isNonceConflictSettlementFailure(
+        500,
+        { code: "unexpected_settle_error", details: "ConflictingNonceInMempool" },
+        ""
+      )
+    ).toBe(true);
+  });
+
+  it("does not treat unrelated failures as nonce conflicts", () => {
+    expect(
+      isNonceConflictSettlementFailure(
+        500,
+        { code: "SETTLEMENT_FAILED", details: "insufficient balance" },
+        ""
+      )
+    ).toBe(false);
+  });
+});
+
+describe("getSuggestedInboxNonce", () => {
+  beforeEach(() => {
+    clearInboxNonceCacheForTests();
+    mockGetAccountNonce.mockReset();
+    mockGetMempoolTransactions.mockReset();
+  });
+
+  it("combines account + mempool nonces and local cache for successive calls", async () => {
+    mockGetAccountNonce.mockResolvedValue(100);
+    mockGetMempoolTransactions.mockResolvedValue({
+      limit: 50,
+      offset: 0,
+      total: 2,
+      results: [{ nonce: 100 }, { nonce: 101 }],
+    });
+
+    const first = await getSuggestedInboxNonce("SP456");
+    const second = await getSuggestedInboxNonce("SP456");
+
+    expect(first).toBe(102);
+    expect(second).toBe(103);
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic nonce reservation for `send_inbox_message` using account nonce + mempool nonce + local cache
- add bounded retry (`max 2`) when settlement fails with nonce conflict (`ConflictingNonceInMempool` / `unexpected_settle_error` nonce variants)
- keep delivery path resilient by falling back if nonce lookup fails
- add focused tests for nonce reservation and conflict detection logic

## Why
Rapid sequential inbox sends can reuse a stale nonce before chain/account state updates, causing relay settlement failures (`ConflictingNonceInMempool`) after a few successful messages.

## Validation
- `npm test -- tests/tools/inbox-nonce.test.ts`
- `npm run build`

Closes #154
