### PR TITLE
fix(zest): pre-check rewards before broadcasting claim tx

### DIFF
--- a/src/services/defi.service.ts
+++ b/src/services/defi.service.ts
@@ -696,6 +696,35 @@ export class ZestProtocolService {
     const [incentivesAddr, incentivesName] = parseContractIdTuple(this.contracts!.incentives);
     const [wstxAddr, wstxName] = parseContractIdTuple(this.contracts!.wstx);
 
+    // Pre-check: query pending rewards before broadcasting to avoid wasted gas
+    try {
+      const rewardResult = await this.hiro.callReadOnlyFunction(
+        this.contracts!.incentives,
+        "get-vault-rewards",
+        [
+          principalCV(account.address),                            // who
+          contractPrincipalCV(lpAddr, lpName),                     // supplied-asset (LP token)
+          contractPrincipalCV(wstxAddr, wstxName),                 // reward-asset (wSTX)
+        ],
+        account.address
+      );
+
+      if (rewardResult.okay && rewardResult.result) {
+        const decoded = cvToJSON(hexToCV(rewardResult.result));
+        const rewards = BigInt(decoded?.value ?? "0");
+        if (rewards === 0n) {
+          return {
+            success: false,
+            message: "No rewards available to claim",
+            rewards: 0,
+          } as unknown as TransferResult;
+        }
+      }
+    } catch {
+      // If the pre-check fails for any reason, proceed with broadcast
+      // (network error, contract not responding, etc.)
+    }
+
     const functionArgs: ClarityValue[] = [
       contractPrincipalCV(lpAddr, lpName),                    // lp
       principalCV(this.contracts!.poolReserve),               // pool-reserve


### PR DESCRIPTION
## Summary

Fixes #279. Adds a read-only pre-check in `claimRewards()` before broadcasting the contract call transaction.

- Calls `incentives-v2-2.get-vault-rewards` read-only with `(who, supplied-asset-lp, reward-asset-wstx)` before broadcasting
- If the result is 0, returns early with `{ success: false, message: "No rewards available to claim", rewards: 0 }` — no transaction is submitted
- If the pre-check call itself fails (network error, unexpected contract state), falls through and broadcasts anyway so legitimate claims are never blocked
- Only broadcasts when rewards are confirmed to be > 0

## Why

Without this guard, calling `zest_claim_rewards` when no rewards have accrued submits an on-chain transaction that fails or is a no-op, burning gas (uSTX) unnecessarily. This is especially wasteful in autonomous agent loops that call claim periodically.

## Test plan

- [ ] Call `zest_claim_rewards` on an account with no accrued rewards — confirm it returns early with `success: false` and the informative message, no transaction broadcast
- [ ] Call `zest_claim_rewards` on an account with pending rewards — confirm it proceeds to broadcast as before
- [ ] Simulate `callReadOnlyFunction` throwing — confirm it falls through to broadcast (resilience path)
- [ ] Run `npm run build` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)