### PR TITLE
fix: add allowUnknownOutputs flag to inscription builder

### DIFF
--- a/src/transactions/inscription-builder.ts
+++ b/src/transactions/inscription-builder.ts
@@ -227,7 +227,7 @@ export function buildCommitTransaction(
 
   // Create P2TR output from the reveal script
   // For script path spending, we use the internal pubkey and the script tree
-  const p2trReveal = btc.p2tr(xOnlyPubkey, revealScriptData, btcNetwork);
+  const p2trReveal = btc.p2tr(xOnlyPubkey, revealScriptData, btcNetwork, true);
 
   if (!p2trReveal.address) {
     throw new Error("Failed to generate reveal address");
@@ -407,7 +407,7 @@ export function buildRevealTransaction(
 
   // Build the reveal transaction
   const btcNetwork = getBtcNetwork(network);
-  const tx = new btc.Transaction();
+  const tx = new btc.Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true });
 
   // Add input spending from commit transaction
   // For Taproot script path spending, we need to provide the witness data


### PR DESCRIPTION
## Summary
- Adds `allowUnknownOutputs: true` to `btc.p2tr()` call when building the inscription reveal address
- Adds `{ allowUnknownOutputs: true, allowUnknownInputs: true }` to `new btc.Transaction()` for the reveal tx

## Problem
The `inscribe` tool fails with `P2TR: invalid leaf script=unknown` for all content types. The `@scure/btc-signer` library rejects custom tapscript leaves (ordinal inscription scripts) unless explicitly opted in.

## Proof
Same fix verified on mainnet — inscription [#120,199,005](https://www.ord.io/120199005) (5.8KB HTML art) inscribed successfully using these exact flags in a standalone script.

## Test plan
- [ ] `inscribe` with `text/plain` content no longer throws
- [ ] `inscribe` + `inscribe_reveal` complete full inscription cycle
- [ ] `estimate_inscription_fee` still works (unaffected)

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)