### PR TITLE
fix(signing): register signing tools in tools/index (closes #356)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -33,6 +33,7 @@ import { registerOrdinalsP2PTools } from "./ordinals-p2p.tools.js";
 import { registerOrdinalsMarketplaceTools } from "./ordinals-marketplace.tools.js";
 import { registerTaprootMultisigTools } from "./taproot-multisig.tools.js";
 import { registerJingswapTools } from "./jingswap.tools.js";
+import { registerSigningTools } from "./signing.tools.js";
 import { getSkillForTool } from "./skill-mappings.js";
 
 /**
@@ -163,6 +164,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Jingswap Auction (blind batch auctions for STX/sBTC)
   registerJingswapTools(server);
+
+  // Message Signing (BTC BIP-322, Stacks SIWS, SIP-018 structured data, Nostr NIP-01)
+  registerSigningTools(server);
 
   restoreRegisterTool();
 }


### PR DESCRIPTION
## Summary

- Adds missing import and registration for `signing.tools.ts` in `src/tools/index.ts`
- Fixes #356 where `btc_sign_message`, `stacks_sign_message`, and other signing tools were completely absent from the MCP server despite the implementation existing

## Root cause

`signing.tools.ts` exports `registerSigningTools` but was never added to the tools index, making all signing tools invisible to MCP clients.

## Test plan
- [ ] Verify signing tools appear in MCP server tool list after fix
- [ ] `btc_sign_message` callable from MCP client
- [ ] `stacks_sign_message` callable from MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)