### PR TITLE
fix: add preflight guardrail for suspicious amount scaling (closes #219)

### DIFF
--- a/src/tools/bitflow.tools.ts
+++ b/src/tools/bitflow.tools.ts
@@ -15,6 +15,33 @@ const HIGH_IMPACT_THRESHOLD = 0.05; // 5%
 const AMOUNT_SCALE_SUSPICION_MULTIPLIER = 10;
 
 /**
+ * Thrown by checkAmountScaling when the requested amount looks like it was
+ * supplied in base units instead of human units.
+ */
+class AmountUnitMismatchError extends Error {
+  readonly code = "AMOUNT_UNIT_MISMATCH_SUSPECTED";
+  readonly details: {
+    requestedAmountHuman: number;
+    requestedAmountInput: string;
+    walletBalanceHuman: number;
+    tokenDecimals: number;
+    tokenSymbol: string;
+    correctedHumanAmount: number;
+    correctedBaseAmount: string;
+    suspicionMultiplier: number;
+  };
+
+  constructor(
+    message: string,
+    details: AmountUnitMismatchError["details"]
+  ) {
+    super(message);
+    this.name = "AmountUnitMismatchError";
+    this.details = details;
+  }
+}
+
+/**
  * Resolve amountIn to the human-unit number the Bitflow SDK expects.
  * When amountUnit is "human" (default), validates and passes through.
  * When amountUnit is "base", converts from smallest units using token decimals.
@@ -89,18 +116,19 @@ async function checkAmountScaling(
     return;
   }
 
-  // Look up the token's decimals from the Bitflow token list.
-  // Fall back to 6 (micro-STX standard) if the token is unknown.
-  const tokens = await bitflowService.getAvailableTokens();
-  const tokenMeta = tokens.find((t) => t.id === tokenX);
-  const decimals = tokenMeta?.decimals ?? 6;
-
-  // Fetch the wallet's balance for this token.
-  // STX is identified in Bitflow as "token-stx".
-  const hiroApi = getHiroApi(NETWORK);
-  let walletBalanceHuman: number;
-
   try {
+    // Look up the token's decimals from the Bitflow token list.
+    // Fall back to 6 (micro-STX standard) if the token is unknown.
+    // NOTE: getAvailableTokens() is inside this try/catch so that a Bitflow
+    // API outage does not propagate as an uncaught error and block all swaps.
+    const tokens = await bitflowService.getAvailableTokens();
+    const tokenMeta = tokens.find((t) => t.id === tokenX);
+    const decimals = tokenMeta?.decimals ?? 6;
+
+    // Fetch the wallet's balance for this token.
+    // STX is identified in Bitflow as "token-stx".
+    const hiroApi = getHiroApi(NETWORK);
+    let walletBalanceHuman: number;
     const isStx = tokenX === "token-stx";
     if (isStx) {
       const stxInfo = await hiroApi.getStxBalance(walletAddress);
@@ -110,48 +138,48 @@ async function checkAmountScaling(
       const rawBalance = await hiroApi.getTokenBalance(walletAddress, tokenX);
       walletBalanceHuman = Number(rawBalance) / 10 ** decimals;
     }
-  } catch {
-    // Balance lookup failed (network issue, unknown token, etc.) — skip the
-    // guard rather than blocking legitimate swaps.
+
+    // If the wallet has no balance at all, there is nothing to compare against.
+    if (walletBalanceHuman <= 0) return;
+
+    const threshold = walletBalanceHuman * AMOUNT_SCALE_SUSPICION_MULTIPLIER;
+    if (humanAmount <= threshold) return;
+
+    // The requested amount looks like it was supplied in base units.
+    // Build a helpful error with corrected examples.
+    const correctedHumanAmount = (humanAmount / 10 ** decimals).toFixed(decimals > 0 ? 6 : 0);
+    const baseEquivalent = Math.round(humanAmount * 10 ** decimals).toString();
+
+    throw new AmountUnitMismatchError(
+      `AMOUNT_UNIT_MISMATCH_SUSPECTED: The requested amount (${humanAmount} in human units) is ` +
+      `${(humanAmount / walletBalanceHuman).toFixed(0)}x your wallet balance ` +
+      `(${walletBalanceHuman.toFixed(6)} ${tokenMeta?.symbol ?? tokenX}). ` +
+      `This strongly suggests you passed a base-unit value as a human-unit value. ` +
+      `To fix this, either:\n` +
+      `  1. Pass amountUnit="base" with amountIn="${Math.round(humanAmount)}" ` +
+      `     (the SDK will convert ${Math.round(humanAmount)} base-units → ~${correctedHumanAmount} ${tokenMeta?.symbol ?? tokenX})\n` +
+      `  2. Pass amountUnit="human" (default) with amountIn="${correctedHumanAmount}" ` +
+      `     (interpreted directly as ${correctedHumanAmount} ${tokenMeta?.symbol ?? tokenX})\n` +
+      `  3. If you really do intend to swap ${humanAmount} ${tokenMeta?.symbol ?? tokenX}, ` +
+      `     first fund your wallet — it currently holds ${walletBalanceHuman.toFixed(6)} ${tokenMeta?.symbol ?? tokenX}.`,
+      {
+        requestedAmountHuman: humanAmount,
+        requestedAmountInput: amountIn,
+        walletBalanceHuman,
+        tokenDecimals: decimals,
+        tokenSymbol: tokenMeta?.symbol ?? tokenX,
+        correctedHumanAmount: Number(correctedHumanAmount),
+        correctedBaseAmount: baseEquivalent,
+        suspicionMultiplier: AMOUNT_SCALE_SUSPICION_MULTIPLIER,
+      }
+    );
+  } catch (err) {
+    // Re-throw only our own typed error — for anything else (Bitflow API down,
+    // balance lookup failed, network issue, unknown token, etc.) we silently
+    // skip the guard rather than blocking legitimate swaps.
+    if (err instanceof AmountUnitMismatchError) throw err;
     return;
   }
-
-  // If the wallet has no balance at all, there is nothing to compare against.
-  if (walletBalanceHuman <= 0) return;
-
-  const threshold = walletBalanceHuman * AMOUNT_SCALE_SUSPICION_MULTIPLIER;
-  if (humanAmount <= threshold) return;
-
-  // The requested amount looks like it was supplied in base units.
-  // Build a helpful error with corrected examples.
-  const correctedHumanAmount = (humanAmount / 10 ** decimals).toFixed(decimals > 0 ? 6 : 0);
-  const baseEquivalent = Math.round(humanAmount * 10 ** decimals).toString();
-
-  const error = new Error(
-    `AMOUNT_UNIT_MISMATCH_SUSPECTED: The requested amount (${humanAmount} in human units) is ` +
-    `${(humanAmount / walletBalanceHuman).toFixed(0)}x your wallet balance ` +
-    `(${walletBalanceHuman.toFixed(6)} ${tokenMeta?.symbol ?? tokenX}). ` +
-    `This strongly suggests you passed a base-unit value as a human-unit value. ` +
-    `To fix this, either:\n` +
-    `  1. Pass amountUnit="base" with amountIn="${Math.round(humanAmount)}" ` +
-    `     (the SDK will convert ${Math.round(humanAmount)} base-units → ~${correctedHumanAmount} ${tokenMeta?.symbol ?? tokenX})\n` +
-    `  2. Pass amountUnit="human" (default) with amountIn="${correctedHumanAmount}" ` +
-    `     (interpreted directly as ${correctedHumanAmount} ${tokenMeta?.symbol ?? tokenX})\n` +
-    `  3. If you really do intend to swap ${humanAmount} ${tokenMeta?.symbol ?? tokenX}, ` +
-    `     first fund your wallet — it currently holds ${walletBalanceHuman.toFixed(6)} ${tokenMeta?.symbol ?? tokenX}.`
-  );
-  (error as any).code = "AMOUNT_UNIT_MISMATCH_SUSPECTED";
-  (error as any).details = {
-    requestedAmountHuman: humanAmount,
-    requestedAmountInput: amountIn,
-    walletBalanceHuman,
-    tokenDecimals: decimals,
-    tokenSymbol: tokenMeta?.symbol ?? tokenX,
-    correctedHumanAmount: Number(correctedHumanAmount),
-    correctedBaseAmount: baseEquivalent,
-    suspicionMultiplier: AMOUNT_SCALE_SUSPICION_MULTIPLIER,
-  };
-  throw error;
 }
 
 export function registerBitflowTools(server: McpServer): void {


### PR DESCRIPTION
## Problem

When an agent calls `bitflow_get_quote` or `bitflow_swap` with `amountUnit="human"` (the default) but accidentally passes a base-unit value — e.g. `amountIn="1000000"` intending 1 STX but actually requesting 1,000,000 STX — the SDK receives an inflated amount and the transaction fails on-chain after burning STX fees and retries. The error is cryptic and gives no guidance on how to fix the call.

## Solution

Add a `checkAmountScaling()` preflight function, called immediately after `resolveAmountIn()` in both the `bitflow_get_quote` and `bitflow_swap` handlers.

**Logic:**
1. Fetch the wallet's current token balance via the Hiro API (STX via `getStxBalance`, FTs via `getTokenBalance`).
2. If `humanAmount > 10 × walletBalanceHuman`, throw `AMOUNT_UNIT_MISMATCH_SUSPECTED`.
3. The error message includes:
   - The requested amount and wallet balance
   - Token symbol and decimals
   - Two corrected call examples: one with `amountUnit="base"`, one with the properly scaled `amountUnit="human"` value

**Graceful degradation:** The check is silently skipped when:
- No wallet is unlocked / no mnemonic is set (cannot resolve address)
- The Hiro balance API is unreachable (network error)

This means a transient API outage never blocks legitimate swaps.

## Changes

Only `src/tools/bitflow.tools.ts` is modified:
- Added `import { getHiroApi }` from the existing hiro-api service
- Added `AMOUNT_SCALE_SUSPICION_MULTIPLIER = 10` constant
- Added `checkAmountScaling()` function (~80 lines, fully documented)
- Added one `await checkAmountScaling(...)` call in `bitflow_get_quote`
- Added one `await checkAmountScaling(...)` call in `bitflow_swap`

TypeScript compiles cleanly (`tsc --noEmit`).

## Test plan

- [ ] Call `bitflow_get_quote` with `amountIn="1000000"` and `amountUnit="human"` on a wallet with ~1 STX balance — expect `AMOUNT_UNIT_MISMATCH_SUSPECTED` error with corrected examples
- [ ] Call the same with `amountUnit="base"` and `amountIn="1000000"` — expect normal quote for 1 STX (no guard fires because unit is explicit)
- [ ] Call with `amountIn="1"` and `amountUnit="human"` on a wallet with ~1 STX balance — expect normal quote (amount ≤ threshold)
- [ ] Call `bitflow_swap` with a suspicious amount — expect the same early rejection before any on-chain tx is constructed
- [ ] Simulate wallet-locked state (no mnemonic set) with a suspicious amount — expect normal pass-through (guard skipped)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)