### PR TITLE
fix: skip STX gas check for sponsored sBTC payments in execute_x402_endpoint

### DIFF
--- a/src/services/x402.service.ts
+++ b/src/services/x402.service.ts
@@ -337,9 +337,10 @@ export type ProbeResult = ProbeResultFree | ProbeResultPaymentRequired;
  */
 export function detectTokenType(asset: string): 'STX' | 'sBTC' {
   const assetLower = asset.trim().toLowerCase();
-  // Treat as sBTC only if the asset is exactly "sbtc" (token name)
-  // or a full contract identifier ending with "::token-sbtc"
-  if (assetLower === 'sbtc' || assetLower.endsWith('::token-sbtc')) {
+  // Treat as sBTC if the asset is exactly "sbtc" (token name),
+  // a full contract identifier ending with "::token-sbtc",
+  // or a contract identifier whose name is ".sbtc-token"
+  if (assetLower === 'sbtc' || assetLower.endsWith('::token-sbtc') || assetLower.includes('.sbtc-token')) {
     return 'sBTC';
   }
   return 'STX';
@@ -491,7 +492,8 @@ export function recordTransaction(key: string, txid: string): void {
 export async function checkSufficientBalance(
   account: Account,
   amount: string,
-  asset: string
+  asset: string,
+  sponsored = false
 ): Promise<void> {
   const tokenType = detectTokenType(asset);
   const requiredAmount = BigInt(amount);
@@ -513,24 +515,27 @@ export async function checkSufficientBalance(
       );
     }
 
-    // sBTC transfers are contract calls that also require STX for gas fees
-    const hiroApiForSbtc = getHiroApi(account.network);
-    const stxInfoForSbtc = await hiroApiForSbtc.getStxBalance(account.address);
-    const stxBalanceForSbtc = BigInt(stxInfoForSbtc.balance);
-    const sbtcFees = await hiroApiForSbtc.getMempoolFees();
-    const estimatedSbtcFee = BigInt(sbtcFees.contract_call.high_priority);
+    // sBTC transfers are contract calls that also require STX for gas fees,
+    // unless the transaction is sponsored (relay pays gas; fee: 0n).
+    if (!sponsored) {
+      const hiroApiForSbtc = getHiroApi(account.network);
+      const stxInfoForSbtc = await hiroApiForSbtc.getStxBalance(account.address);
+      const stxBalanceForSbtc = BigInt(stxInfoForSbtc.balance);
+      const sbtcFees = await hiroApiForSbtc.getMempoolFees();
+      const estimatedSbtcFee = BigInt(sbtcFees.contract_call.high_priority);
 
-    if (stxBalanceForSbtc < estimatedSbtcFee) {
-      const stxShortfall = estimatedSbtcFee - stxBalanceForSbtc;
-      throw new InsufficientBalanceError(
-        `Insufficient STX balance to cover sBTC transfer fee: need ${formatStx(estimatedSbtcFee.toString())} estimated fee, ` +
-        `have ${formatStx(stxInfoForSbtc.balance)} (shortfall: ${formatStx(stxShortfall.toString())}). ` +
-        `Deposit more STX or use a different wallet.`,
-        'STX',
-        stxInfoForSbtc.balance,
-        estimatedSbtcFee.toString(),
-        stxShortfall.toString()
-      );
+      if (stxBalanceForSbtc < estimatedSbtcFee) {
+        const stxShortfall = estimatedSbtcFee - stxBalanceForSbtc;
+        throw new InsufficientBalanceError(
+          `Insufficient STX balance to cover sBTC transfer fee: need ${formatStx(estimatedSbtcFee.toString())} estimated fee, ` +
+          `have ${formatStx(stxInfoForSbtc.balance)} (shortfall: ${formatStx(stxShortfall.toString())}). ` +
+          `Deposit more STX or use a different wallet.`,
+          'STX',
+          stxInfoForSbtc.balance,
+          estimatedSbtcFee.toString(),
+          stxShortfall.toString()
+        );
+      }
     }
 
     return;
@@ -541,15 +546,18 @@ export async function checkSufficientBalance(
   const balanceInfo = await hiroApi.getStxBalance(account.address);
   const balance = BigInt(balanceInfo.balance);
 
-  const mempoolFees = await hiroApi.getMempoolFees();
-  const estimatedFee = BigInt(mempoolFees.contract_call.high_priority);
-  const totalRequired = requiredAmount + estimatedFee;
+  let totalRequired = requiredAmount;
+  if (!sponsored) {
+    const mempoolFees = await hiroApi.getMempoolFees();
+    const estimatedFee = BigInt(mempoolFees.contract_call.high_priority);
+    totalRequired = requiredAmount + estimatedFee;
+  }
 
   if (balance >= totalRequired) return;
 
   const shortfall = totalRequired - balance;
   throw new InsufficientBalanceError(
-    `Insufficient STX balance: need ${formatStx(totalRequired.toString())} (${formatStx(amount)} payment + ${formatStx(estimatedFee.toString())} estimated fee), ` +
+    `Insufficient STX balance: need ${formatStx(totalRequired.toString())} (${formatStx(amount)} payment${!sponsored ? ` + estimated fee` : ''}), ` +
     `have ${formatStx(balanceInfo.balance)} (shortfall: ${formatStx(shortfall.toString())}). ` +
     `Deposit more STX or use a different wallet.`,
     'STX',

--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -330,7 +330,7 @@ For aibtc.com inbox messages, use send_inbox_message instead — it uses sponsor
           }
 
           const account = await getAccount();
-          await checkSufficientBalance(account, probeResult.amount, probeResult.asset);
+          await checkSufficientBalance(account, probeResult.amount, probeResult.asset, true);
 
           const api = await createApiClient(parsed.baseUrl);
           const response = await api.request({ method, url: parsed.requestPath, params, data });


### PR DESCRIPTION
## Summary

Closes #238.

`createApiClient` always builds **sponsored transactions** (`fee: 0n`) so the relay covers the STX gas cost. However, `checkSufficientBalance` was still checking that the agent holds enough STX to cover the estimated gas fee for sBTC contract-calls. This caused agents with zero (or low) STX but sufficient sBTC to get a false `InsufficientBalanceError` and fail entirely.

## Root Cause

`checkSufficientBalance` had no way to know whether the transaction would be self-paid or sponsored. Every path through `execute_x402_endpoint` calls `createApiClient`, which unconditionally sets `sponsored: true` and `fee: 0n`. The STX-balance check was therefore always wrong for that flow.

## Changes

### `src/services/x402.service.ts`

- **`checkSufficientBalance` signature** — adds `sponsored = false` parameter (default `false` keeps all other callers safe).
- **sBTC STX gas block** — wraps the STX balance/fee estimation in `if (!sponsored)`. When sponsored, the relay pays gas so no STX is needed from the agent.
- **STX fee block** — wraps `mempoolFees` fetch and `totalRequired = requiredAmount + estimatedFee` in `if (!sponsored)`. When sponsored only the raw payment amount is checked.
- **`detectTokenType`** — adds `.sbtc-token` to the sBTC detection pattern. The actual mainnet sBTC contract is `SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token`; the old check only matched `::token-sbtc` suffixes, so assets advertised as `...sbtc-token::...` would have been misidentified as STX.

### `src/tools/endpoint.tools.ts`

- **`checkSufficientBalance` call site** — passes `true` as the `sponsored` argument since `createApiClient` always builds sponsored transactions.

## Test Plan

- [ ] Agent with sBTC but zero STX can successfully execute a paid sBTC x402 endpoint
- [ ] Agent with insufficient sBTC still gets `InsufficientBalanceError` for sBTC shortfall
- [ ] Agent with insufficient STX (non-sponsored call, if any) still gets `InsufficientBalanceError`
- [ ] `detectTokenType('SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token')` returns `'sBTC'`
- [ ] `detectTokenType('STX')` still returns `'STX'`
- [ ] TypeScript build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)