### PR TITLE
fix: fall back to LP token balance in zest_get_position

### DIFF
--- a/src/services/defi.service.ts
+++ b/src/services/defi.service.ts
@@ -510,6 +510,11 @@ export class ZestProtocolService {
 
   /**
    * Get user's reserve/position data for an asset
+   *
+   * Note: `current-a-token-balance` from pool-borrow tracks borrow collateral
+   * accounting and is zero for supply-only users. When it returns "0", we fall
+   * back to querying the LP token contract's `get-balance` to capture the
+   * actual supply position. See: https://github.com/aibtcdev/aibtc-mcp-server/issues/278
    */
   async getUserPosition(
     asset: string,
@@ -535,10 +540,38 @@ export class ZestProtocolService {
       const decoded = cvToJSON(hexToCV(result.result));
 
       if (decoded && typeof decoded === "object") {
+        let supplied = decoded["current-a-token-balance"]?.value || "0";
+        const borrowed = decoded["current-variable-debt"]?.value || "0";
+
+        // Fallback: current-a-token-balance only tracks borrow collateral.
+        // For supply-only users it reads "0", so check the LP token balance.
+        if (supplied === "0") {
+          try {
+            const assetConfig = this.getAssetConfig(asset);
+            const lpResult = await this.hiro.callReadOnlyFunction(
+              assetConfig.lpToken,
+              "get-balance",
+              [principalCV(userAddress)],
+              userAddress
+            );
+
+            if (lpResult.okay && lpResult.result) {
+              const lpDecoded = cvToJSON(hexToCV(lpResult.result));
+              // get-balance returns (ok u<amount>) — cvToJSON unwraps to { value: { value: "..." } }
+              const lpBalance = lpDecoded?.value?.value;
+              if (lpBalance && lpBalance !== "0") {
+                supplied = lpBalance;
+              }
+            }
+          } catch {
+            // LP token lookup failed — keep supplied as "0"
+          }
+        }
+
         return {
           asset,
-          supplied: decoded["current-a-token-balance"]?.value || "0",
-          borrowed: decoded["current-variable-debt"]?.value || "0",
+          supplied,
+          borrowed,
         };
       }
 


### PR DESCRIPTION
## Summary

Fixes #278 — `zest_get_position` returns `0` for `supplied` even when a user has an active supply position.

**Root cause:** `getUserPosition()` reads `current-a-token-balance` from `poolBorrow.get-user-reserve-data`. That field only tracks borrow collateral (a-token) accounting. For supply-only users who never borrowed, it is always zero.

**Fix:** When `current-a-token-balance` is `"0"`, make a second read-only call to the asset's LP token contract (`get-balance`) to retrieve the actual supply position. The LP token contract address is already available in `ZestAssetConfig.lpToken` for every supported asset.

- No new dependencies or config changes
- The LP token fallback is wrapped in its own try/catch so failures degrade gracefully (returns `"0"` as before)
- Code compiles cleanly with `npx tsc --noEmit`

Credit to @arc0btc for diagnosing the issue and suggesting the LP token fallback approach.

## Test plan

- [ ] Call `zest_get_position` for a supply-only user (e.g. someone who supplied sBTC but never borrowed) — `supplied` should now show the LP token balance instead of `"0"`
- [ ] Call `zest_get_position` for a user with both supply and borrow — behavior unchanged (`current-a-token-balance` is non-zero so fallback is skipped)
- [ ] Call `zest_get_position` for a user with no position — returns `"0"` for both fields as before
- [ ] Verify `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)