### PR TITLE
feat: return interpreted amount metadata in Bitflow quote/swap (closes #218)

### DIFF
--- a/src/tools/bitflow.tools.ts
+++ b/src/tools/bitflow.tools.ts
@@ -42,7 +42,20 @@ class AmountUnitMismatchError extends Error {
 }
 
 /**
- * Resolve amountIn to the human-unit number the Bitflow SDK expects.
+ * Metadata describing how amountIn was interpreted and converted.
+ */
+interface AmountMetadata {
+  amountInRawInput: string;
+  amountUnit: "human" | "base";
+  tokenDecimals: number | null;
+  amountInHuman: number;
+  amountInBase: string;
+  interpretation: string;
+}
+
+/**
+ * Resolve amountIn to the human-unit number the Bitflow SDK expects,
+ * and return full interpretation metadata for auditability.
  * When amountUnit is "human" (default), validates and passes through.
  * When amountUnit is "base", converts from smallest units using token decimals.
  */
@@ -51,7 +64,7 @@ async function resolveAmountIn(
   tokenX: string,
   amountIn: string,
   amountUnit: "human" | "base"
-): Promise<number> {
+): Promise<{ normalizedAmountIn: number; amountMetadata: AmountMetadata }> {
   if (amountUnit === "base") {
     if (!/^[1-9]\d*$/.test(amountIn)) {
       throw new Error("amountIn must be a positive integer when amountUnit='base'");
@@ -65,14 +78,48 @@ async function resolveAmountIn(
     if (!Number.isFinite(numeric)) {
       throw new Error("Converted amount is too large to handle safely");
     }
-    return numeric;
+    const amountMetadata: AmountMetadata = {
+      amountInRawInput: amountIn,
+      amountUnit: "base",
+      tokenDecimals: tokenIn.decimals,
+      amountInHuman: numeric,
+      amountInBase: amountIn,
+      interpretation: `Input '${amountIn}' interpreted as base units; converted to ${numeric} human units using ${tokenIn.decimals} decimals`,
+    };
+    return { normalizedAmountIn: numeric, amountMetadata };
   }
 
   const numeric = Number(amountIn);
   if (!Number.isFinite(numeric) || numeric <= 0) {
     throw new Error("amountIn must be a positive number");
   }
-  return numeric;
+  // For human units we don't need decimals from the token list; base = round(human * 10^decimals).
+  // Since we don't know decimals without an extra fetch, we omit the base string here and
+  // attempt a best-effort lookup so the metadata is as complete as possible.
+  let tokenDecimals: number | null = null;
+  let amountInBase: string = "unknown (decimals not fetched for human-unit input)";
+  try {
+    const tokens = await bitflowService.getAvailableTokens();
+    const tokenIn = tokens.find((t) => t.id === tokenX);
+    if (tokenIn) {
+      tokenDecimals = tokenIn.decimals;
+      amountInBase = String(Math.round(numeric * 10 ** tokenIn.decimals));
+    }
+  } catch {
+    // Non-fatal: metadata degrades gracefully if token list is unavailable
+  }
+  const amountMetadata: AmountMetadata = {
+    amountInRawInput: amountIn,
+    amountUnit: "human",
+    tokenDecimals,
+    amountInHuman: numeric,
+    amountInBase,
+    interpretation:
+      tokenDecimals !== null
+        ? `Input '${amountIn}' interpreted as human units (${tokenDecimals} decimals); base unit equivalent is ${amountInBase}`
+        : `Input '${amountIn}' interpreted as human units; token decimals unavailable so base unit string is omitted`,
+  };
+  return { normalizedAmountIn: numeric, amountMetadata };
 }
 
 /**
@@ -356,7 +403,12 @@ Note: Bitflow is only available on mainnet.`,
         }
 
         const bitflowService = getBitflowService(NETWORK);
-        const normalizedAmountIn = await resolveAmountIn(bitflowService, tokenX, amountIn, amountUnit);
+        const { normalizedAmountIn, amountMetadata } = await resolveAmountIn(
+          bitflowService,
+          tokenX,
+          amountIn,
+          amountUnit
+        );
         await checkAmountScaling(bitflowService, tokenX, normalizedAmountIn, amountIn, amountUnit);
 
         const quote = await bitflowService.getSwapQuote(tokenX, tokenY, normalizedAmountIn);
@@ -376,6 +428,7 @@ Note: Bitflow is only available on mainnet.`,
             amountUnit,
             normalizedAmountIn,
           },
+          amountMetadata,
           quote,
           priceImpact,
           highImpactWarning,
@@ -477,7 +530,12 @@ Note: Bitflow is only available on mainnet.`,
         }
 
         const bitflowService = getBitflowService(NETWORK);
-        const normalizedAmountIn = await resolveAmountIn(bitflowService, tokenX, amountIn, amountUnit);
+        const { normalizedAmountIn, amountMetadata } = await resolveAmountIn(
+          bitflowService,
+          tokenX,
+          amountIn,
+          amountUnit
+        );
         await checkAmountScaling(bitflowService, tokenX, normalizedAmountIn, amountIn, amountUnit);
 
         // Safety check: require explicit confirmation for high-impact swaps
@@ -487,6 +545,7 @@ Note: Bitflow is only available on mainnet.`,
           return createJsonResponse({
             error: "High price impact swap requires explicit confirmation",
             message: `This swap has ${impact.combinedImpactPct} price impact (${impact.severity}). Set confirmHighImpact=true to proceed.`,
+            amountMetadata,
             quote,
             threshold: `${(HIGH_IMPACT_THRESHOLD * 100).toFixed(0)}%`,
             requiredParam: "confirmHighImpact",
@@ -516,6 +575,7 @@ Note: Bitflow is only available on mainnet.`,
             slippageTolerance: slippageTolerance || 0.01,
             priceImpact: impact,
           },
+          amountMetadata,
           network: NETWORK,
           explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
         });


### PR DESCRIPTION
## Summary

- Adds an `AmountMetadata` TypeScript interface capturing how `amountIn` was interpreted before being passed to the Bitflow SDK.
- Refactors `resolveAmountIn()` to return `{ normalizedAmountIn, amountMetadata }` instead of a bare number; all call sites updated.
- `amountMetadata` is now included in the response of `bitflow_get_quote` and `bitflow_swap` (including the high-impact early-return path), giving agents a full audit trail.

### amountMetadata fields

| Field | Description |
|---|---|
| `amountInRawInput` | The original input string exactly as provided |
| `amountUnit` | `"human"` or `"base"` |
| `tokenDecimals` | Decimals for the input token (null if unavailable) |
| `amountInHuman` | The resolved human-unit float passed to the SDK |
| `amountInBase` | The base-unit string (integer for `"base"` input; computed for `"human"` input; `"unknown"` if token list fetch fails) |
| `interpretation` | Human-readable summary of the conversion |

### Behaviour notes

- For `amountUnit="base"`: token decimals are always fetched (already required for conversion); `amountInBase` equals the raw input; metadata is fully populated.
- For `amountUnit="human"`: a best-effort token-list fetch is attempted to populate `tokenDecimals` and `amountInBase`. Failure is non-fatal — the field degrades to an explanatory string and the normal swap path is unaffected.
- `npx tsc --noEmit` passes with zero errors.

## Test plan

- [ ] Call `bitflow_get_quote` with `amountUnit="human"` — verify `amountMetadata` appears in response with correct `amountInHuman` and computed `amountInBase`.
- [ ] Call `bitflow_get_quote` with `amountUnit="base"` — verify `amountMetadata.amountInBase` matches raw input and `amountInHuman` reflects the converted value.
- [ ] Call `bitflow_swap` with a high-impact scenario and `confirmHighImpact=false` — verify `amountMetadata` is present in the early-return error response.
- [ ] Call `bitflow_swap` successfully — verify `amountMetadata` appears alongside `swap` and `txid`.
- [ ] Confirm TypeScript compiles: `npx tsc --noEmit`.

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)