### PR TITLE
fix: rename mempool tools to avoid duplicate registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,11 @@ Tools for Bitcoin L1 blockchain operations via mempool.space API:
 | "Send 50000 sats to tb1q..." | `transfer_btc` with recipient, amount=50000 |
 | "Transfer 0.001 BTC with fast fees" | `transfer_btc` with amount=100000, feeRate="fast" |
 
+### Mempool Watch (Bitcoin)
+- `get_btc_mempool_info` - Get current Bitcoin mempool statistics (tx count, vsize, fees, fee histogram)
+- `get_btc_transaction_status` - Get confirmation status and details for a Bitcoin transaction by txid
+- `get_btc_address_txs` - Get recent transaction history for a Bitcoin address (last 25 transactions)
+
 ### Direct Stacks Transactions
 - `transfer_stx` - Transfer STX tokens to a recipient (signs and broadcasts)
 - `call_contract` - Call a smart contract function (signs and broadcasts)

--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ Both addresses are derived from the same recovery phrase, making it easy to mana
 | `get_cardinal_utxos` | UTXOs safe to spend (no inscriptions) |
 | `get_ordinal_utxos` | UTXOs containing inscriptions |
 
+### Mempool Watch (Bitcoin)
+| Tool | Description |
+|------|-------------|
+| `get_btc_mempool_info` | Get current Bitcoin mempool statistics (tx count, vsize, fees, fee histogram) |
+| `get_btc_transaction_status` | Get confirmation status and details for a Bitcoin transaction by txid |
+| `get_btc_address_txs` | Get recent transaction history for a Bitcoin address (last 25 transactions) |
+
 ### Bitcoin Inscriptions
 | Tool | Description |
 |------|-------------|

--- a/src/tools/mempool.tools.ts
+++ b/src/tools/mempool.tools.ts
@@ -2,9 +2,9 @@
  * Mempool Watch tools
  *
  * These tools provide read-only Bitcoin mempool monitoring:
- * - get_mempool_info: Current mempool statistics (tx count, vsize, fees)
- * - get_transaction_status: Confirmation status and details for a txid
- * - get_address_txs: Recent transaction history for a Bitcoin address
+ * - get_btc_mempool_info: Current mempool statistics (tx count, vsize, fees)
+ * - get_btc_transaction_status: Confirmation status and details for a txid
+ * - get_btc_address_txs: Recent transaction history for a Bitcoin address
  *
  * Data is fetched from the public mempool.space API (no authentication required).
  */
@@ -67,7 +67,7 @@ function formatTxSummary(tx: MempoolTx, network: typeof NETWORK) {
 export function registerMempoolTools(server: McpServer): void {
   // Get mempool info
   server.registerTool(
-    "get_mempool_info",
+    "get_btc_mempool_info",
     {
       description:
         "Get current Bitcoin mempool statistics including transaction count, " +
@@ -98,7 +98,7 @@ export function registerMempoolTools(server: McpServer): void {
 
   // Get transaction status
   server.registerTool(
-    "get_transaction_status",
+    "get_btc_transaction_status",
     {
       description:
         "Get confirmation status and details for a Bitcoin transaction by txid. " +
@@ -129,7 +129,7 @@ export function registerMempoolTools(server: McpServer): void {
 
   // Get address transaction history
   server.registerTool(
-    "get_address_txs",
+    "get_btc_address_txs",
     {
       description:
         "Get recent transaction history for a Bitcoin address (last 25 transactions). " +

--- a/src/tools/skill-mappings.ts
+++ b/src/tools/skill-mappings.ts
@@ -39,6 +39,9 @@ export const TOOL_SKILL_MAP: Record<string, string> = {
   get_cardinal_utxos: "btc",
   get_ordinal_utxos: "btc",
   get_inscriptions_by_address: "btc",
+  get_btc_mempool_info: "btc",
+  get_btc_transaction_status: "btc",
+  get_btc_address_txs: "btc",
 
   // sbtc skill — sBTC token operations
   sbtc_get_balance: "sbtc",


### PR DESCRIPTION
## Summary

- Renamed three Bitcoin mempool tools to avoid colliding with existing Stacks tool names that crashed the MCP server on startup:
  - `get_mempool_info` → `get_btc_mempool_info` (collided with Stacks query tool)
  - `get_transaction_status` → `get_btc_transaction_status` (collided with Stacks contract tool)
  - `get_address_txs` → `get_btc_address_txs` (preemptive rename for consistency)
- Updated `skill-mappings.ts` with the new tool names mapped to the `btc` skill
- Updated README.md and CLAUDE.md with a new "Mempool Watch (Bitcoin)" tools section

Fixes #321

## Test plan

- [ ] `npm run build` passes with no errors
- [ ] MCP server starts without duplicate tool registration crash
- [ ] `get_btc_mempool_info` returns mempool stats
- [ ] `get_btc_transaction_status` returns tx details for a known txid
- [ ] `get_btc_address_txs` returns address history
- [ ] Original Stacks tools (`get_mempool_info`, `get_transaction_status`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)