### PR TITLE
fix(inscriptions): correct tapLeafScript spread and extract deriveRevealScript

### DIFF
--- a/src/config/bitcoin-constants.ts
+++ b/src/config/bitcoin-constants.ts
@@ -35,3 +35,8 @@ export const DUST_THRESHOLD = 546;
  * Taproot input base size (vbytes) - without witness data
  */
 export const P2TR_INPUT_BASE_VBYTES = 57.5;
+
+/**
+ * Inscription witness overhead (vbytes) - control block, script, and protocol framing
+ */
+export const WITNESS_OVERHEAD_VBYTES = 80;

--- a/src/tools/ordinals.tools.ts
+++ b/src/tools/ordinals.tools.ts
@@ -21,6 +21,7 @@ import {
   TX_OVERHEAD_VBYTES,
   DUST_THRESHOLD,
   P2TR_INPUT_BASE_VBYTES,
+  WITNESS_OVERHEAD_VBYTES,
 } from "../config/bitcoin-constants.js";
 import { createJsonResponse, createErrorResponse } from "../utils/index.js";
 import {
@@ -144,8 +145,6 @@ export function registerOrdinalsTools(server: McpServer): void {
         const commitFee = Math.ceil(commitSize * actualFeeRate);
 
         // Reveal tx size (1 input with inscription witness + 1 output)
-        // Include overhead for control block, script, and protocol framing
-        const WITNESS_OVERHEAD_VBYTES = 80;
         const revealWitnessSize =
           Math.ceil((body.length / 4) * 1.25) + WITNESS_OVERHEAD_VBYTES;
         const revealSize =

--- a/src/transactions/bitcoin-builder.ts
+++ b/src/transactions/bitcoin-builder.ts
@@ -126,7 +126,7 @@ export function estimateTxSize(inputCount: number, outputCount: number): number 
 /**
  * Get the @scure/btc-signer network object for a network name
  */
-function getBtcNetwork(network: Network): typeof btc.NETWORK {
+export function getBtcNetwork(network: Network): typeof btc.NETWORK {
   return network === "testnet" ? btc.TEST_NETWORK : btc.NETWORK;
 }
 

--- a/src/transactions/inscription-builder.ts
+++ b/src/transactions/inscription-builder.ts
@@ -17,8 +17,10 @@ import {
   TX_OVERHEAD_VBYTES,
   DUST_THRESHOLD,
   P2TR_INPUT_BASE_VBYTES,
+  WITNESS_OVERHEAD_VBYTES,
 } from "../config/bitcoin-constants.js";
 import type { UTXO } from "../services/mempool-api.js";
+import { getBtcNetwork } from "./bitcoin-builder.js";
 
 /**
  * Inscription data structure
@@ -160,14 +162,6 @@ export interface BuildRevealTransactionResult {
   outputAmount: number;
 }
 
-
-/**
- * Get the @scure/btc-signer network object for a network name
- */
-function getBtcNetwork(network: Network): typeof btc.NETWORK {
-  return network === "testnet" ? btc.TEST_NETWORK : btc.NETWORK;
-}
-
 /**
  * Derive the Taproot P2TR reveal script from inscription data and sender public key.
  *
@@ -222,7 +216,6 @@ export function deriveRevealScript(
  * const inscription = {
  *   contentType: "text/plain",
  *   body: new TextEncoder().encode("Hello, Ordinals!"),
- *   compress: true,
  * };
  *
  * const result = buildCommitTransaction({
@@ -274,8 +267,7 @@ export function buildCommitTransaction(
   // Estimate reveal transaction size to determine commit amount
   // Reveal tx: 1 input (Taproot with inscription witness) + 1 output (recipient)
   // The witness includes the inscription data plus script & control-block overhead
-  const revealInputSize = P2TR_INPUT_BASE_VBYTES; // Taproot input base size (vbytes)
-  const WITNESS_OVERHEAD_VBYTES = 80; // Control block + script + protocol framing
+  const revealInputSize = P2TR_INPUT_BASE_VBYTES;
   const revealWitnessSize =
     Math.ceil((inscription.body.length / 4) * 1.25) + WITNESS_OVERHEAD_VBYTES;
   const revealTxSize = TX_OVERHEAD_VBYTES + revealInputSize + revealWitnessSize + P2TR_OUTPUT_VBYTES;

--- a/tests/transactions/inscription-builder.test.ts
+++ b/tests/transactions/inscription-builder.test.ts
@@ -13,38 +13,59 @@ import {
 import type { UTXO } from "../../src/services/mempool-api.js";
 
 describe("inscription-builder", () => {
-  // Test mnemonic from BIP84 test vectors
   const TEST_MNEMONIC =
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
-  // Derive key pair for testing (P2WPKH, 33-byte compressed pubkey)
   const testKeyPair = deriveBitcoinKeyPair(TEST_MNEMONIC, "mainnet");
   const testPubKey = testKeyPair.publicKeyBytes;
-
-  // Derive a taproot address for the inscription recipient
   const testTaprootAddress = deriveTaprootAddress(TEST_MNEMONIC, "mainnet").address;
 
-  // Sample inscription for tests
+  const MOCK_TXID = "0".repeat(64);
+
   const TEST_INSCRIPTION: InscriptionData = {
     contentType: "text/plain",
     body: new TextEncoder().encode("Hello, Ordinals!"),
   };
 
-  // Create mock confirmed UTXO
-  const createMockUtxo = (
+  function createMockUtxo(
     txid: string,
     vout: number,
     value: number,
     confirmed = true
-  ): UTXO => ({
-    txid,
-    vout,
-    value,
-    status: {
-      confirmed,
-      block_height: confirmed ? 800000 : undefined,
-    },
-  });
+  ): UTXO {
+    return {
+      txid,
+      vout,
+      value,
+      status: {
+        confirmed,
+        block_height: confirmed ? 800000 : undefined,
+      },
+    };
+  }
+
+  function buildTestCommit(value = 500000) {
+    return buildCommitTransaction({
+      utxos: [createMockUtxo(MOCK_TXID, 0, value)],
+      inscription: TEST_INSCRIPTION,
+      feeRate: 10,
+      senderPubKey: testPubKey,
+      senderAddress: testKeyPair.address,
+      network: "mainnet",
+    });
+  }
+
+  function buildTestReveal(commitResult: ReturnType<typeof buildTestCommit>, txid = "a".repeat(64)) {
+    return buildRevealTransaction({
+      commitTxid: txid,
+      commitVout: 0,
+      commitAmount: commitResult.revealAmount,
+      revealScript: commitResult.revealScript,
+      recipientAddress: testTaprootAddress,
+      feeRate: 10,
+      network: "mainnet",
+    });
+  }
 
   describe("deriveRevealScript", () => {
     it("should return P2TR output with address, script, and tapLeafScript", () => {
@@ -54,28 +75,22 @@ describe("inscription-builder", () => {
         network: "mainnet",
       });
 
-      expect(result.address).toBeDefined();
-      expect(typeof result.address).toBe("string");
       expect(result.address).toMatch(/^bc1p/);
       expect(result.script).toBeInstanceOf(Uint8Array);
       expect(result.script!.byteLength).toBeGreaterThan(0);
       expect(result.tapLeafScript).toBeDefined();
-      expect(Array.isArray(result.tapLeafScript)).toBe(true);
       expect(result.tapLeafScript!.length).toBeGreaterThan(0);
     });
 
     it("should be deterministic for the same inputs", () => {
-      const result1 = deriveRevealScript({
+      const options = {
         inscription: TEST_INSCRIPTION,
         senderPubKey: testPubKey,
-        network: "mainnet",
-      });
+        network: "mainnet" as const,
+      };
 
-      const result2 = deriveRevealScript({
-        inscription: TEST_INSCRIPTION,
-        senderPubKey: testPubKey,
-        network: "mainnet",
-      });
+      const result1 = deriveRevealScript(options);
+      const result2 = deriveRevealScript(options);
 
       expect(result1.address).toBe(result2.address);
     });
@@ -149,85 +164,26 @@ describe("inscription-builder", () => {
   });
 
   describe("buildRevealTransaction", () => {
-    // Helper: build a commit tx to get a valid revealScript
-    function buildTestCommit(inscriptionValue = 500000) {
-      const mockUtxo = createMockUtxo(
-        "0000000000000000000000000000000000000000000000000000000000000001",
-        0,
-        inscriptionValue
-      );
-
-      return buildCommitTransaction({
-        utxos: [mockUtxo],
-        inscription: TEST_INSCRIPTION,
-        feeRate: 10,
-        senderPubKey: testPubKey,
-        senderAddress: testKeyPair.address,
-        network: "mainnet",
-      });
-    }
-
     it("should produce a transaction that can be signed and finalized without throwing", () => {
-      // This is the regression test for the tapLeafScript fix.
+      // Regression test for the tapLeafScript fix.
       // Before the fix, finalize() threw "No inputs signed" because tapLeafScript
       // was spread (...revealScript.tapLeafScript) instead of assigned directly.
       const commitResult = buildTestCommit();
-
-      // Use a fake but valid commit txid (64 hex chars)
-      const fakeCommitTxid = "a".repeat(64);
-
-      const revealResult = buildRevealTransaction({
-        commitTxid: fakeCommitTxid,
-        commitVout: 0,
-        commitAmount: commitResult.revealAmount,
-        revealScript: commitResult.revealScript,
-        recipientAddress: testTaprootAddress,
-        feeRate: 10,
-        network: "mainnet",
-      });
+      const revealResult = buildTestReveal(commitResult);
 
       expect(revealResult.tx).toBeInstanceOf(btc.Transaction);
 
-      // Sign with the test private key
       revealResult.tx.sign(testKeyPair.privateKey);
-
-      // Finalize must not throw — this is the key assertion proving the fix
       expect(() => revealResult.tx.finalize()).not.toThrow();
     });
 
     it("should produce correct fee and output amount that sum to commit amount", () => {
       const commitResult = buildTestCommit();
-      const commitAmount = commitResult.revealAmount;
-
-      const revealResult = buildRevealTransaction({
-        commitTxid: "b".repeat(64),
-        commitVout: 0,
-        commitAmount,
-        revealScript: commitResult.revealScript,
-        recipientAddress: testTaprootAddress,
-        feeRate: 10,
-        network: "mainnet",
-      });
+      const revealResult = buildTestReveal(commitResult);
 
       expect(revealResult.fee).toBeGreaterThan(0);
       expect(revealResult.outputAmount).toBeGreaterThan(0);
-      expect(revealResult.outputAmount + revealResult.fee).toBe(commitAmount);
-    });
-
-    it("should return a Transaction instance", () => {
-      const commitResult = buildTestCommit();
-
-      const revealResult = buildRevealTransaction({
-        commitTxid: "c".repeat(64),
-        commitVout: 0,
-        commitAmount: commitResult.revealAmount,
-        revealScript: commitResult.revealScript,
-        recipientAddress: testTaprootAddress,
-        feeRate: 10,
-        network: "mainnet",
-      });
-
-      expect(revealResult.tx).toBeInstanceOf(btc.Transaction);
+      expect(revealResult.outputAmount + revealResult.fee).toBe(commitResult.revealAmount);
     });
 
     it("should throw for invalid commit txid (too short)", () => {
@@ -265,7 +221,6 @@ describe("inscription-builder", () => {
     it("should throw when commit amount is too small to cover fee and dust", () => {
       const commitResult = buildTestCommit();
 
-      // A very small commit amount that can't cover the fee + dust
       expect(() =>
         buildRevealTransaction({
           commitTxid: "e".repeat(64),
@@ -281,66 +236,16 @@ describe("inscription-builder", () => {
   });
 
   describe("buildCommitTransaction", () => {
-    it("should return revealScript with tapLeafScript for use in reveal transaction", () => {
-      const mockUtxo = createMockUtxo(
-        "0000000000000000000000000000000000000000000000000000000000000001",
-        0,
-        500000
-      );
-
-      const result = buildCommitTransaction({
-        utxos: [mockUtxo],
-        inscription: TEST_INSCRIPTION,
-        feeRate: 10,
-        senderPubKey: testPubKey,
-        senderAddress: testKeyPair.address,
-        network: "mainnet",
-      });
-
-      // The revealScript must have tapLeafScript set for the reveal tx to sign correctly
-      expect(result.revealScript.tapLeafScript).toBeDefined();
-      expect(Array.isArray(result.revealScript.tapLeafScript)).toBe(true);
-      expect(result.revealScript.tapLeafScript!.length).toBeGreaterThan(0);
-    });
-
-    it("should return a valid reveal address starting with bc1p", () => {
-      const mockUtxo = createMockUtxo(
-        "0000000000000000000000000000000000000000000000000000000000000001",
-        0,
-        500000
-      );
-
-      const result = buildCommitTransaction({
-        utxos: [mockUtxo],
-        inscription: TEST_INSCRIPTION,
-        feeRate: 10,
-        senderPubKey: testPubKey,
-        senderAddress: testKeyPair.address,
-        network: "mainnet",
-      });
-
-      expect(result.revealAddress).toMatch(/^bc1p/);
-    });
-
-    it("should return a Transaction instance for the commit tx", () => {
-      const mockUtxo = createMockUtxo(
-        "0000000000000000000000000000000000000000000000000000000000000001",
-        0,
-        500000
-      );
-
-      const result = buildCommitTransaction({
-        utxos: [mockUtxo],
-        inscription: TEST_INSCRIPTION,
-        feeRate: 10,
-        senderPubKey: testPubKey,
-        senderAddress: testKeyPair.address,
-        network: "mainnet",
-      });
+    it("should return valid commit result with tapLeafScript, reveal address, and transaction", () => {
+      const result = buildTestCommit();
 
       expect(result.tx).toBeInstanceOf(btc.Transaction);
       expect(result.fee).toBeGreaterThan(0);
       expect(result.revealAmount).toBeGreaterThan(0);
+      expect(result.revealAddress).toMatch(/^bc1p/);
+      expect(result.revealScript.tapLeafScript).toBeDefined();
+      expect(Array.isArray(result.revealScript.tapLeafScript)).toBe(true);
+      expect(result.revealScript.tapLeafScript!.length).toBeGreaterThan(0);
     });
 
     it("should throw for empty UTXOs", () => {
@@ -357,20 +262,12 @@ describe("inscription-builder", () => {
     });
 
     it("should throw for invalid pubkey length (not 33 bytes)", () => {
-      const mockUtxo = createMockUtxo(
-        "0000000000000000000000000000000000000000000000000000000000000001",
-        0,
-        500000
-      );
-
-      const shortKey = new Uint8Array(16);
-
       expect(() =>
         buildCommitTransaction({
-          utxos: [mockUtxo],
+          utxos: [createMockUtxo(MOCK_TXID, 0, 500000)],
           inscription: TEST_INSCRIPTION,
           feeRate: 10,
-          senderPubKey: shortKey,
+          senderPubKey: new Uint8Array(16),
           senderAddress: testKeyPair.address,
           network: "mainnet",
         })
@@ -378,16 +275,9 @@ describe("inscription-builder", () => {
     });
 
     it("should throw for no confirmed UTXOs", () => {
-      const unconfirmedUtxo = createMockUtxo(
-        "0000000000000000000000000000000000000000000000000000000000000001",
-        0,
-        500000,
-        false // unconfirmed
-      );
-
       expect(() =>
         buildCommitTransaction({
-          utxos: [unconfirmedUtxo],
+          utxos: [createMockUtxo(MOCK_TXID, 0, 500000, false)],
           inscription: TEST_INSCRIPTION,
           feeRate: 10,
           senderPubKey: testPubKey,
@@ -400,69 +290,27 @@ describe("inscription-builder", () => {
 
   describe("commit-reveal round trip", () => {
     it("should complete the full commit-reveal flow with signing and finalization", () => {
-      // Step 1: Build commit transaction
-      const mockUtxo = createMockUtxo(
-        "0000000000000000000000000000000000000000000000000000000000000001",
-        0,
-        500000
-      );
+      const commitResult = buildTestCommit();
 
-      const commitResult = buildCommitTransaction({
-        utxos: [mockUtxo],
-        inscription: TEST_INSCRIPTION,
-        feeRate: 10,
-        senderPubKey: testPubKey,
-        senderAddress: testKeyPair.address,
-        network: "mainnet",
-      });
-
-      // Reveal address must be a valid P2TR address
       expect(commitResult.revealAddress).toMatch(/^bc1p/);
       expect(commitResult.revealAmount).toBeGreaterThan(0);
       expect(commitResult.fee).toBeGreaterThan(0);
 
-      // Step 2: Sign and finalize commit transaction
       commitResult.tx.sign(testKeyPair.privateKey);
       expect(() => commitResult.tx.finalize()).not.toThrow();
 
-      // Step 3: Build reveal transaction using reveal script from commit
-      const fakeCommitTxid = "f".repeat(64);
-      const revealResult = buildRevealTransaction({
-        commitTxid: fakeCommitTxid,
-        commitVout: 0,
-        commitAmount: commitResult.revealAmount,
-        revealScript: commitResult.revealScript,
-        recipientAddress: testTaprootAddress,
-        feeRate: 10,
-        network: "mainnet",
-      });
+      const revealResult = buildTestReveal(commitResult);
 
       expect(revealResult.outputAmount).toBeGreaterThan(0);
       expect(revealResult.fee).toBeGreaterThan(0);
 
-      // Step 4: Sign and finalize reveal transaction
-      // This is the key test — tapLeafScript must be correctly set for signing to work
+      // tapLeafScript must be correctly set for signing to work
       revealResult.tx.sign(testKeyPair.privateKey);
       expect(() => revealResult.tx.finalize()).not.toThrow();
     });
 
     it("should derive the same reveal address in commit and standalone deriveRevealScript", () => {
-      // Verify that buildCommitTransaction and deriveRevealScript produce the same reveal address
-      // This confirms the inscription tool can call deriveRevealScript independently
-      const mockUtxo = createMockUtxo(
-        "0000000000000000000000000000000000000000000000000000000000000002",
-        0,
-        500000
-      );
-
-      const commitResult = buildCommitTransaction({
-        utxos: [mockUtxo],
-        inscription: TEST_INSCRIPTION,
-        feeRate: 10,
-        senderPubKey: testPubKey,
-        senderAddress: testKeyPair.address,
-        network: "mainnet",
-      });
+      const commitResult = buildTestCommit();
 
       const standaloneScript = deriveRevealScript({
         inscription: TEST_INSCRIPTION,
@@ -470,7 +318,6 @@ describe("inscription-builder", () => {
         network: "mainnet",
       });
 
-      // Both must produce the same reveal address (deterministic)
       expect(commitResult.revealAddress).toBe(standaloneScript.address);
     });
   });


### PR DESCRIPTION
## Summary

- **Fixes the "No inputs signed" bug** in `inscribe_reveal` (issue #196) — `buildRevealTransaction()` was spreading `revealScript.tapLeafScript` (an array) into an object, producing `{0: element}` instead of `{tapLeafScript: [...]}`, so `tx.sign()` found nothing to sign
- **Extracts `deriveRevealScript()`** as a standalone exported function so `inscribe_reveal` no longer rebuilds the entire commit transaction with a dummy UTXO just to get the reveal script
- **Adds 17 unit tests** covering deriveRevealScript determinism, buildRevealTransaction signing, commit-then-reveal round-trip, and error paths
- **Consolidates duplicates** — shared `getBtcNetwork` export, centralized `WITNESS_OVERHEAD_VBYTES` in bitcoin-constants.ts

Closes #196

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` — 347 tests pass across 14 files
- [x] New tests cover all three PR #203-style regression paths
- [ ] Manual end-to-end: `inscribe` commit tx → confirm → `inscribe_reveal` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)