### PR TITLE
fix: require explicit amountUnit in Bitflow quote/swap (closes #217)

### DIFF
--- a/src/tools/bitflow.tools.ts
+++ b/src/tools/bitflow.tools.ts
@@ -202,9 +202,7 @@ Note: Bitflow is only available on mainnet.`,
           .describe("Amount of input token. Default interpretation is human units (e.g. '100' = 100 LEO)."),
         amountUnit: z
           .enum(["human", "base"])
-          .optional()
-          .default("human")
-          .describe("Amount units: 'human' (default, frontend-style) or 'base' (smallest units)."),
+          .describe("Required. Amount units: 'human' (frontend-style decimal, e.g. '2' for 2 STX) or 'base' (smallest integer units, e.g. '2000000' for 2 STX)."),
       },
     },
     async ({ tokenX, tokenY, amountIn, amountUnit }) => {
@@ -310,9 +308,7 @@ Note: Bitflow is only available on mainnet.`,
           .describe("Amount of input token. Default interpretation is human units (e.g. '100' = 100 LEO)."),
         amountUnit: z
           .enum(["human", "base"])
-          .optional()
-          .default("human")
-          .describe("Amount units: 'human' (default, frontend-style) or 'base' (smallest units)."),
+          .describe("Required. Amount units: 'human' (frontend-style decimal, e.g. '2' for 2 STX) or 'base' (smallest integer units, e.g. '2000000' for 2 STX)."),
         slippageTolerance: z
           .number()
           .optional()


### PR DESCRIPTION
## Summary
- Makes `amountUnit` required (removes `.optional().default("human")`) in `bitflow_get_quote` and `bitflow_swap` tools
- Agents must now explicitly specify `"human"` or `"base"` — no more silent defaults that cause double-scaling bugs
- Error message explains valid values when omitted

## Changes
- `src/tools/bitflow.tools.ts`: Remove `.optional()` and `.default("human")` from `amountUnit` schema in both `bitflow_get_quote` and `bitflow_swap`
- Updated `.describe()` text to clarify the parameter is required and provide examples

## Test plan
- [ ] `bitflow_get_quote` without `amountUnit` → returns Zod validation error explaining valid values
- [ ] `bitflow_get_quote` with `amountUnit: "human"` → works as before
- [ ] `bitflow_get_quote` with `amountUnit: "base"` → works as before
- [ ] `bitflow_swap` without `amountUnit` → returns Zod validation error
- [ ] `bitflow_swap` with explicit `amountUnit` → works as before
- [ ] Build passes (`npm run build`)

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)