### PR TITLE
fix(stacking-lottery): register stackspot tools in tools/index (closes #308)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,7 @@ import { registerTokenTools } from "./tokens.tools.js";
 import { registerNftTools } from "./nft.tools.js";
 import { registerStackingTools } from "./stacking.tools.js";
 import { registerDualStackingTools } from "./dual-stacking.tools.js";
+import { registerStackingLotteryTools } from "./stacking-lottery.tools.js";
 import { registerBnsTools } from "./bns.tools.js";
 import { registerStyxTools } from "./styx.tools.js";
 import { registerQueryTools } from "./query.tools.js";
@@ -91,6 +92,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Dual Stacking (sBTC yield via Dual Stacking protocol)
   registerDualStackingTools(server);
+
+  // Stacking Lottery (StackSpot — pool STX, VRF picks sBTC winner)
+  registerStackingLotteryTools(server);
 
   // BNS Domains
   registerBnsTools(server);


### PR DESCRIPTION
## Summary

`stacking-lottery.tools.ts` exports `registerStackingLotteryTools` with 6 stackspot tools but was never imported or called in `tools/index.ts`. As a result, all 6 stackspot operations were dead code — they compiled but were never registered with the MCP server.

This PR adds the missing import and registration call.

## Changes

- Add `import { registerStackingLotteryTools }` to `src/tools/index.ts`
- Call `registerStackingLotteryTools(server)` in `registerAllTools()`

## Test plan
- [ ] `npm run build` passes
- [ ] `stackspot_list_pots` tool is now accessible in the MCP server

closes #308