### PR TITLE
test(bitflow): add unit tests covering PR #203 regressions

### DIFF
--- a/tests/services/bitflow.test.ts
+++ b/tests/services/bitflow.test.ts
@@ -175,7 +175,7 @@ describe("bitflow.service", () => {
       (service as any).sdk = null;
 
       await expect(service.getAvailableTokens()).rejects.toThrow(
-        "Bitflow SDK failed to initialize"
+        "Bitflow SDK failed to initialize. Check BITFLOW_API_HOST / BITFLOW_READONLY_API_HOST configuration and server logs."
       );
     });
 


### PR DESCRIPTION
## Summary

- Adds 53 unit tests for `BitflowService` in `tests/services/bitflow.test.ts`
- Covers the three bug-fix code paths from PR #203: token context population before quotes, base-unit price impact calculation, and base-unit swap amounts in `SwapExecutionData`
- Tests are fully mocked (no network calls) covering `toBaseUnits`, `classifyImpact`, guard methods, singleton factory, `getAvailableTokens`, `calculatePriceImpact` XYK formula, `getSwapQuote`, and `swap` execution

## Test plan

- [x] All 53 new tests pass
- [x] Full suite (330 tests across 13 files) passes with `npm test`
- [x] No network calls — all external dependencies mocked

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)