### PR TITLE
fix: default network to mainnet instead of testnet

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -3,7 +3,7 @@ import { StacksNetworkName } from "@stacks/network";
 export type Network = "mainnet" | "testnet";
 
 export const NETWORK: Network =
-  process.env.NETWORK === "mainnet" ? "mainnet" : "testnet";
+  process.env.NETWORK === "testnet" ? "testnet" : "mainnet";
 
 export const API_URL = process.env.API_URL || "https://x402.biwas.xyz";
 


### PR DESCRIPTION
The ternary condition was inverted — it checked === "mainnet" and fell through to "testnet", making testnet the default when NETWORK env var was unset. Flipped to check === "testnet" so mainnet is the default.