### PR TITLE
feat(mempool): add mempool watch MCP tools (#303)

### DIFF
--- a/src/services/mempool-api.ts
+++ b/src/services/mempool-api.ts
@@ -64,6 +64,46 @@ export interface FeeEstimates {
 }
 
 /**
+ * Bitcoin transaction from mempool.space API
+ */
+export interface MempoolTx {
+  txid: string;
+  version: number;
+  locktime: number;
+  size: number;
+  weight: number;
+  fee: number;
+  vin: Array<{
+    txid: string;
+    vout: number;
+    prevout?: { value: number; scriptpubkey_address?: string };
+    sequence: number;
+    is_coinbase: boolean;
+  }>;
+  vout: Array<{
+    value: number;
+    scriptpubkey_address?: string;
+    scriptpubkey_type: string;
+  }>;
+  status: {
+    confirmed: boolean;
+    block_height?: number;
+    block_hash?: string;
+    block_time?: number;
+  };
+}
+
+/**
+ * Mempool statistics from mempool.space API
+ */
+export interface MempoolStats {
+  count: number;
+  vsize: number;
+  total_fee: number;
+  fee_histogram: Array<[number, number]>;
+}
+
+/**
  * Simplified fee tiers for user selection
  */
 export interface FeeTiers {
@@ -286,6 +326,65 @@ export class MempoolApi {
 
     const txHex = await response.text();
     return txHex.trim();
+  }
+
+  /**
+   * Get transaction details by txid
+   *
+   * @param txid - Bitcoin transaction ID (64 hex chars)
+   * @returns Transaction details including inputs, outputs, and confirmation status
+   * @throws Error if API request fails
+   */
+  async getTx(txid: string): Promise<MempoolTx> {
+    const response = await fetch(`${this.baseUrl}/tx/${txid}`);
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "Unknown error");
+      throw new Error(
+        `Failed to fetch transaction ${txid}: ${response.status} ${response.statusText} - ${errorText}`
+      );
+    }
+
+    return response.json() as Promise<MempoolTx>;
+  }
+
+  /**
+   * Get confirmed transaction history for a Bitcoin address (up to 25 most recent)
+   *
+   * @param address - Bitcoin address
+   * @returns Array of transactions (most recent first)
+   * @throws Error if API request fails
+   */
+  async getAddressTxs(address: string): Promise<MempoolTx[]> {
+    const response = await fetch(`${this.baseUrl}/address/${address}/txs`);
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "Unknown error");
+      throw new Error(
+        `Failed to fetch transactions for ${address}: ${response.status} ${response.statusText} - ${errorText}`
+      );
+    }
+
+    return response.json() as Promise<MempoolTx[]>;
+  }
+
+  /**
+   * Get current mempool statistics
+   *
+   * @returns Mempool stats including transaction count, vsize, total fee, and fee histogram
+   * @throws Error if API request fails
+   */
+  async getMempoolStats(): Promise<MempoolStats> {
+    const response = await fetch(`${this.baseUrl}/mempool`);
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "Unknown error");
+      throw new Error(
+        `Failed to fetch mempool stats: ${response.status} ${response.statusText} - ${errorText}`
+      );
+    }
+
+    return response.json() as Promise<MempoolStats>;
   }
 
   /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -21,6 +21,7 @@ import { registerYieldHunterTools } from "./yield-hunter.tools.js";
 import { registerPillarTools } from "./pillar.tools.js";
 import { registerPillarDirectTools } from "./pillar-direct.tools.js";
 import { registerBitcoinTools } from "./bitcoin.tools.js";
+import { registerMempoolTools } from "./mempool.tools.js";
 import { registerRelayDiagnosticTools } from "./relay-diagnostic.tools.js";
 import { getSkillForTool } from "./skill-mappings.js";
 
@@ -116,6 +117,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Bitcoin L1 (read-only: balance, fees, UTXOs)
   registerBitcoinTools(server);
+
+  // Mempool Watch (read-only: mempool stats, tx status, address tx history)
+  registerMempoolTools(server);
 
   // Relay Diagnostics (sponsor relay health, nonce status, stuck transactions)
   registerRelayDiagnosticTools(server);

--- a/src/tools/mempool.tools.ts
+++ b/src/tools/mempool.tools.ts
@@ -1,0 +1,161 @@
+/**
+ * Mempool Watch tools
+ *
+ * These tools provide read-only Bitcoin mempool monitoring:
+ * - get_mempool_info: Current mempool statistics (tx count, vsize, fees)
+ * - get_transaction_status: Confirmation status and details for a txid
+ * - get_address_txs: Recent transaction history for a Bitcoin address
+ *
+ * Data is fetched from the public mempool.space API (no authentication required).
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { NETWORK } from "../config/networks.js";
+import { createJsonResponse, createErrorResponse } from "../utils/index.js";
+import {
+  MempoolApi,
+  getMempoolTxUrl,
+  getMempoolAddressUrl,
+  type MempoolTx,
+} from "../services/mempool-api.js";
+
+/**
+ * Format satoshis as BTC string
+ */
+function formatBtc(satoshis: number): string {
+  const btc = satoshis / 100_000_000;
+  return btc.toFixed(8).replace(/\.?0+$/, "") + " BTC";
+}
+
+/**
+ * Format a MempoolTx for API response (summarized view)
+ */
+function formatTxSummary(tx: MempoolTx, network: typeof NETWORK) {
+  const totalInput = tx.vin.reduce(
+    (sum, input) => sum + (input.prevout?.value ?? 0),
+    0
+  );
+  const totalOutput = tx.vout.reduce((sum, output) => sum + output.value, 0);
+
+  return {
+    txid: tx.txid,
+    confirmed: tx.status.confirmed,
+    blockHeight: tx.status.block_height,
+    blockTime: tx.status.block_time
+      ? new Date(tx.status.block_time * 1000).toISOString()
+      : undefined,
+    fee: {
+      satoshis: tx.fee,
+      btc: formatBtc(tx.fee),
+    },
+    size: {
+      bytes: tx.size,
+      weight: tx.weight,
+      vsize: Math.ceil(tx.weight / 4),
+    },
+    inputs: tx.vin.length,
+    outputs: tx.vout.length,
+    totalOutput: {
+      satoshis: totalOutput,
+      btc: formatBtc(totalOutput),
+    },
+    explorerUrl: getMempoolTxUrl(tx.txid, network),
+  };
+}
+
+export function registerMempoolTools(server: McpServer): void {
+  // Get mempool info
+  server.registerTool(
+    "get_mempool_info",
+    {
+      description:
+        "Get current Bitcoin mempool statistics including transaction count, " +
+        "virtual size, total fees, and fee histogram. " +
+        "Useful for monitoring network congestion and estimating confirmation times.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const api = new MempoolApi(NETWORK);
+        const stats = await api.getMempoolStats();
+
+        return createJsonResponse({
+          count: stats.count,
+          vsize: stats.vsize,
+          totalFeeSats: stats.total_fee,
+          totalFeeBtc: formatBtc(stats.total_fee),
+          feeHistogram: stats.fee_histogram.slice(0, 10),
+          network: NETWORK,
+        });
+      } catch (err) {
+        return createErrorResponse(
+          `Failed to get mempool info: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+  );
+
+  // Get transaction status
+  server.registerTool(
+    "get_transaction_status",
+    {
+      description:
+        "Get confirmation status and details for a Bitcoin transaction by txid. " +
+        "Returns whether the transaction is confirmed, block height, fee, size, and I/O summary. " +
+        "Works for both confirmed and unconfirmed (mempool) transactions.",
+      inputSchema: {
+        txid: z
+          .string()
+          .describe("Bitcoin transaction ID (64 hex characters)"),
+      },
+    },
+    async ({ txid }) => {
+      try {
+        const api = new MempoolApi(NETWORK);
+        const tx = await api.getTx(txid);
+
+        return createJsonResponse({
+          ...formatTxSummary(tx, NETWORK),
+          network: NETWORK,
+        });
+      } catch (err) {
+        return createErrorResponse(
+          `Failed to get transaction status: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+  );
+
+  // Get address transaction history
+  server.registerTool(
+    "get_address_txs",
+    {
+      description:
+        "Get recent transaction history for a Bitcoin address (last 25 transactions). " +
+        "Returns a summary of each transaction including confirmation status, fee, and amounts. " +
+        "Useful for monitoring address activity and verifying payment receipts.",
+      inputSchema: {
+        address: z.string().describe("Bitcoin address (e.g. bc1... for mainnet, tb1... for testnet)"),
+      },
+    },
+    async ({ address }) => {
+      try {
+        const api = new MempoolApi(NETWORK);
+        const txs = await api.getAddressTxs(address);
+
+        return createJsonResponse({
+          address,
+          network: NETWORK,
+          count: txs.length,
+          transactions: txs.map((tx) => formatTxSummary(tx, NETWORK)),
+          explorerUrl: getMempoolAddressUrl(address, NETWORK),
+        });
+      } catch (err) {
+        return createErrorResponse(
+          `Failed to get address transactions: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary
Closes #303 — adds three read-only MCP tools for Bitcoin mempool monitoring:

- `get_mempool_info` — current mempool stats (tx count, vsize, total fee, fee histogram)
- `get_transaction_status` — check confirmation status and details for any txid
- `get_address_txs` — recent transaction history for a Bitcoin address (last 25 txs)

Also extends `MempoolApi` service with `getTx()`, `getAddressTxs()`, and `getMempoolStats()` methods, and adds `MempoolTx` and `MempoolStats` interfaces.

All tools are read-only and use the public mempool.space API (no authentication required).