### PR TITLE
fix: nonce conflicts and inbox reliability (supersedes #155, #150)

### DIFF
--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -302,14 +302,10 @@ For aibtc.com inbox messages, use send_inbox_message instead — it uses sponsor
       },
     },
     async ({ method, url, path, apiUrl, params, data, autoApprove }) => {
-      let baseUrl = "";
-      let requestPath = "";
       let fullUrl = "";
 
       try {
         const parsed = parseEndpointUrl({ url, path, apiUrl, params });
-        baseUrl = parsed.baseUrl;
-        requestPath = parsed.requestPath;
         fullUrl = parsed.fullUrl;
         params = parsed.params;
 
@@ -322,7 +318,6 @@ For aibtc.com inbox messages, use send_inbox_message instead — it uses sponsor
         const probeResult = await probeEndpoint({ method, url: fullUrl, params, data });
 
         if (probeResult.type === 'payment_required') {
-          // Check for duplicate transaction
           const dedupKey = generateDedupKey(method, fullUrl, params, data);
           const existingTxid = checkDedupCache(dedupKey);
           if (existingTxid) {
@@ -334,16 +329,12 @@ For aibtc.com inbox messages, use send_inbox_message instead — it uses sponsor
             });
           }
 
-          // Check sufficient balance before creating payment client
           const account = await getAccount();
           await checkSufficientBalance(account, probeResult.amount, probeResult.asset);
 
-          // Balance is sufficient - create payment client and execute
-          const api = await createApiClient(baseUrl);
-          const response = await api.request({ method, url: requestPath, params, data });
+          const api = await createApiClient(parsed.baseUrl);
+          const response = await api.request({ method, url: parsed.requestPath, params, data });
 
-          // Extract txid from response and record for dedup
-          // x402 payment responses typically include txid in response data or headers
           const txid = (response.data as { txid?: string })?.txid ||
                        response.headers?.['x-transaction-id'] ||
                        'unknown';
@@ -357,8 +348,8 @@ For aibtc.com inbox messages, use send_inbox_message instead — it uses sponsor
         }
 
         // Free endpoint - execute directly without payment client
-        const api = createPlainClient(baseUrl);
-        const response = await api.request({ method, url: requestPath, params, data });
+        const api = createPlainClient(parsed.baseUrl);
+        const response = await api.request({ method, url: parsed.requestPath, params, data });
 
         return createJsonResponse({
           endpoint: `${method} ${fullUrl}`,

--- a/src/tools/inbox.tools.ts
+++ b/src/tools/inbox.tools.ts
@@ -44,11 +44,9 @@ const NONCE_TTL_MS = 120_000;
 async function getNextNonce(address: string): Promise<number> {
   const hiroApi = getHiroApi(NETWORK);
 
-  // Fetch confirmed nonce from account info
   const accountInfo = await hiroApi.getAccountInfo(address);
   const confirmedNonce = accountInfo.nonce;
 
-  // Fetch mempool transactions to find the highest pending nonce
   let highestMempoolNonce = -1;
   try {
     const mempool = await hiroApi.getMempoolTransactions({
@@ -64,17 +62,10 @@ async function getNextNonce(address: string): Promise<number> {
     // Non-fatal: fall back to confirmed nonce only
   }
 
-  const fromMempool = highestMempoolNonce >= 0 ? highestMempoolNonce + 1 : 0;
-
-  // Check local cache
-  const now = Date.now();
   const cached = nonceCache.get(address);
-  let fromCache = 0;
-  if (cached && now < cached.expiresAt) {
-    fromCache = cached.nextNonce;
-  }
+  const fromCache = (cached && Date.now() < cached.expiresAt) ? cached.nextNonce : 0;
 
-  return Math.max(confirmedNonce, fromMempool, fromCache);
+  return Math.max(confirmedNonce, highestMempoolNonce + 1, fromCache);
 }
 
 /**
@@ -169,12 +160,7 @@ function isRetryableError(status: number, body: unknown): boolean {
     }
   }
   if (typeof body === "string") {
-    if (
-      body.includes("ConflictingNonceInMempool") ||
-      body.includes("BadNonce")
-    ) {
-      return true;
-    }
+    return body.includes("ConflictingNonceInMempool") || body.includes("BadNonce");
   }
   return false;
 }

--- a/src/utils/x402-protocol.ts
+++ b/src/utils/x402-protocol.ts
@@ -115,58 +115,33 @@ export const X402_HEADERS = {
 
 // ===== Functions =====
 
-/**
- * Decode the payment-required header from base64 JSON.
- * Returns null if the header is missing or cannot be decoded.
- */
-export function decodePaymentRequired(
-  header: string | null | undefined
-): PaymentRequiredV2 | null {
-  if (!header) return null;
+function decodeBase64Json<T>(encoded: string | null | undefined): T | null {
+  if (!encoded) return null;
   try {
-    const decoded = Buffer.from(header, "base64").toString("utf-8");
-    return JSON.parse(decoded) as PaymentRequiredV2;
+    return JSON.parse(Buffer.from(encoded, "base64").toString("utf-8")) as T;
   } catch {
     return null;
   }
 }
 
-/**
- * Encode a payment payload to base64 JSON.
- */
+export function decodePaymentRequired(
+  header: string | null | undefined
+): PaymentRequiredV2 | null {
+  return decodeBase64Json<PaymentRequiredV2>(header);
+}
+
 export function encodePaymentPayload(payload: PaymentPayloadV2): string {
   return Buffer.from(JSON.stringify(payload)).toString("base64");
 }
 
-/**
- * Decode a payment payload from base64 JSON.
- * Returns null if the input is missing or cannot be decoded.
- * Used to extract the signed transaction from a payment-signature header.
- */
 export function decodePaymentPayload(
   encoded: string | null | undefined
 ): PaymentPayloadV2 | null {
-  if (!encoded) return null;
-  try {
-    const decoded = Buffer.from(encoded, "base64").toString("utf-8");
-    return JSON.parse(decoded) as PaymentPayloadV2;
-  } catch {
-    return null;
-  }
+  return decodeBase64Json<PaymentPayloadV2>(encoded);
 }
 
-/**
- * Decode the payment-response header from base64 JSON.
- * Returns null if the header is missing or cannot be decoded.
- */
 export function decodePaymentResponse(
   header: string | null | undefined
 ): SettlementResponseV2 | null {
-  if (!header) return null;
-  try {
-    const decoded = Buffer.from(header, "base64").toString("utf-8");
-    return JSON.parse(decoded) as SettlementResponseV2;
-  } catch {
-    return null;
-  }
+  return decodeBase64Json<SettlementResponseV2>(header);
 }

--- a/src/utils/x402-recovery.ts
+++ b/src/utils/x402-recovery.ts
@@ -10,7 +10,7 @@
 
 import { deserializeTransaction } from "@stacks/transactions";
 import { getHiroApi } from "../services/hiro-api.js";
-import { type Network } from "../config/networks.js";
+import { type Network, getExplorerTxUrl } from "../config/networks.js";
 import { decodePaymentPayload } from "./x402-protocol.js";
 
 // ============================================================================
@@ -76,18 +76,17 @@ export async function pollTransactionConfirmation(
   intervalMs = 2_000
 ): Promise<TransactionConfirmationResult> {
   const hiroApi = getHiroApi(network);
-  const cleanTxid = txid.startsWith("0x") ? txid.slice(2) : txid;
-  const explorerUrl = `https://explorer.hiro.so/txid/${cleanTxid}?chain=${network}`;
+  const normalizedTxid = txid.startsWith("0x") ? txid.slice(2) : txid;
+  const explorerUrl = getExplorerTxUrl(normalizedTxid, network);
 
   const deadline = Date.now() + maxWaitMs;
 
   while (Date.now() < deadline) {
     try {
-      const status = await hiroApi.getTransactionStatus(cleanTxid);
-      // If confirmed or failed, return immediately
+      const status = await hiroApi.getTransactionStatus(normalizedTxid);
       if (status.status !== "pending") {
         return {
-          txid: cleanTxid,
+          txid: normalizedTxid,
           status: status.status,
           block_height: status.block_height,
           tx_result: status.tx_result,
@@ -103,9 +102,8 @@ export async function pollTransactionConfirmation(
     await new Promise((resolve) => setTimeout(resolve, Math.min(intervalMs, remaining)));
   }
 
-  // Return pending status after timeout
   return {
-    txid: cleanTxid,
+    txid: normalizedTxid,
     status: "pending",
     explorer: explorerUrl,
   };


### PR DESCRIPTION
## Summary

- **Nonce manager** in `inbox.tools.ts`: fetches confirmed + mempool nonces, takes max with 120s local cache, injects explicit nonce into each `makeContractCall` to prevent `ConflictingNonceInMempool` (closes #154, #166, #167)
- **Retry loop** in `send_inbox_message`: up to 3 attempts with 1s/2s backoff; retries on `retryable: true`, HTTP 409 `NONCE_CONFLICT`, `ConflictingNonceInMempool`, and `BadNonce`; does NOT retry on duplicate-message 409 or non-transient errors (closes #157)
- **Txid recovery utilities** in `src/utils/x402-recovery.ts`: `extractTxidFromPaymentSignature()` deserializes the signed tx from the payment-signature header to compute txid; `pollTransactionConfirmation()` polls Hiro API (with API key) for brief status check
- **Txid recovery wired** into both `send_inbox_message` (error message includes txid + explorer URL) and `execute_x402_endpoint` (error handler checks `error.config.headers` for payment-signature, polls status)

Supersedes and closes draft PRs #155 (nonce conflicts) and #150 (txid recovery), which had stale bases and merge conflicts.

## Issues Resolved

Closes #154 — ConflictingNonceInMempool rapid sends
Closes #157 — SETTLEMENT_BROADCAST_FAILED no retry
Closes #166 — Review nonce handling (architecture audit)
Closes #167 — Agent-side nonce manager spec

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] `npm test` passes all 268 existing tests
- [ ] Send back-to-back inbox messages and verify no `ConflictingNonceInMempool` errors
- [ ] Simulate relay returning `retryable: true` and verify retry loop fires
- [ ] Simulate settlement failure and verify txid + explorer URL appear in error response
- [ ] Verify `execute_x402_endpoint` error includes txid recovery info when payment was attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)