### PR TITLE
fix: correct Xverse API field mapping in lookupParentInscription

### DIFF
--- a/src/transactions/child-inscription-builder.ts
+++ b/src/transactions/child-inscription-builder.ts
@@ -420,24 +420,27 @@ export async function lookupParentInscription(
   }
 
   const data = (await response.json()) as {
-    txid?: string;
-    vout?: number;
-    value?: string;
+    tx_id?: string;
+    value?: number;
     address?: string;
     output?: string;
   };
 
-  if (!data.txid || data.vout === undefined || !data.value || !data.address) {
+  if (!data.tx_id || !data.output || data.value === undefined || !data.address) {
     throw new Error(
       `Inscription ${inscriptionId} not found or missing UTXO data`
     );
   }
 
+  // Xverse returns output as "txid:vout" — parse vout from it
+  const outputParts = data.output.split(":");
+  const vout = parseInt(outputParts[1], 10);
+
   return {
-    txid: data.txid,
-    vout: data.vout,
-    value: parseInt(data.value, 10),
+    txid: data.tx_id,
+    vout,
+    value: data.value,
     address: data.address,
-    output: data.output || `${data.txid}:${data.vout}`,
+    output: data.output,
   };
 }


### PR DESCRIPTION
## Summary

- Fixes `lookupParentInscription` which always threw "not found or missing UTXO data" for valid inscriptions
- The Xverse Ordinals API (`api-3.xverse.app`) returns different field names than the code expected:
  - `tx_id` not `txid`
  - `output` as `"txid:vout"` string (no separate `vout` field)
  - `value` as a number (not a string)

## Bug found during

Testing PR #254 (parent-child inscription tools) end-to-end on mainnet. The parent inscription was created successfully but `inscribe_child` failed when looking up the parent via Xverse API.

## Test plan

- [x] `npm run build` compiles cleanly
- [x] Verified fix locally with `node -e` calling `lookupParentInscription` against a real inscription
- [ ] Full end-to-end test: `inscribe_child` → `inscribe_child_reveal` (requires MCP server restart with local build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)