### PR TITLE
feat(credentials): add encrypted credential store MCP tools

### DIFF
--- a/src/services/credentials.ts
+++ b/src/services/credentials.ts
@@ -1,0 +1,213 @@
+/**
+ * Credential store service for aibtc-mcp-server.
+ *
+ * Compatible implementation of Arc's credential store (AES-256-GCM + scrypt KDF).
+ * Storage: ~/.aibtc/credentials.enc
+ * Password: ARC_CREDS_PASSWORD env var
+ */
+
+import crypto from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+function getStoreDir(): string {
+  return process.env.ARC_CREDS_DIR ?? path.join(os.homedir(), ".aibtc");
+}
+
+function getStoreFile(): string {
+  return path.join(getStoreDir(), "credentials.enc");
+}
+
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1, keyLen: 32 } as const;
+const VERSION = 1;
+
+interface Credential {
+  service: string;
+  key: string;
+  value: string;
+  updatedAt: string;
+}
+
+interface CredentialStore {
+  version: number;
+  credentials: Credential[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface EncryptedData {
+  ciphertext: string;
+  iv: string;
+  authTag: string;
+  salt: string;
+  scryptParams: typeof SCRYPT_PARAMS;
+  version: number;
+}
+
+interface EncryptedFile {
+  version: number;
+  encrypted: EncryptedData;
+}
+
+let _store: CredentialStore | null = null;
+let _password: string | null = null;
+
+function requireStore(): CredentialStore {
+  if (!_store) throw new Error("Credential store not unlocked. Set ARC_CREDS_PASSWORD env var.");
+  return _store;
+}
+
+async function deriveKey(password: string, salt: Buffer): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    crypto.scrypt(
+      password,
+      salt,
+      SCRYPT_PARAMS.keyLen,
+      { N: SCRYPT_PARAMS.N, r: SCRYPT_PARAMS.r, p: SCRYPT_PARAMS.p },
+      (err, key) => {
+        if (err) reject(err);
+        else resolve(key);
+      }
+    );
+  });
+}
+
+async function encrypt(data: string, password: string): Promise<EncryptedData> {
+  const salt = crypto.randomBytes(32);
+  const iv = crypto.randomBytes(12);
+  const key = await deriveKey(password, salt);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(data, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return {
+    ciphertext: encrypted.toString("base64"),
+    iv: iv.toString("base64"),
+    authTag: authTag.toString("base64"),
+    salt: salt.toString("base64"),
+    scryptParams: SCRYPT_PARAMS,
+    version: VERSION,
+  };
+}
+
+async function decrypt(encrypted: EncryptedData, password: string): Promise<string> {
+  const key = await deriveKey(password, Buffer.from(encrypted.salt, "base64"));
+  const decipher = crypto.createDecipheriv(
+    "aes-256-gcm",
+    key,
+    Buffer.from(encrypted.iv, "base64")
+  );
+  decipher.setAuthTag(Buffer.from(encrypted.authTag, "base64"));
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(encrypted.ciphertext, "base64")),
+    decipher.final(),
+  ]);
+  return decrypted.toString("utf8");
+}
+
+function emptyStore(): CredentialStore {
+  const now = new Date().toISOString();
+  return { version: VERSION, credentials: [], createdAt: now, updatedAt: now };
+}
+
+async function save(): Promise<void> {
+  if (!_store || !_password) throw new Error("Store not unlocked");
+  await fs.mkdir(getStoreDir(), { recursive: true });
+  const file: EncryptedFile = {
+    version: VERSION,
+    encrypted: await encrypt(JSON.stringify(_store), _password),
+  };
+  await fs.writeFile(getStoreFile(), JSON.stringify(file, null, 2));
+}
+
+async function load(password: string): Promise<CredentialStore> {
+  const raw = await fs.readFile(getStoreFile(), "utf-8");
+  const file: EncryptedFile = JSON.parse(raw) as EncryptedFile;
+  return JSON.parse(await decrypt(file.encrypted, password)) as CredentialStore;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function unlock(password?: string): Promise<void> {
+  if (_store) return;
+  const pw = password ?? process.env.ARC_CREDS_PASSWORD;
+  if (!pw) throw new Error("Password required: pass arg or set ARC_CREDS_PASSWORD");
+
+  _password = pw;
+  if (await fileExists(getStoreFile())) {
+    _store = await load(pw);
+  } else {
+    _store = emptyStore();
+    await save();
+  }
+}
+
+export function lock(): void {
+  _store = null;
+  _password = null;
+}
+
+export function isUnlocked(): boolean {
+  return _store !== null;
+}
+
+export function get(service: string, key: string): string | null {
+  const store = requireStore();
+  return store.credentials.find((c) => c.service === service && c.key === key)?.value ?? null;
+}
+
+export async function set(service: string, key: string, value: string): Promise<void> {
+  const store = requireStore();
+  const now = new Date().toISOString();
+  const idx = store.credentials.findIndex((c) => c.service === service && c.key === key);
+  if (idx >= 0) {
+    store.credentials[idx] = { ...store.credentials[idx], value, updatedAt: now };
+  } else {
+    store.credentials.push({ service, key, value, updatedAt: now });
+  }
+  store.updatedAt = now;
+  await save();
+}
+
+export async function del(service: string, key: string): Promise<boolean> {
+  const store = requireStore();
+  const idx = store.credentials.findIndex((c) => c.service === service && c.key === key);
+  if (idx < 0) return false;
+  store.credentials.splice(idx, 1);
+  store.updatedAt = new Date().toISOString();
+  await save();
+  return true;
+}
+
+export function list(): Array<{ service: string; key: string; updatedAt: string }> {
+  const store = requireStore();
+  return store.credentials.map((c) => ({
+    service: c.service,
+    key: c.key,
+    updatedAt: c.updatedAt,
+  }));
+}
+
+export function storePath(): string {
+  return getStoreFile();
+}
+
+export const credentials = {
+  unlock,
+  lock,
+  isUnlocked,
+  get,
+  set,
+  del,
+  list,
+  storePath,
+};
+
+export default credentials;

--- a/src/tools/credentials.tools.ts
+++ b/src/tools/credentials.tools.ts
@@ -1,0 +1,184 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { createJsonResponse, createErrorResponse } from "../utils/index.js";
+import credentials from "../services/credentials.js";
+
+/**
+ * Ensure the credential store is unlocked before operations.
+ * Uses ARC_CREDS_PASSWORD env var.
+ */
+async function ensureUnlocked(): Promise<void> {
+  if (!credentials.isUnlocked()) {
+    await credentials.unlock();
+  }
+}
+
+/**
+ * Register credential management tools with the MCP server.
+ *
+ * Provides encrypted credential storage (AES-256-GCM + scrypt KDF)
+ * at ~/.aibtc/credentials.enc. Password from ARC_CREDS_PASSWORD env var.
+ */
+export function registerCredentialsTools(server: McpServer): void {
+  /**
+   * List stored credentials (service/key names only, no values)
+   */
+  server.registerTool(
+    "credentials_list",
+    {
+      description:
+        "List all stored credentials. Shows service names, key names, and last-updated timestamps. Does NOT reveal credential values.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        await ensureUnlocked();
+        const entries = credentials.list();
+
+        return createJsonResponse({
+          count: entries.length,
+          credentials: entries,
+          storePath: credentials.storePath(),
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  /**
+   * Get a credential value
+   */
+  server.registerTool(
+    "credentials_get",
+    {
+      description:
+        "Retrieve a stored credential value by service and key. Returns the decrypted value. WARNING: The returned value is sensitive — do not log or display it unnecessarily.",
+      inputSchema: {
+        service: z.string().min(1).describe("Service name (e.g. 'github', 'openrouter')"),
+        key: z.string().min(1).describe("Key name within the service (e.g. 'api_key', 'token')"),
+      },
+    },
+    async ({ service, key }) => {
+      try {
+        await ensureUnlocked();
+        const value = credentials.get(service, key);
+
+        if (value === null) {
+          return createJsonResponse({
+            found: false,
+            service,
+            key,
+            message: `No credential found for ${service}/${key}`,
+          });
+        }
+
+        return createJsonResponse({
+          found: true,
+          service,
+          key,
+          value,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  /**
+   * Set or update a credential
+   */
+  server.registerTool(
+    "credentials_set",
+    {
+      description:
+        "Store or update a credential. Encrypts the value with AES-256-GCM and saves to ~/.aibtc/credentials.enc. If the service/key pair already exists, it is updated.",
+      inputSchema: {
+        service: z.string().min(1).describe("Service name (e.g. 'github', 'openrouter')"),
+        key: z.string().min(1).describe("Key name within the service (e.g. 'api_key', 'token')"),
+        value: z
+          .string()
+          .min(1)
+          .describe("The credential value to store — WARNING: sensitive"),
+      },
+    },
+    async ({ service, key, value }) => {
+      try {
+        await ensureUnlocked();
+
+        const existed = credentials.get(service, key) !== null;
+        await credentials.set(service, key, value);
+
+        return createJsonResponse({
+          success: true,
+          action: existed ? "updated" : "created",
+          service,
+          key,
+          storedIn: credentials.storePath(),
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  /**
+   * Delete a credential
+   */
+  server.registerTool(
+    "credentials_delete",
+    {
+      description:
+        "Remove a stored credential by service and key. The encrypted store file is rewritten without the deleted entry.",
+      inputSchema: {
+        service: z.string().min(1).describe("Service name (e.g. 'github', 'openrouter')"),
+        key: z.string().min(1).describe("Key name within the service (e.g. 'api_key', 'token')"),
+      },
+    },
+    async ({ service, key }) => {
+      try {
+        await ensureUnlocked();
+        const deleted = await credentials.del(service, key);
+
+        return createJsonResponse({
+          success: deleted,
+          service,
+          key,
+          message: deleted
+            ? `Credential ${service}/${key} deleted`
+            : `No credential found for ${service}/${key}`,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  /**
+   * Unlock / verify credential store
+   */
+  server.registerTool(
+    "credentials_unlock",
+    {
+      description:
+        "Verify that the credential store password works and show store info. Uses ARC_CREDS_PASSWORD env var. Creates a new empty store if none exists.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        await credentials.unlock();
+        const entries = credentials.list();
+
+        return createJsonResponse({
+          success: true,
+          unlocked: true,
+          credentialCount: entries.length,
+          storePath: credentials.storePath(),
+          message: "Credential store unlocked and verified",
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -36,6 +36,7 @@ import { registerJingswapTools } from "./jingswap.tools.js";
 import { registerSigningTools } from "./signing.tools.js";
 import { registerNewsTools } from "./news.tools.js";
 import { registerIdentityTools } from "./identity.tools.js";
+import { registerCredentialsTools } from "./credentials.tools.js";
 import { getSkillForTool } from "./skill-mappings.js";
 
 /**
@@ -175,6 +176,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Identity (ERC-8004 on-chain agent identity management)
   registerIdentityTools(server);
+
+  // Credentials (encrypted credential store — list, get, set, delete, unlock)
+  registerCredentialsTools(server);
 
   restoreRegisterTool();
 }

--- a/src/tools/skill-mappings.ts
+++ b/src/tools/skill-mappings.ts
@@ -281,6 +281,13 @@ export const TOOL_SKILL_MAP: Record<string, string> = {
   bitflow_cancel_order: "bitflow",
   bitflow_get_keeper_user: "bitflow",
 
+  // credentials skill — encrypted credential store (AES-256-GCM)
+  credentials_list: "credentials",
+  credentials_get: "credentials",
+  credentials_set: "credentials",
+  credentials_delete: "credentials",
+  credentials_unlock: "credentials",
+
   // jingswap skill — blind batch auction for sBTC
   jingswap_get_cycle_state: "jingswap",
   jingswap_get_depositors: "jingswap",


### PR DESCRIPTION
## Summary
- Adds 5 MCP tools for credential management: `credentials_list`, `credentials_get`, `credentials_set`, `credentials_delete`, `credentials_unlock`
- Backed by AES-256-GCM + scrypt KDF encrypted storage at `~/.aibtc/credentials.enc`
- Compatible with Arc's credential store format (same encryption, same file layout)
- Password sourced from `ARC_CREDS_PASSWORD` env var

## Files added/changed
- `src/services/credentials.ts` — Node.js-compatible credential store (adapted from Arc's Bun-based store)
- `src/tools/credentials.tools.ts` — MCP tool registration (5 tools)
- `src/tools/index.ts` — Register credentials tools in tool registry
- `src/tools/skill-mappings.ts` — Map credential tools to `credentials` skill

## Test plan
- [ ] `tsc --noEmit` passes (verified locally)
- [ ] `credentials_unlock` creates new store when none exists
- [ ] `credentials_set` stores and `credentials_get` retrieves values
- [ ] `credentials_list` shows service/key without values
- [ ] `credentials_delete` removes entries
- [ ] Store is compatible with Arc's `arc creds` CLI

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)