### PR TITLE
feat: enable RBF on inscription txs and fix reveal fee estimation

### DIFF
--- a/src/config/bitcoin-constants.ts
+++ b/src/config/bitcoin-constants.ts
@@ -40,3 +40,9 @@ export const P2TR_INPUT_BASE_VBYTES = 57.5;
  * Inscription witness overhead (vbytes) - control block, script, and protocol framing
  */
 export const WITNESS_OVERHEAD_VBYTES = 80;
+
+/**
+ * BIP 125 RBF sequence number.
+ * Any sequence < 0xfffffffe signals replaceability, allowing fee bumps via RBF.
+ */
+export const RBF_SEQUENCE = 0xfffffffd;

--- a/src/transactions/child-inscription-builder.ts
+++ b/src/transactions/child-inscription-builder.ts
@@ -19,6 +19,7 @@ import {
   TX_OVERHEAD_VBYTES,
   DUST_THRESHOLD,
   WITNESS_OVERHEAD_VBYTES,
+  RBF_SEQUENCE,
 } from "../config/bitcoin-constants.js";
 import type { UTXO } from "../services/mempool-api.js";
 import { getBtcNetwork } from "./bitcoin-builder.js";
@@ -267,6 +268,7 @@ export function buildChildCommitTransaction(
     tx.addInput({
       txid: utxo.txid,
       index: utxo.vout,
+      sequence: RBF_SEQUENCE,
       witnessUtxo: {
         script: senderP2wpkh.script,
         amount: BigInt(utxo.value),
@@ -329,9 +331,11 @@ export function buildChildRevealTransaction(
   // Estimate reveal transaction size
   const revealInputSize = P2TR_INPUT_BASE_VBYTES; // commit input
   const parentInputSize = P2TR_INPUT_BASE_VBYTES; // parent key-path input
-  const revealWitnessSize = Math.ceil(
-    (revealScript.script?.byteLength || 0) / 4
-  );
+  // The witness includes the full tapLeafScript (inscription data + control block)
+  const tapLeafScriptSize = revealScript.tapLeafScript
+    ? revealScript.tapLeafScript.reduce((sum, [_, s]) => sum + s.length + 33, 0)
+    : 0;
+  const revealWitnessSize = Math.ceil(tapLeafScriptSize / 4) + WITNESS_OVERHEAD_VBYTES;
   const revealTxSize =
     TX_OVERHEAD_VBYTES +
     revealInputSize +
@@ -362,6 +366,7 @@ export function buildChildRevealTransaction(
   tx.addInput({
     txid: commitTxid,
     index: commitVout,
+    sequence: RBF_SEQUENCE,
     witnessUtxo: {
       script: revealScript.script,
       amount: BigInt(commitAmount),
@@ -378,6 +383,7 @@ export function buildChildRevealTransaction(
   tx.addInput({
     txid: parentUtxo.txid,
     index: parentUtxo.vout,
+    sequence: RBF_SEQUENCE,
     witnessUtxo: {
       script: parentP2tr.script,
       amount: BigInt(parentUtxo.value),

--- a/src/transactions/inscription-builder.ts
+++ b/src/transactions/inscription-builder.ts
@@ -18,6 +18,7 @@ import {
   DUST_THRESHOLD,
   P2TR_INPUT_BASE_VBYTES,
   WITNESS_OVERHEAD_VBYTES,
+  RBF_SEQUENCE,
 } from "../config/bitcoin-constants.js";
 import type { UTXO } from "../services/mempool-api.js";
 import { getBtcNetwork } from "./bitcoin-builder.js";
@@ -344,6 +345,7 @@ export function buildCommitTransaction(
     tx.addInput({
       txid: utxo.txid,
       index: utxo.vout,
+      sequence: RBF_SEQUENCE,
       witnessUtxo: {
         script: senderP2wpkh.script,
         amount: BigInt(utxo.value),
@@ -418,10 +420,12 @@ export function buildRevealTransaction(
 
   // Estimate reveal transaction size
   // 1 input (Taproot with inscription witness) + 1 output (recipient)
+  // The witness includes the full tapLeafScript (inscription data + control block)
   const revealInputSize = P2TR_INPUT_BASE_VBYTES;
-  const revealWitnessSize = Math.ceil(
-    (revealScript.script?.byteLength || 0) / 4
-  );
+  const tapLeafScriptSize = revealScript.tapLeafScript
+    ? revealScript.tapLeafScript.reduce((sum, [_, s]) => sum + s.length + 33, 0)
+    : 0;
+  const revealWitnessSize = Math.ceil(tapLeafScriptSize / 4) + WITNESS_OVERHEAD_VBYTES;
   const revealTxSize =
     TX_OVERHEAD_VBYTES + revealInputSize + revealWitnessSize + P2TR_OUTPUT_VBYTES;
   const revealFee = Math.ceil(revealTxSize * feeRate);
@@ -444,6 +448,7 @@ export function buildRevealTransaction(
   tx.addInput({
     txid: commitTxid,
     index: commitVout,
+    sequence: RBF_SEQUENCE,
     witnessUtxo: {
       script: revealScript.script,
       amount: BigInt(commitAmount),


### PR DESCRIPTION
## Summary
- Enable BIP 125 RBF on all inscription transaction inputs (commit + reveal, both regular and child) by setting sequence to `0xfffffffd`
- Fix reveal fee estimation: was using `revealScript.script.byteLength` (34 bytes = P2TR output script) instead of actual `tapLeafScript` witness data size, underestimating fees by ~30 vB
- Adds `RBF_SEQUENCE` constant to `bitcoin-constants.ts`

## Context
During live testing of child inscriptions, the reveal tx landed at 0.88 sat/vB despite requesting 1 sat/vB, and couldn't be fee-bumped because sequence was 0xffffffff (no RBF). Required a CPFP transaction to accelerate confirmation.

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] Verify inscription commit txs have sequence 0xfffffffd (RBF-enabled)
- [ ] Verify reveal tx fee estimation matches actual vsize more closely

🤖 Generated with [Claude Code](https://claude.com/claude-code)