### PR TITLE
feat: add sbtc_withdraw_status alias for sBTC peg-out status

### DIFF
--- a/src/tools/sbtc.tools.ts
+++ b/src/tools/sbtc.tools.ts
@@ -252,78 +252,107 @@ Signers later process the request and send BTC on L1.`,
     }
   );
 
+  // Shared withdrawal status logic used by sbtc_withdrawal_status and sbtc_withdraw_status
+  async function fetchWithdrawalStatus(params: {
+    requestId?: number;
+    txid?: string;
+  }) {
+    const { requestId, txid } = params;
+
+    if (requestId === undefined && !txid) {
+      throw new Error("Provide either requestId or txid.");
+    }
+
+    const sbtcService = getSbtcService(NETWORK);
+    let resolvedRequestId: number | null | undefined = requestId;
+
+    if (resolvedRequestId === undefined && txid) {
+      resolvedRequestId = await sbtcService.getWithdrawalRequestIdFromTx(txid);
+      if (resolvedRequestId === null) {
+        return createJsonResponse({
+          txid,
+          requestId: null,
+          status: "pending_tx",
+          message:
+            "Could not resolve requestId from tx yet. The transaction may still be pending or unindexed.",
+          network: NETWORK,
+          explorerUrl: getExplorerTxUrl(txid, NETWORK),
+        });
+      }
+    }
+
+    if (resolvedRequestId == null) {
+      throw new Error("Unable to resolve withdrawal request ID.");
+    }
+
+    const request = await sbtcService.getWithdrawalRequest(
+      resolvedRequestId,
+      getReadonlySenderAddress()
+    );
+
+    if (!request) {
+      return createJsonResponse({
+        requestId: resolvedRequestId,
+        status: "not_found",
+        network: NETWORK,
+      });
+    }
+
+    return createJsonResponse({
+      requestId: request.id,
+      status: request.status,
+      network: NETWORK,
+      amountSats: request.amountSats,
+      maxFeeSats: request.maxFeeSats,
+      sender: request.sender,
+      blockHeight: request.blockHeight,
+      recipient: request.recipient,
+      txid,
+      ...(txid ? { explorerUrl: getExplorerTxUrl(txid, NETWORK) } : {}),
+    });
+  }
+
+  const withdrawalStatusInputSchema = {
+    requestId: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Withdrawal request ID"),
+    txid: z
+      .string()
+      .optional()
+      .describe("Initiate-withdrawal transaction ID (used to resolve requestId)"),
+  };
+
   // Check withdrawal request status
   server.registerTool(
     "sbtc_withdrawal_status",
     {
       description:
         "Check status of an sBTC withdrawal request by requestId or initiating txid.",
-      inputSchema: {
-        requestId: z
-          .number()
-          .int()
-          .positive()
-          .optional()
-          .describe("Withdrawal request ID"),
-        txid: z
-          .string()
-          .optional()
-          .describe("Initiate-withdrawal transaction ID (used to resolve requestId)"),
-      },
+      inputSchema: withdrawalStatusInputSchema,
     },
     async ({ requestId, txid }) => {
       try {
-        if (requestId === undefined && !txid) {
-          throw new Error("Provide either requestId or txid.");
-        }
+        return await fetchWithdrawalStatus({ requestId, txid });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
 
-        const sbtcService = getSbtcService(NETWORK);
-        let resolvedRequestId: number | null | undefined = requestId;
-
-        if (resolvedRequestId === undefined && txid) {
-          resolvedRequestId = await sbtcService.getWithdrawalRequestIdFromTx(txid);
-          if (resolvedRequestId === null) {
-            return createJsonResponse({
-              txid,
-              requestId: null,
-              status: "pending_tx",
-              message:
-                "Could not resolve requestId from tx yet. The transaction may still be pending or unindexed.",
-              network: NETWORK,
-              explorerUrl: getExplorerTxUrl(txid, NETWORK),
-            });
-          }
-        }
-
-        if (resolvedRequestId == null) {
-          throw new Error("Unable to resolve withdrawal request ID.");
-        }
-
-        const request = await sbtcService.getWithdrawalRequest(
-          resolvedRequestId,
-          getReadonlySenderAddress()
-        );
-
-        if (!request) {
-          return createJsonResponse({
-            requestId: resolvedRequestId,
-            status: "not_found",
-            network: NETWORK,
-          });
-        }
-
-        return createJsonResponse({
-          requestId: request.id,
-          status: request.status,
-          network: NETWORK,
-          amountSats: request.amountSats,
-          maxFeeSats: request.maxFeeSats,
-          sender: request.sender,
-          blockHeight: request.blockHeight,
-          recipient: request.recipient,
-          txid,
-          ...(txid ? { explorerUrl: getExplorerTxUrl(txid, NETWORK) } : {}),
-        });
+  // Compatibility alias for sbtc_withdrawal_status
+  server.registerTool(
+    "sbtc_withdraw_status",
+    {
+      description:
+        "Alias for sbtc_withdrawal_status. Check the status of an sBTC peg-out (withdrawal) request.",
+      inputSchema: withdrawalStatusInputSchema,
+    },
+    async ({ requestId, txid }) => {
+      try {
+        return await fetchWithdrawalStatus({ requestId, txid });
       } catch (error) {
         return createErrorResponse(error);
       }


### PR DESCRIPTION
## Summary

- Adds `sbtc_withdraw_status` as a compatibility alias for `sbtc_withdrawal_status`
- Refactors shared status logic into a `fetchWithdrawalStatus` helper function, mirroring the existing `executeWithdrawal` pattern used by `sbtc_withdraw` / `sbtc_initiate_withdrawal`
- No existing tool behaviour is changed

## Background

Issue #189 originally requested two tools: `sbtc_withdraw` and `sbtc_withdraw_status`. PR #235 (merged) delivered `sbtc_initiate_withdrawal`, `sbtc_withdraw` (alias), and `sbtc_withdrawal_status`. The shorter alias `sbtc_withdraw_status` was not included. This PR adds that missing alias so agent code targeting the originally-requested tool name works without modification.

Closes #189

## Test plan
- [x] TypeScript compiles with `npx tsc --noEmit` — no errors
- [ ] Call `sbtc_withdraw_status` with a known `requestId` — returns same response as `sbtc_withdrawal_status`
- [ ] Call `sbtc_withdraw_status` with a known `txid` — resolves requestId and returns status
- [ ] Call `sbtc_withdraw_status` with neither param — returns clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)