### PR TITLE
fix: add tapInternalKey to parent input for key-path signing

### DIFF
--- a/src/transactions/child-inscription-builder.ts
+++ b/src/transactions/child-inscription-builder.ts
@@ -382,6 +382,7 @@ export function buildChildRevealTransaction(
       script: parentP2tr.script,
       amount: BigInt(parentUtxo.value),
     },
+    tapInternalKey: parentOwnerTaprootInternalPubKey,
   });
 
   // Output[0]: Parent return → owner's P2TR address (dust)


### PR DESCRIPTION
## Summary
- Adds `tapInternalKey` to the parent UTXO input in `buildChildRevealTransaction`
- Without this field, `@scure/btc-signer` cannot perform Taproot key-path signing on the parent input, causing "No inputs signed" error during `inscribe_child_reveal`
- Verified fix with a live mainnet child inscription: `fdfc0566aed98edcc29f06af7b55c0383d49a83187787752c2eae371d52d178bi0` (parent: `93f65d6c...27ffi0`)

## Test plan
- [x] Both inputs sign correctly (`btcPrivateKey` → Input[0] script-path, `taprootPrivateKey` → Input[1] key-path)
- [x] Reveal tx broadcast and confirmed on mainnet
- [x] Child inscription visible with parent tag via Xverse API

🤖 Generated with [Claude Code](https://claude.com/claude-code)