### PR TITLE
feat(jingswap): add multi-market support (sbtc-stx + sbtc-usdcx)

### DIFF
--- a/src/tools/jingswap.tools.ts
+++ b/src/tools/jingswap.tools.ts
@@ -1,6 +1,7 @@
 // Jingswap Auction MCP Tools
-// Query + deposit/cancel tools for the STX/sBTC blind auction on Stacks.
-// Contract: SPV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RCJDC22.sbtc-stx-jingswap
+// Query + deposit/cancel tools for sBTC blind auctions on Stacks.
+// Markets: sbtc-stx (SPV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RCJDC22.sbtc-stx-jingswap)
+//          sbtc-usdcx (SPV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RCJDC22.sbtc-usdcx-jingswap)
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -16,6 +17,53 @@ const JINGSWAP_API =
 // Set JINGSWAP_API_KEY env var for higher limits.
 const JINGSWAP_API_KEY =
   process.env.JINGSWAP_API_KEY || "jc_b058d7f2e0976bd4ee34be3e5c7ba7ebe45289c55d3f5e45f666ebc14b7ebfd0";
+
+// ── Market Configuration ─────────────────────────────────────────────
+
+interface MarketConfig {
+  contractName: string;
+  tokenBSymbol: string;
+  tokenBDecimals: number;
+  tokenBContract?: string;  // undefined = native STX
+  tokenBAsset?: string;
+  depositFn: string;        // "deposit-stx" | "deposit-usdcx"
+  cancelFn: string;         // "cancel-stx-deposit" | "cancel-usdcx-deposit"
+  priceUnit: string;        // "STX/BTC" | "USDCx/BTC"
+}
+
+const MARKETS: Record<string, MarketConfig> = {
+  "sbtc-stx": {
+    contractName: "sbtc-stx-jingswap",
+    tokenBSymbol: "STX",
+    tokenBDecimals: 6,
+    depositFn: "deposit-stx",
+    cancelFn: "cancel-stx-deposit",
+    priceUnit: "STX/BTC",
+  },
+  "sbtc-usdcx": {
+    contractName: "sbtc-usdcx-jingswap",
+    tokenBSymbol: "USDCx",
+    tokenBDecimals: 6,
+    tokenBContract: "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx",
+    tokenBAsset: "usdcx-token",
+    depositFn: "deposit-usdcx",
+    cancelFn: "cancel-usdcx-deposit",
+    priceUnit: "USDCx/BTC",
+  },
+};
+
+const DEFAULT_MARKET = "sbtc-stx";
+
+function getMarket(market?: string): MarketConfig {
+  const key = market || DEFAULT_MARKET;
+  const config = MARKETS[key];
+  if (!config) throw new Error(`Unknown market "${key}". Available: ${Object.keys(MARKETS).join(", ")}`);
+  return config;
+}
+
+function apiContractParam(market: MarketConfig): string {
+  return market.contractName === "sbtc-stx-jingswap" ? "" : `?contract=${market.contractName}`;
+}
 
 async function jingswapGet(path: string): Promise<any> {
   const res = await fetch(`${JINGSWAP_API}${path}`, {
@@ -35,20 +83,25 @@ export function registerJingswapTools(server: McpServer): void {
     {
       description:
         "Get the current Jingswap auction cycle state including phase (deposit/buffer/settle), " +
-        "blocks elapsed, cycle totals (STX + sBTC deposited), and minimum deposit requirements. " +
+        "blocks elapsed, cycle totals (token B + sBTC deposited), and minimum deposit requirements. " +
         "Use this to understand where the auction currently stands.",
+      inputSchema: {
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
+      },
     },
-    async () => {
+    async ({ market }) => {
       try {
-        const data = await jingswapGet("/api/auction/cycle-state");
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/cycle-state${apiContractParam(m)}`);
         return createJsonResponse({
           ...data,
+          market: market || DEFAULT_MARKET,
           _hint: {
             phases: "0=deposit (open for deposits, min 150 blocks), 1=buffer (30 blocks ~1 min, no actions), 2=settle (call settle-with-refresh)",
             blockTime: "Stacks blocks average ~2 seconds each (Nakamoto)",
             depositMinBlocks: "150 blocks (~5 minutes) before deposits can be closed",
             bufferBlocks: "30 blocks (~1 minute) after close before settlement is possible",
-            stxUnits: "micro-STX (÷1e6 for STX)",
+            tokenBUnits: `micro-${m.tokenBSymbol} (÷1e${m.tokenBDecimals} for ${m.tokenBSymbol})`,
             sbtcUnits: "satoshis (÷1e8 for sBTC)",
           },
         });
@@ -64,15 +117,17 @@ export function registerJingswapTools(server: McpServer): void {
     "jingswap_get_depositors",
     {
       description:
-        "Get the list of STX and sBTC depositors for a specific auction cycle. " +
+        "Get the list of token B and sBTC depositors for a specific auction cycle. " +
         "Returns arrays of Stacks addresses on each side. Max 50 depositors per side.",
       inputSchema: {
         cycle: z.number().describe("Cycle number to query"),
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
       },
     },
-    async ({ cycle }) => {
+    async ({ cycle, market }) => {
       try {
-        const data = await jingswapGet(`/api/auction/depositors/${cycle}`);
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/depositors/${cycle}${apiContractParam(m)}`);
         return createJsonResponse(data);
       } catch (error) {
         return createErrorResponse(error);
@@ -86,15 +141,17 @@ export function registerJingswapTools(server: McpServer): void {
     "jingswap_get_user_deposit",
     {
       description:
-        "Get a specific user's deposit amounts (STX and sBTC) for a given auction cycle.",
+        "Get a specific user's deposit amounts (token B and sBTC) for a given auction cycle.",
       inputSchema: {
         cycle: z.number().describe("Cycle number"),
         address: z.string().describe("Stacks address of the depositor"),
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
       },
     },
-    async ({ cycle, address }) => {
+    async ({ cycle, address, market }) => {
       try {
-        const data = await jingswapGet(`/api/auction/deposit/${cycle}/${address}`);
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/deposit/${cycle}/${address}${apiContractParam(m)}`);
         return createJsonResponse(data);
       } catch (error) {
         return createErrorResponse(error);
@@ -108,16 +165,18 @@ export function registerJingswapTools(server: McpServer): void {
     "jingswap_get_settlement",
     {
       description:
-        "Get settlement details for a completed auction cycle. Returns clearing price (STX/BTC), " +
+        "Get settlement details for a completed auction cycle. Returns clearing price, " +
         "amounts cleared, fees, and the block height at which settlement occurred. " +
         "Returns null settlement if the cycle hasn't been settled yet.",
       inputSchema: {
         cycle: z.number().describe("Cycle number to query"),
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
       },
     },
-    async ({ cycle }) => {
+    async ({ cycle, market }) => {
       try {
-        const data = await jingswapGet(`/api/auction/settlement/${cycle}`);
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/settlement/${cycle}${apiContractParam(m)}`);
         return createJsonResponse(data);
       } catch (error) {
         return createErrorResponse(error);
@@ -134,10 +193,14 @@ export function registerJingswapTools(server: McpServer): void {
         "Get the full history of all auction cycles from cycle 0 to the current cycle. " +
         "Each entry includes settlement data (if settled) and cycle totals. " +
         "Useful for analyzing historical auction performance and volume.",
+      inputSchema: {
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
+      },
     },
-    async () => {
+    async ({ market }) => {
       try {
-        const data = await jingswapGet("/api/auction/cycles-history");
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/cycles-history${apiContractParam(m)}`);
         return createJsonResponse(data);
       } catch (error) {
         return createErrorResponse(error);
@@ -155,17 +218,20 @@ export function registerJingswapTools(server: McpServer): void {
         "Indexed from on-chain contract events.",
       inputSchema: {
         address: z.string().describe("Stacks address to query"),
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
       },
     },
-    async ({ address }) => {
+    async ({ address, market }) => {
       try {
-        const data = await jingswapGet(`/api/auction/activity/${address}`);
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/activity/${address}${apiContractParam(m)}`);
         return createJsonResponse({
           ...data,
+          market: market || DEFAULT_MARKET,
           _hint: {
-            "distribute-stx-depositor": "stxAmount = unswapped STX rolled to next cycle, sbtcAmount = sBTC received from swap",
-            "distribute-sbtc-depositor": "sbtcAmount = unswapped sats rolled to next cycle, stxAmount = STX received from swap",
-            "refund-stx": "deposit rejected (e.g. duplicate or below minimum)",
+            "distribute-tokenB-depositor": `${m.tokenBSymbol} amount = unswapped ${m.tokenBSymbol} rolled to next cycle, sbtcAmount = sBTC received from swap`,
+            "distribute-sbtc-depositor": `sbtcAmount = unswapped sats rolled to next cycle, ${m.tokenBSymbol} amount = ${m.tokenBSymbol} received from swap`,
+            "refund-tokenB": "deposit rejected (e.g. duplicate or below minimum)",
             "refund-sbtc": "deposit rejected (e.g. duplicate or below minimum)",
           },
         });
@@ -178,11 +244,10 @@ export function registerJingswapTools(server: McpServer): void {
   // ── Deposit STX ─────────────────────────────────────────────
 
   const JINGSWAP_CONTRACT_ADDRESS = "SPV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RCJDC22";
-  const JINGSWAP_CONTRACT_NAME = "sbtc-stx-jingswap";
   const SBTC_CONTRACT = "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token";
 
-  async function assertDepositPhase(): Promise<void> {
-    const data = await jingswapGet("/api/auction/cycle-state");
+  async function assertDepositPhase(market: MarketConfig): Promise<void> {
+    const data = await jingswapGet(`/api/auction/cycle-state${apiContractParam(market)}`);
     if (data.phase !== 0) {
       const phaseNames = ["deposit", "buffer", "settle"];
       throw new Error(
@@ -195,34 +260,48 @@ export function registerJingswapTools(server: McpServer): void {
     "jingswap_deposit_stx",
     {
       description:
-        "Deposit STX into the current Jingswap auction cycle. " +
-        "Only works during the deposit phase. Amount is in STX (e.g. 10 for 10 STX).",
+        "Deposit the token-B side (STX or USDCx depending on market) into the current Jingswap auction cycle. " +
+        "Only works during the deposit phase. Amount is in human units (e.g. 10 for 10 STX, or 10 for 10 USDCx).",
       inputSchema: {
-        amount: z.number().positive().describe("Amount of STX to deposit"),
+        amount: z.number().positive().describe("Amount of token B to deposit (human units)"),
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
       },
     },
-    async ({ amount }) => {
+    async ({ amount, market }) => {
       try {
-        await assertDepositPhase();
+        const m = getMarket(market);
+        await assertDepositPhase(m);
         const account = await getAccount();
-        const microStx = BigInt(Math.floor(amount * 1_000_000));
+        const micro = BigInt(Math.floor(amount * 10 ** m.tokenBDecimals));
+
+        let postConditions;
+        if (!m.tokenBContract) {
+          // Native STX
+          postConditions = [Pc.principal(account.address).willSendEq(micro).ustx()];
+        } else {
+          // FT (e.g. USDCx)
+          postConditions = [
+            Pc.principal(account.address)
+              .willSendEq(micro)
+              .ft(m.tokenBContract as `${string}.${string}`, m.tokenBAsset!),
+          ];
+        }
 
         const result = await callContract(account, {
           contractAddress: JINGSWAP_CONTRACT_ADDRESS,
-          contractName: JINGSWAP_CONTRACT_NAME,
-          functionName: "deposit-stx",
-          functionArgs: [uintCV(microStx)],
+          contractName: m.contractName,
+          functionName: m.depositFn,
+          functionArgs: [uintCV(micro)],
           postConditionMode: PostConditionMode.Deny,
-          postConditions: [
-            Pc.principal(account.address).willSendEq(microStx).ustx(),
-          ],
+          postConditions,
         });
 
         return createJsonResponse({
           success: true,
           txid: result.txid,
-          action: "deposit-stx",
-          amount: `${amount} STX`,
+          action: m.depositFn,
+          amount: `${amount} ${m.tokenBSymbol}`,
+          market: market || DEFAULT_MARKET,
           network: NETWORK,
           explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
         });
@@ -239,20 +318,23 @@ export function registerJingswapTools(server: McpServer): void {
     {
       description:
         "Deposit sBTC into the current Jingswap auction cycle. " +
-        "Only works during the deposit phase. Amount is in satoshis (e.g. 1000 for 1000 sats).",
+        "Only works during the deposit phase. Amount is in satoshis (e.g. 1000 for 1000 sats). " +
+        "Works the same for both sbtc-stx and sbtc-usdcx markets.",
       inputSchema: {
         amount: z.number().int().positive().describe("Amount of sBTC in satoshis"),
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
       },
     },
-    async ({ amount }) => {
+    async ({ amount, market }) => {
       try {
-        await assertDepositPhase();
+        const m = getMarket(market);
+        await assertDepositPhase(m);
         const account = await getAccount();
         const sats = BigInt(amount);
 
         const result = await callContract(account, {
           contractAddress: JINGSWAP_CONTRACT_ADDRESS,
-          contractName: JINGSWAP_CONTRACT_NAME,
+          contractName: m.contractName,
           functionName: "deposit-sbtc",
           functionArgs: [uintCV(sats)],
           postConditionMode: PostConditionMode.Deny,
@@ -268,6 +350,7 @@ export function registerJingswapTools(server: McpServer): void {
           txid: result.txid,
           action: "deposit-sbtc",
           amount: `${amount} sats`,
+          market: market || DEFAULT_MARKET,
           network: NETWORK,
           explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
         });
@@ -283,18 +366,22 @@ export function registerJingswapTools(server: McpServer): void {
     "jingswap_cancel_stx",
     {
       description:
-        "Cancel your STX deposit from the current Jingswap auction cycle and get a full refund. " +
-        "Only works during the deposit phase.",
+        "Cancel your token-B deposit (STX or USDCx depending on market) from the current Jingswap auction cycle " +
+        "and get a full refund. Only works during the deposit phase.",
+      inputSchema: {
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
+      },
     },
-    async () => {
+    async ({ market }) => {
       try {
-        await assertDepositPhase();
+        const m = getMarket(market);
+        await assertDepositPhase(m);
         const account = await getAccount();
 
         const result = await callContract(account, {
           contractAddress: JINGSWAP_CONTRACT_ADDRESS,
-          contractName: JINGSWAP_CONTRACT_NAME,
-          functionName: "cancel-stx-deposit",
+          contractName: m.contractName,
+          functionName: m.cancelFn,
           functionArgs: [],
           postConditionMode: PostConditionMode.Allow,
           postConditions: [],
@@ -303,7 +390,8 @@ export function registerJingswapTools(server: McpServer): void {
         return createJsonResponse({
           success: true,
           txid: result.txid,
-          action: "cancel-stx-deposit",
+          action: m.cancelFn,
+          market: market || DEFAULT_MARKET,
           network: NETWORK,
           explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
         });
@@ -320,16 +408,20 @@ export function registerJingswapTools(server: McpServer): void {
     {
       description:
         "Cancel your sBTC deposit from the current Jingswap auction cycle and get a full refund. " +
-        "Only works during the deposit phase.",
+        "Only works during the deposit phase. Works the same for both markets.",
+      inputSchema: {
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
+      },
     },
-    async () => {
+    async ({ market }) => {
       try {
-        await assertDepositPhase();
+        const m = getMarket(market);
+        await assertDepositPhase(m);
         const account = await getAccount();
 
         const result = await callContract(account, {
           contractAddress: JINGSWAP_CONTRACT_ADDRESS,
-          contractName: JINGSWAP_CONTRACT_NAME,
+          contractName: m.contractName,
           functionName: "cancel-sbtc-deposit",
           functionArgs: [],
           postConditionMode: PostConditionMode.Allow,
@@ -340,6 +432,7 @@ export function registerJingswapTools(server: McpServer): void {
           success: true,
           txid: result.txid,
           action: "cancel-sbtc-deposit",
+          market: market || DEFAULT_MARKET,
           network: NETWORK,
           explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
         });
@@ -357,13 +450,16 @@ export function registerJingswapTools(server: McpServer): void {
       description:
         "Close the deposit phase of the current Jingswap auction cycle. " +
         "Before calling, check jingswap_get_cycle_state to verify: phase is 0 (deposit), " +
-        "blocksElapsed >= 150 (DEPOSIT_MIN_BLOCKS), and both sides meet minimums " +
-        "(min 1 STX = 1,000,000 micro-STX and min 1,000 sats sBTC). " +
+        "blocksElapsed >= 150 (DEPOSIT_MIN_BLOCKS), and both sides meet minimums. " +
         "Anyone can call this. Transitions to buffer phase.",
+      inputSchema: {
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
+      },
     },
-    async () => {
+    async ({ market }) => {
       try {
-        const data = await jingswapGet("/api/auction/cycle-state");
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/cycle-state${apiContractParam(m)}`);
         if (data.phase !== 0) {
           throw new Error("Cannot close deposits — auction is not in deposit phase");
         }
@@ -371,7 +467,7 @@ export function registerJingswapTools(server: McpServer): void {
 
         const result = await callContract(account, {
           contractAddress: JINGSWAP_CONTRACT_ADDRESS,
-          contractName: JINGSWAP_CONTRACT_NAME,
+          contractName: m.contractName,
           functionName: "close-deposits",
           functionArgs: [],
           postConditionMode: PostConditionMode.Allow,
@@ -382,6 +478,7 @@ export function registerJingswapTools(server: McpServer): void {
           success: true,
           txid: result.txid,
           action: "close-deposits",
+          market: market || DEFAULT_MARKET,
           cycle: data.currentCycle,
           network: NETWORK,
           explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
@@ -402,10 +499,14 @@ export function registerJingswapTools(server: McpServer): void {
         "WARNING: This will almost always fail because stored prices go stale quickly. " +
         "Prefer jingswap_settle_with_refresh instead — it fetches fresh prices and is much more reliable. " +
         "Only works after deposits have been closed (buffer/settle phase).",
+      inputSchema: {
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
+      },
     },
-    async () => {
+    async ({ market }) => {
       try {
-        const data = await jingswapGet("/api/auction/cycle-state");
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/cycle-state${apiContractParam(m)}`);
         if (data.phase === 0) {
           throw new Error("Cannot settle — auction is still in deposit phase. Close deposits first.");
         }
@@ -413,7 +514,7 @@ export function registerJingswapTools(server: McpServer): void {
 
         const result = await callContract(account, {
           contractAddress: JINGSWAP_CONTRACT_ADDRESS,
-          contractName: JINGSWAP_CONTRACT_NAME,
+          contractName: m.contractName,
           functionName: "settle",
           functionArgs: [],
           postConditionMode: PostConditionMode.Allow,
@@ -424,6 +525,7 @@ export function registerJingswapTools(server: McpServer): void {
           success: true,
           txid: result.txid,
           action: "settle",
+          market: market || DEFAULT_MARKET,
           cycle: data.currentCycle,
           network: NETWORK,
           explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
@@ -452,10 +554,14 @@ export function registerJingswapTools(server: McpServer): void {
         "Settlement distributes funds to all depositors so post conditions are in Allow mode. " +
         "There is no guarantee settlement succeeds (e.g. if oracle update fails), but this is " +
         "the most reliable path. Only works after deposits have been closed (buffer/settle phase).",
+      inputSchema: {
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
+      },
     },
-    async () => {
+    async ({ market }) => {
       try {
-        const data = await jingswapGet("/api/auction/cycle-state");
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/cycle-state${apiContractParam(m)}`);
         if (data.phase === 0) {
           throw new Error("Cannot settle — auction is still in deposit phase. Close deposits first.");
         }
@@ -469,7 +575,7 @@ export function registerJingswapTools(server: McpServer): void {
 
         const result = await callContract(account, {
           contractAddress: JINGSWAP_CONTRACT_ADDRESS,
-          contractName: JINGSWAP_CONTRACT_NAME,
+          contractName: m.contractName,
           functionName: "settle-with-refresh",
           functionArgs: [
             btcVaaBuffer,
@@ -486,6 +592,7 @@ export function registerJingswapTools(server: McpServer): void {
           success: true,
           txid: result.txid,
           action: "settle-with-refresh",
+          market: market || DEFAULT_MARKET,
           cycle: data.currentCycle,
           network: NETWORK,
           explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
@@ -507,10 +614,14 @@ export function registerJingswapTools(server: McpServer): void {
         "(BUFFER_BLOCKS 30 + CANCEL_THRESHOLD 500). " +
         "Rolls all deposits into the next cycle — no refunds, users can withdraw " +
         "individually during the next deposit phase. This is the safety valve.",
+      inputSchema: {
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
+      },
     },
-    async () => {
+    async ({ market }) => {
       try {
-        const data = await jingswapGet("/api/auction/cycle-state");
+        const m = getMarket(market);
+        const data = await jingswapGet(`/api/auction/cycle-state${apiContractParam(m)}`);
         if (data.phase === 0) {
           throw new Error("Cannot cancel cycle — auction is still in deposit phase");
         }
@@ -518,7 +629,7 @@ export function registerJingswapTools(server: McpServer): void {
 
         const result = await callContract(account, {
           contractAddress: JINGSWAP_CONTRACT_ADDRESS,
-          contractName: JINGSWAP_CONTRACT_NAME,
+          contractName: m.contractName,
           functionName: "cancel-cycle",
           functionArgs: [],
           postConditionMode: PostConditionMode.Allow,
@@ -529,6 +640,7 @@ export function registerJingswapTools(server: McpServer): void {
           success: true,
           txid: result.txid,
           action: "cancel-cycle",
+          market: market || DEFAULT_MARKET,
           cycle: data.currentCycle,
           network: NETWORK,
           explorerUrl: getExplorerTxUrl(result.txid, NETWORK),
@@ -547,13 +659,17 @@ export function registerJingswapTools(server: McpServer): void {
       description:
         "Get current oracle and DEX prices used by the Jingswap auction. " +
         "Returns Pyth oracle prices (BTC/USD, STX/USD with confidence and freshness), " +
-        "on-chain DEX prices (XYK pool with TVL, DLMM), and the derived STX/BTC price.",
+        "on-chain DEX prices (XYK pool with TVL, DLMM), and the derived price ratio.",
+      inputSchema: {
+        market: z.string().optional().describe('Market: "sbtc-stx" (default) or "sbtc-usdcx"'),
+      },
     },
-    async () => {
+    async ({ market }) => {
       try {
+        const m = getMarket(market);
         const [pyth, dex] = await Promise.all([
-          jingswapGet("/api/auction/pyth-prices"),
-          jingswapGet("/api/auction/dex-price"),
+          jingswapGet(`/api/auction/pyth-prices${apiContractParam(m)}`),
+          jingswapGet(`/api/auction/dex-price${apiContractParam(m)}`),
         ]);
         // Compute human-readable STX/BTC prices
         const xykStxPerBtc =
@@ -566,6 +682,7 @@ export function registerJingswapTools(server: McpServer): void {
             ? Math.round((1 / (dex.dlmmPrice * 1e-10)) * 100) / 100
             : null;
         return createJsonResponse({
+          market: market || DEFAULT_MARKET,
           pyth,
           dex: {
             ...dex,
@@ -573,12 +690,12 @@ export function registerJingswapTools(server: McpServer): void {
             dlmmStxPerBtc,
           },
           _hint: {
-            xykStxPerBtc: "STX per BTC from XYK pool",
-            dlmmStxPerBtc: "STX per BTC from DLMM pool",
-            xykPrice: "Raw contract value — use xykStxPerBtc instead",
-            dlmmPrice: "Raw fixed-point (×1e-10 = STX/BTC ratio) — use dlmmStxPerBtc instead",
+            xykStxPerBtc: `${m.tokenBSymbol} per BTC from XYK pool`,
+            dlmmStxPerBtc: `${m.tokenBSymbol} per BTC from DLMM pool`,
+            xykPrice: `Raw contract value — use xykStxPerBtc instead`,
+            dlmmPrice: `Raw fixed-point (x1e-10 = ${m.priceUnit} ratio) — use dlmmStxPerBtc instead`,
             xBalance: "sBTC in sats (÷1e8 for BTC)",
-            yBalance: "STX in micro-STX (÷1e6 for STX)",
+            yBalance: `${m.tokenBSymbol} in micro-units (÷1e${m.tokenBDecimals} for ${m.tokenBSymbol})`,
           },
         });
       } catch (error) {

--- a/src/tools/skill-mappings.ts
+++ b/src/tools/skill-mappings.ts
@@ -270,6 +270,23 @@ export const TOOL_SKILL_MAP: Record<string, string> = {
   bitflow_get_order: "bitflow",
   bitflow_cancel_order: "bitflow",
   bitflow_get_keeper_user: "bitflow",
+
+  // jingswap skill — blind batch auction for sBTC
+  jingswap_get_cycle_state: "jingswap",
+  jingswap_get_depositors: "jingswap",
+  jingswap_get_user_deposit: "jingswap",
+  jingswap_get_settlement: "jingswap",
+  jingswap_get_cycles_history: "jingswap",
+  jingswap_get_user_activity: "jingswap",
+  jingswap_get_prices: "jingswap",
+  jingswap_deposit_stx: "jingswap",
+  jingswap_deposit_sbtc: "jingswap",
+  jingswap_cancel_stx: "jingswap",
+  jingswap_cancel_sbtc: "jingswap",
+  jingswap_close_deposits: "jingswap",
+  jingswap_settle: "jingswap",
+  jingswap_settle_with_refresh: "jingswap",
+  jingswap_cancel_cycle: "jingswap",
 };
 
 /**


### PR DESCRIPTION
## Summary

- All 15 Jingswap tools now accept optional `market` parameter (`"sbtc-stx"` default, `"sbtc-usdcx"` new)
- Read tools route to correct backend contract via `?contract=` query param
- Write tools use market-specific function names (`deposit-usdcx`, `cancel-usdcx-deposit`) and FT post conditions for USDCx
- Adds jingswap skill mappings to `TOOL_SKILL_MAP` for proper `_meta.skill` injection
- Backward compatible — all existing calls without `market` param continue to work

## Markets

| Market | Contract | Quote Token |
|--------|----------|-------------|
| `sbtc-stx` (default) | `sbtc-stx-jingswap` | STX (native) |
| `sbtc-usdcx` | `sbtc-usdcx-jingswap` | USDCx (FT, 6 decimals) |

## Notes

This is a clean rebase of Rapha-btc's PR #346 on current main (which had diverged due to
ordinals-marketplace, taproot-multisig, and reputation tools added after the original branch).
The multi-market implementation is identical to the original PR.

Closes #346

Co-authored-by: Rapha-btc <github@rapha.dev>
🤖 Generated with [Claude Code](https://claude.com/claude-code)