### PR TITLE
fix(signing): remove varint prepend from bip322TaggedHash

### DIFF
--- a/src/tools/signing.tools.ts
+++ b/src/tools/signing.tools.ts
@@ -239,16 +239,17 @@ function parseDERSignature(der: Uint8Array): Uint8Array {
 // ---------------------------------------------------------------------------
 
 /**
- * BIP-322 tagged hash: SHA256(SHA256(tag) || SHA256(tag) || varint(msg.len) || msg)
+ * BIP-322 tagged hash: SHA256(SHA256(tag) || SHA256(tag) || msg)
  * where tag = "BIP0322-signed-message"
+ *
+ * Per BIP-322 spec, message bytes are passed directly — no varint length prefix.
+ * Ref: https://github.com/aibtcdev/x402-sponsor-relay/issues/135
  */
 function bip322TaggedHash(message: string): Uint8Array {
   const tagBytes = new TextEncoder().encode("BIP0322-signed-message");
   const tagHash = hashSha256Sync(tagBytes);
   const msgBytes = new TextEncoder().encode(message);
-  const varint = encodeVarInt(msgBytes.length);
-  const msgPart = concatBytes(varint, msgBytes);
-  return hashSha256Sync(concatBytes(tagHash, tagHash, msgPart));
+  return hashSha256Sync(concatBytes(tagHash, tagHash, msgBytes));
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the non-standard varint length prefix in `bip322TaggedHash` that caused BIP-322 signature verification failures for spec-compliant clients.

**Bug:** `bip322TaggedHash` was computing:
```
SHA256(tagHash || tagHash || varint(msg.length) || msgBytes)
```

**BIP-322 spec requires:**
```
SHA256(tagHash || tagHash || msgBytes)
```

The extra `varint(msg.length)` prefix produces a different `toSpend` txid → different BIP-143/BIP-341 sighash → signatures from standard libraries like `bip322-js` always fail verification.

**Fix:** Remove the `varint` and `msgPart` intermediate variables; pass `msgBytes` directly to `hashSha256Sync`.

## Impact

- BIP-137 (P2PKH/P2SH) verification is **unaffected** — uses `formatBitcoinMessage`, not `bip322TaggedHash`
- BIP-322 (P2WPKH `bc1q…`, P2TR `bc1p…`) verification now works for spec-compliant clients
- Coordinated fix across 4 repos — all must ship together so signing and verification stay in sync

## References

- Tracking issue: https://github.com/aibtcdev/x402-sponsor-relay/issues/135
- Linked issue: https://github.com/aibtcdev/aibtc-mcp-server/issues/236
- Related fixes:
  - **landing-page** (verification): https://github.com/aibtcdev/landing-page/issues/313
  - **skills** (signing): https://github.com/aibtcdev/skills/issues/68
  - **x402-sponsor-relay** (verification): https://github.com/aibtcdev/x402-sponsor-relay/issues/135

## Test plan

- [ ] BIP-322 signature from `bip322-js` (or any spec-compliant library) verifies successfully against a `bc1q…` address
- [ ] BIP-322 signature from `bc1p…` (Taproot) verifies successfully
- [ ] BIP-137 signature verification (`1…` or `3…` addresses) continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)