### PR TITLE
fix: pre-check rewards before broadcasting zest_claim_rewards

### DIFF
--- a/src/services/defi.service.ts
+++ b/src/services/defi.service.ts
@@ -787,13 +787,26 @@ export class ZestProtocolService {
 
     if (rewardsResult.okay && rewardsResult.result) {
       const decoded = cvToJSON(hexToCV(rewardsResult.result));
-      if (decoded?.value === undefined) {
+      // get-vault-rewards returns a bare uint, but handle (ok uint) / (response uint uint)
+      // defensively in case the contract is upgraded.
+      // Bare uint: { type: "uint", value: "123" }
+      // Response-wrapped: { type: "ok", value: { type: "uint", value: "123" } }
+      const rawValue =
+        typeof decoded?.value === "object" && decoded.value?.value !== undefined
+          ? decoded.value.value
+          : decoded?.value;
+
+      if (rawValue === undefined) {
         // Can't decode response -- skip pre-check, let the on-chain tx decide
-      } else if (BigInt(decoded.value) === 0n) {
+      } else if (BigInt(rawValue) === 0n) {
         throw new Error(
           "No rewards available to claim. Skipping broadcast to avoid wasting gas."
         );
       }
+    } else if (!rewardsResult.okay) {
+      console.error(
+        `[zest] get-vault-rewards read-only call failed: ${rewardsResult.result ?? "unknown error"}. Skipping pre-check.`
+      );
     }
 
     const priceFeedBytes = await this.fetchPriceFeedBytes();


### PR DESCRIPTION
## Summary

- Adds a read-only pre-check call to `incentives-v2-2.get-vault-rewards` before broadcasting the `claim-rewards` transaction
- When pending rewards are zero, the function throws early with a descriptive error message instead of broadcasting a transaction that would abort on-chain with `ERR_NO_REWARDS` and waste gas
- Follows the existing `callReadOnlyFunction` pattern used elsewhere in the file (e.g., `getPoolInfo`, `getUserPosition`)

Closes #279

## Test plan

- [ ] Verify TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Test `zest_claim_rewards` with an account that has pending rewards -- should broadcast as before
- [ ] Test `zest_claim_rewards` with an account that has zero rewards -- should return an error without broadcasting
- [ ] Confirm the read-only call arguments match the `incentives-v2-2.get-vault-rewards` Clarity function signature: `(user principal, supplied-asset principal, reward-asset principal)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)