### PR TITLE
feat(nostr): add Nostr protocol MCP tools (closes #300)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,10 @@
         "axios": "^1.13.6",
         "dotenv": "^17.3.1",
         "micro-ordinals": "^0.3.0",
+        "nostr-tools": "^2.23.3",
         "sbtc": "^0.3.2",
         "tslib": "^2.8.1",
+        "ws": "^8.19.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -35,6 +37,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.19.13",
+        "@types/ws": "^8.18.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
@@ -591,6 +594,18 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
+      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
@@ -1508,6 +1523,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2905,6 +2930,61 @@
         }
       }
     },
+    "node_modules/nostr-tools": {
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.3.tgz",
+      "integrity": "sha512-AALyt9k8xPdF4UV2mlLJ2mgCn4kpTB0DZ8t2r6wjdUh6anfx2cTVBsHUlo9U0EY/cKC5wcNyiMAmRJV5OVEalA==",
+      "license": "Unlicense",
+      "dependencies": {
+        "@noble/ciphers": "2.1.1",
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0",
+        "@scure/bip32": "2.0.1",
+        "@scure/bip39": "2.0.1",
+        "nostr-wasm": "0.1.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nostr-tools/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nostr-tools/node_modules/@scure/bip32": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.0.1.tgz",
+      "integrity": "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nostr-wasm": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nostr-wasm/-/nostr-wasm-0.1.0.tgz",
+      "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3715,7 +3795,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3981,6 +4061,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -60,12 +60,15 @@
     "axios": "^1.13.6",
     "dotenv": "^17.3.1",
     "micro-ordinals": "^0.3.0",
+    "nostr-tools": "^2.23.3",
     "sbtc": "^0.3.2",
     "tslib": "^2.8.1",
+    "ws": "^8.19.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.13",
+    "@types/ws": "^8.18.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -23,6 +23,7 @@ import { registerPillarTools } from "./pillar.tools.js";
 import { registerPillarDirectTools } from "./pillar-direct.tools.js";
 import { registerBitcoinTools } from "./bitcoin.tools.js";
 import { registerMempoolTools } from "./mempool.tools.js";
+import { registerNostrTools } from "./nostr.tools.js";
 import { registerRelayDiagnosticTools } from "./relay-diagnostic.tools.js";
 import { registerTeneroTools } from "./tenero.tools.js";
 import { getSkillForTool } from "./skill-mappings.js";
@@ -125,6 +126,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Mempool Watch (read-only: mempool stats, tx status, address tx history)
   registerMempoolTools(server);
+
+  // Nostr protocol (publish notes, read feed, manage profile)
+  registerNostrTools(server);
 
   // Relay Diagnostics (sponsor relay health, nonce status, stuck transactions)
   registerRelayDiagnosticTools(server);

--- a/src/tools/nostr.tools.ts
+++ b/src/tools/nostr.tools.ts
@@ -1,0 +1,501 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import WebSocket from "ws";
+import { createJsonResponse, createErrorResponse } from "../utils/index.js";
+import { getWalletManager } from "../services/wallet-manager.js";
+import {
+  finalizeEvent,
+  getPublicKey,
+  type EventTemplate,
+  type VerifiedEvent,
+} from "nostr-tools/pure";
+import * as nip19 from "nostr-tools/nip19";
+import { SimplePool } from "nostr-tools/pool";
+import type { Filter } from "nostr-tools/filter";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_RELAYS = ["wss://relay.damus.io", "wss://nos.lol"];
+const WS_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+function deriveNostrKeys(): { sk: Uint8Array; pubkey: string; npub: string } {
+  const walletManager = getWalletManager();
+  const account = walletManager.getActiveAccount();
+  if (!account) {
+    throw new Error("Wallet is not unlocked. Use wallet_unlock first.");
+  }
+  if (!account.nostrPrivateKey) {
+    throw new Error("Nostr private key not available. Re-unlock your wallet.");
+  }
+  const sk = account.nostrPrivateKey;
+  const pubkey = getPublicKey(sk);
+  const npub = nip19.npubEncode(pubkey);
+  return { sk, pubkey, npub };
+}
+
+function resolveHexPubkey(input: string): string {
+  if (input.startsWith("npub")) {
+    const decoded = nip19.decode(input);
+    return decoded.data as string;
+  }
+  return input;
+}
+
+function createPool(): SimplePool {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).WebSocket = WebSocket;
+  return new SimplePool();
+}
+
+async function publishToRelays(
+  pool: SimplePool,
+  event: VerifiedEvent,
+  relays: string[]
+): Promise<Record<string, string>> {
+  const results: Record<string, string> = {};
+  await Promise.allSettled(
+    relays.map(async (relay) => {
+      try {
+        const pubPromises = pool.publish([relay], event);
+        await Promise.race([
+          ...pubPromises,
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("timeout")), WS_TIMEOUT_MS)
+          ),
+        ]);
+        results[relay] = "ok";
+      } catch (err: unknown) {
+        results[relay] = `error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    })
+  );
+  return results;
+}
+
+async function queryRelays(
+  pool: SimplePool,
+  relays: string[],
+  filter: Filter
+): Promise<VerifiedEvent[]> {
+  return Promise.race([
+    pool.querySync(relays, filter) as Promise<VerifiedEvent[]>,
+    new Promise<VerifiedEvent[]>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("query timeout")),
+        WS_TIMEOUT_MS * 2
+      )
+    ),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Tool registration
+// ---------------------------------------------------------------------------
+
+export function registerNostrTools(server: McpServer): void {
+  // -------------------------------------------------------------------------
+  // nostr_get_pubkey
+  // -------------------------------------------------------------------------
+  server.registerTool(
+    "nostr_get_pubkey",
+    {
+      description:
+        "Derive the Nostr public key from the active wallet. " +
+        "Uses the NIP-06 derivation path (m/44'/1237'/0'/0/0). " +
+        "Returns both hex pubkey and npub (bech32) formats. " +
+        "Requires an unlocked wallet.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const { pubkey, npub } = deriveNostrKeys();
+        return createJsonResponse({ pubkey, npub });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // nostr_post
+  // -------------------------------------------------------------------------
+  server.registerTool(
+    "nostr_post",
+    {
+      description:
+        "Publish a short-text note (kind:1) to Nostr relays. " +
+        "Optionally include hashtag tags and specify target relays. " +
+        "Requires an unlocked wallet.",
+      inputSchema: {
+        content: z.string().describe("The note content to publish."),
+        tags: z
+          .string()
+          .optional()
+          .describe(
+            "Comma-separated hashtags to include (e.g., 'bitcoin,nostr,aibtc'). " +
+              "Do not include the '#' prefix."
+          ),
+        relays: z
+          .array(z.string().url())
+          .optional()
+          .describe(
+            `Relay URLs to publish to. Defaults to ${DEFAULT_RELAYS.join(", ")}.`
+          ),
+      },
+    },
+    async ({ content, tags, relays }) => {
+      try {
+        const { sk } = deriveNostrKeys();
+        const targetRelays = relays && relays.length > 0 ? relays : DEFAULT_RELAYS;
+
+        const hashtagTags: string[][] = tags
+          ? tags
+              .split(",")
+              .map((t) => t.trim())
+              .filter(Boolean)
+              .map((t) => ["t", t.toLowerCase()])
+          : [];
+
+        const template: EventTemplate = {
+          kind: 1,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: hashtagTags,
+          content,
+        };
+
+        const event = finalizeEvent(template, sk);
+        const pool = createPool();
+        const publishResults = await publishToRelays(pool, event, targetRelays);
+        pool.close(targetRelays);
+
+        return createJsonResponse({
+          eventId: event.id,
+          pubkey: event.pubkey,
+          createdAt: event.created_at,
+          content: event.content,
+          tags: event.tags,
+          relays: publishResults,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // nostr_read_feed
+  // -------------------------------------------------------------------------
+  server.registerTool(
+    "nostr_read_feed",
+    {
+      description:
+        "Read recent kind:1 notes from Nostr relays. " +
+        "Optionally filter by author pubkey. " +
+        "No wallet required.",
+      inputSchema: {
+        pubkey: z
+          .string()
+          .optional()
+          .describe("Author public key (hex or npub) to filter by."),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Maximum number of notes to return (default: 20)."),
+        relay: z
+          .string()
+          .url()
+          .optional()
+          .describe("Single relay URL to query. Defaults to all DEFAULT_RELAYS."),
+      },
+    },
+    async ({ pubkey, limit, relay }) => {
+      try {
+        const pool = createPool();
+        const targetRelays = relay ? [relay] : DEFAULT_RELAYS;
+        const queryLimit = limit ?? 20;
+
+        const filter: Filter = {
+          kinds: [1],
+          limit: queryLimit,
+        };
+
+        if (pubkey) {
+          filter.authors = [resolveHexPubkey(pubkey)];
+        }
+
+        const events = await queryRelays(pool, targetRelays, filter);
+        pool.close(targetRelays);
+
+        // Sort descending by created_at
+        const sorted = events
+          .sort((a, b) => b.created_at - a.created_at)
+          .slice(0, queryLimit)
+          .map((e) => ({
+            id: e.id,
+            pubkey: e.pubkey,
+            npub: nip19.npubEncode(e.pubkey),
+            createdAt: e.created_at,
+            content: e.content,
+            tags: e.tags,
+          }));
+
+        return createJsonResponse({
+          count: sorted.length,
+          events: sorted,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // nostr_search_tags
+  // -------------------------------------------------------------------------
+  server.registerTool(
+    "nostr_search_tags",
+    {
+      description:
+        "Search Nostr for kind:1 notes matching hashtags using NIP-12 #t filter. " +
+        "No wallet required.",
+      inputSchema: {
+        tags: z
+          .string()
+          .describe(
+            "Comma-separated hashtags to search for (e.g., 'bitcoin,nostr'). " +
+              "Do not include the '#' prefix."
+          ),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Maximum number of notes to return (default: 20)."),
+        relay: z
+          .string()
+          .url()
+          .optional()
+          .describe("Single relay URL to query. Defaults to all DEFAULT_RELAYS."),
+      },
+    },
+    async ({ tags, limit, relay }) => {
+      try {
+        const pool = createPool();
+        const targetRelays = relay ? [relay] : DEFAULT_RELAYS;
+        const queryLimit = limit ?? 20;
+
+        const tagList = tags
+          .split(",")
+          .map((t) => t.trim().toLowerCase())
+          .filter(Boolean);
+
+        const filter: Filter = {
+          kinds: [1],
+          "#t": tagList,
+          limit: queryLimit,
+        };
+
+        const events = await queryRelays(pool, targetRelays, filter);
+        pool.close(targetRelays);
+
+        const sorted = events
+          .sort((a, b) => b.created_at - a.created_at)
+          .slice(0, queryLimit)
+          .map((e) => ({
+            id: e.id,
+            pubkey: e.pubkey,
+            npub: nip19.npubEncode(e.pubkey),
+            createdAt: e.created_at,
+            content: e.content,
+            tags: e.tags,
+          }));
+
+        return createJsonResponse({
+          searchTags: tagList,
+          count: sorted.length,
+          events: sorted,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // nostr_get_profile
+  // -------------------------------------------------------------------------
+  server.registerTool(
+    "nostr_get_profile",
+    {
+      description:
+        "Get a Nostr profile (kind:0 metadata) for any public key. " +
+        "No wallet required.",
+      inputSchema: {
+        pubkey: z
+          .string()
+          .describe("Public key to look up (hex or npub bech32 format)."),
+        relay: z
+          .string()
+          .url()
+          .optional()
+          .describe("Single relay URL to query. Defaults to all DEFAULT_RELAYS."),
+      },
+    },
+    async ({ pubkey, relay }) => {
+      try {
+        const pool = createPool();
+        const targetRelays = relay ? [relay] : DEFAULT_RELAYS;
+        const hexPubkey = resolveHexPubkey(pubkey);
+
+        const filter: Filter = {
+          kinds: [0],
+          authors: [hexPubkey],
+          limit: 1,
+        };
+
+        const events = await queryRelays(pool, targetRelays, filter);
+        pool.close(targetRelays);
+
+        if (events.length === 0) {
+          return createJsonResponse({
+            pubkey: hexPubkey,
+            npub: nip19.npubEncode(hexPubkey),
+            found: false,
+            profile: null,
+          });
+        }
+
+        // Use most recent kind:0 event
+        const latest = events.sort((a, b) => b.created_at - a.created_at)[0];
+        let profile: Record<string, unknown> = {};
+        try {
+          profile = JSON.parse(latest.content) as Record<string, unknown>;
+        } catch {
+          // content was not valid JSON — return as-is
+          profile = { raw: latest.content };
+        }
+
+        return createJsonResponse({
+          pubkey: hexPubkey,
+          npub: nip19.npubEncode(hexPubkey),
+          found: true,
+          updatedAt: latest.created_at,
+          profile,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // nostr_set_profile
+  // -------------------------------------------------------------------------
+  server.registerTool(
+    "nostr_set_profile",
+    {
+      description:
+        "Update the agent's Nostr profile (kind:0 metadata event). " +
+        "Only provided fields are updated; existing fields are preserved by fetching " +
+        "the current profile first. " +
+        "Requires an unlocked wallet.",
+      inputSchema: {
+        name: z.string().optional().describe("Display name."),
+        about: z.string().optional().describe("Bio / about text."),
+        picture: z.string().url().optional().describe("Profile picture URL."),
+        website: z.string().url().optional().describe("Website URL."),
+        nip05: z
+          .string()
+          .optional()
+          .describe("NIP-05 identifier (e.g., user@example.com)."),
+        relays: z
+          .array(z.string().url())
+          .optional()
+          .describe(
+            `Relay URLs to publish to. Defaults to ${DEFAULT_RELAYS.join(", ")}.`
+          ),
+      },
+    },
+    async ({ name, about, picture, website, nip05, relays }) => {
+      try {
+        const { sk, pubkey } = deriveNostrKeys();
+        const targetRelays = relays && relays.length > 0 ? relays : DEFAULT_RELAYS;
+        const pool = createPool();
+
+        // Fetch existing profile to preserve fields
+        let existingProfile: Record<string, unknown> = {};
+        try {
+          const existing = await queryRelays(pool, targetRelays, {
+            kinds: [0],
+            authors: [pubkey],
+            limit: 1,
+          });
+          if (existing.length > 0) {
+            const latest = existing.sort((a, b) => b.created_at - a.created_at)[0];
+            existingProfile = JSON.parse(latest.content) as Record<string, unknown>;
+          }
+        } catch {
+          // Ignore fetch errors — publish with just the new fields
+        }
+
+        // Merge: only override fields that were explicitly provided
+        const updates: Record<string, unknown> = {};
+        if (name !== undefined) updates.name = name;
+        if (about !== undefined) updates.about = about;
+        if (picture !== undefined) updates.picture = picture;
+        if (website !== undefined) updates.website = website;
+        if (nip05 !== undefined) updates.nip05 = nip05;
+
+        const mergedProfile = { ...existingProfile, ...updates };
+
+        const template: EventTemplate = {
+          kind: 0,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [],
+          content: JSON.stringify(mergedProfile),
+        };
+
+        const event = finalizeEvent(template, sk);
+        const publishResults = await publishToRelays(pool, event, targetRelays);
+        pool.close(targetRelays);
+
+        return createJsonResponse({
+          eventId: event.id,
+          pubkey: event.pubkey,
+          createdAt: event.created_at,
+          profile: mergedProfile,
+          relays: publishResults,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // nostr_relay_list
+  // -------------------------------------------------------------------------
+  server.registerTool(
+    "nostr_relay_list",
+    {
+      description:
+        "List the configured default Nostr relay URLs. No wallet required.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        return createJsonResponse({ relays: DEFAULT_RELAYS });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Adds 7 MCP tools for Nostr protocol operations, closing issue #300.

**New file:** `src/tools/nostr.tools.ts`

### Tools
- `nostr_get_pubkey` — derive Nostr public key from active wallet (NIP-06 path m/44'/1237'/0'/0/0)
- `nostr_post` — publish a kind:1 note with optional hashtag tags to configurable relays
- `nostr_read_feed` — read recent notes with optional pubkey filter and relay override
- `nostr_search_tags` — search notes by hashtag using NIP-12 #t filter
- `nostr_get_profile` — get a kind:0 profile metadata for any pubkey
- `nostr_set_profile` — update the agent's kind:0 profile (name, about, picture, website, nip05); merges with existing profile
- `nostr_relay_list` — list configured relay URLs

## Implementation Notes
- Key derivation: NIP-06 standard path (m/44'/1237'/0'/0/0) via `account.nostrPrivateKey` already populated by wallet-manager at unlock time
- Uses `nostr-tools` for event signing/verification (`finalizeEvent`, `getPublicKey`, `nip19`), `ws` for WebSocket in Node/Bun
- Default relays: `wss://relay.damus.io` + `wss://nos.lol`
- Read tools (`nostr_read_feed`, `nostr_search_tags`, `nostr_get_profile`, `nostr_relay_list`) require no wallet
- Write tools (`nostr_post`, `nostr_set_profile`) require unlocked wallet
- `nostr_set_profile` fetches existing kind:0 before publishing so unspecified fields are preserved

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] `nostr_relay_list` returns relay list without wallet
- [ ] `nostr_get_pubkey` returns consistent pubkey after wallet unlock
- [ ] `nostr_read_feed` returns events from damus relay
- [ ] Write tools return clear error when wallet is locked

🤖 Generated with [Claude Code](https://claude.com/claude-code)