### PR TITLE
fix(security): upgrade @hono/node-server to 1.19.10 (CVE-2026-29087)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -538,9 +538,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.10",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.10.tgz",
+      "integrity": "sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "@hono/node-server": ">=1.19.10"
   }
 }


### PR DESCRIPTION
## Summary

- Patches **CVE-2026-29087** (high, CVSS 7.5): authorization bypass via encoded slashes (`%2F`) in `@hono/node-server`'s Serve Static Middleware
- `@hono/node-server` is a transitive dependency via `@modelcontextprotocol/sdk`
- Added `overrides` in `package.json` to enforce `>=1.19.10` and updated `package-lock.json`

## Vulnerability Details

When using `@hono/node-server`'s static file serving with route-based middleware protections (e.g., protecting `/admin/*`), inconsistent URL decoding allows protected static resources to be accessed without authorization. Paths with encoded slashes (`%2F`) bypass middleware matching while still being resolved by the static handler.

**Impact for this project:** aibtc-mcp-server is primarily an MCP protocol server — it does not appear to serve protected static subdirectories. Risk is low but patching is straightforward and closes the alert.

## Test plan

- [ ] CI passes (TypeScript build + unit tests)
- [ ] Dependabot alert #7 dismissed after merge

Closes: https://github.com/aibtcdev/aibtc-mcp-server/security/dependabot/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)