### PR TITLE
feat(bounty-scanner): add bounty scanner MCP tools

### DIFF
--- a/src/tools/bounty-scanner.tools.ts
+++ b/src/tools/bounty-scanner.tools.ts
@@ -1,0 +1,481 @@
+/**
+ * Bounty Scanner Tools
+ *
+ * Tools for interacting with the bounty.drx4.xyz sBTC bounty board.
+ * Agents can list open bounties, view details, score against their capabilities,
+ * claim tasks, check status, and review their submission history.
+ *
+ * Read-only tools (no auth required):
+ * - bounty_list       — List bounties with optional filters
+ * - bounty_get        — Full detail for a single bounty by ID
+ * - bounty_match      — Score open bounties against agent capability tags
+ * - bounty_status     — Check claim/submission status for a bounty
+ * - bounty_my_claims  — List all claims/submissions for current wallet
+ * - bounty_stats      — Platform aggregate stats
+ *
+ * Authenticated tool (requires unlocked wallet with bc1q address):
+ * - bounty_claim      — Claim a bounty (BIP-322 signed)
+ *
+ * Authentication: BIP-322 simple signature (P2WPKH, bc1q addresses preferred).
+ * Message format: "agent-bounties | {action} | {btc_address} | {resource} | {timestamp}"
+ * Headers: X-BTC-Address, X-Signature, X-Timestamp
+ *
+ * Status flow: open → claimed → submitted → approved → paid (or cancelled)
+ *
+ * Reference: https://bounty.drx4.xyz/api
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  p2wpkh,
+  NETWORK as BTC_MAINNET,
+  TEST_NETWORK as BTC_TESTNET,
+} from "@scure/btc-signer";
+import { NETWORK } from "../config/networks.js";
+import { getAccount } from "../services/x402.service.js";
+import { createJsonResponse, createErrorResponse } from "../utils/index.js";
+import { bip322Sign } from "../utils/bip322.js";
+
+const BOUNTY_BASE = "https://bounty.drx4.xyz/api";
+
+// ============================================================================
+// Auth header builder for authenticated endpoints
+// ============================================================================
+
+/**
+ * Account fields needed for BIP-322 auth header construction.
+ */
+type AccountForAuth = {
+  btcAddress: string;
+  btcPrivateKey: Uint8Array;
+  btcPublicKey: Uint8Array;
+  address?: string;
+};
+
+/**
+ * Build BIP-322 auth headers for bounty.drx4.xyz write operations.
+ * Message format: "agent-bounties | {action} | {btc_address} | {resource} | {timestamp}"
+ *
+ * @param action  - Action string (e.g. "claim-bounty")
+ * @param resource - Resource path (e.g. "bounties/{uuid}")
+ * @param account - Pre-fetched account with BTC keys
+ */
+function buildBountyAuthHeaders(
+  action: string,
+  resource: string,
+  account: AccountForAuth
+): Record<string, string> {
+  const timestamp = new Date().toISOString();
+  const message = `agent-bounties | ${action} | ${account.btcAddress} | ${resource} | ${timestamp}`;
+
+  const btcNetwork = NETWORK === "testnet" ? BTC_TESTNET : BTC_MAINNET;
+  const scriptPubKey = p2wpkh(account.btcPublicKey, btcNetwork).script;
+  const signature = bip322Sign(message, account.btcPrivateKey, scriptPubKey);
+
+  const headers: Record<string, string> = {
+    "X-BTC-Address": account.btcAddress,
+    "X-Signature": signature,
+    "X-Timestamp": timestamp,
+    "Content-Type": "application/json",
+  };
+
+  if (account.address) {
+    headers["X-STX-Address"] = account.address;
+  }
+
+  return headers;
+}
+
+// ============================================================================
+// Tool Registration
+// ============================================================================
+
+export function registerBountyScannerTools(server: McpServer): void {
+  // --------------------------------------------------------------------------
+  // bounty_list — List bounties with optional filters
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "bounty_list",
+    {
+      description: `List bounties on the bounty.drx4.xyz sBTC bounty board.
+
+Returns bounties matching the given filters in reverse chronological order.
+
+Filters:
+- status: "open", "claimed", "submitted", "approved", "paid", "cancelled" (default: all)
+- tags: comma-separated tag filter (e.g. "stacks,defi")
+- creator: filter by creator BTC address
+- min_amount: minimum reward in satoshis
+- max_amount: maximum reward in satoshis
+- limit: max results (default 20)
+- offset: pagination offset
+
+No authentication required.`,
+      inputSchema: {
+        status: z
+          .enum(["open", "claimed", "submitted", "approved", "paid", "cancelled"])
+          .optional()
+          .describe("Filter by bounty status"),
+        tags: z
+          .string()
+          .optional()
+          .describe("Comma-separated tag filter (e.g. 'stacks,defi')"),
+        creator: z
+          .string()
+          .optional()
+          .describe("Filter by creator BTC address"),
+        min_amount: z
+          .number()
+          .optional()
+          .describe("Minimum reward in satoshis"),
+        max_amount: z
+          .number()
+          .optional()
+          .describe("Maximum reward in satoshis"),
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("Max results (default 20, max 100)"),
+        offset: z
+          .number()
+          .min(0)
+          .optional()
+          .describe("Pagination offset (default 0)"),
+      },
+    },
+    async ({ status, tags, creator, min_amount, max_amount, limit, offset }) => {
+      try {
+        const params = new URLSearchParams();
+        if (status) params.set("status", status);
+        if (tags) params.set("tags", tags);
+        if (creator) params.set("creator", creator);
+        if (min_amount !== undefined) params.set("min_amount", String(min_amount));
+        if (max_amount !== undefined) params.set("max_amount", String(max_amount));
+        if (limit !== undefined) params.set("limit", String(limit));
+        if (offset !== undefined) params.set("offset", String(offset));
+
+        const query = params.toString();
+        const url = `${BOUNTY_BASE}/bounties${query ? `?${query}` : ""}`;
+
+        const res = await fetch(url);
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(`Failed to list bounties (${res.status}): ${text}`);
+        }
+
+        const data = await res.json();
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // --------------------------------------------------------------------------
+  // bounty_get — Full detail for a single bounty by ID
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "bounty_get",
+    {
+      description: `Get full details for a single bounty on bounty.drx4.xyz.
+
+Returns the bounty description, reward amount, tags, status, all claims,
+submissions, payments, and available actions for the current agent.
+
+No authentication required.`,
+      inputSchema: {
+        id: z
+          .string()
+          .describe("Bounty UUID or identifier"),
+      },
+    },
+    async ({ id }) => {
+      try {
+        const res = await fetch(`${BOUNTY_BASE}/bounties/${encodeURIComponent(id)}`);
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(`Failed to fetch bounty ${id} (${res.status}): ${text}`);
+        }
+
+        const data = await res.json();
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // --------------------------------------------------------------------------
+  // bounty_match — Score open bounties against agent capability tags
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "bounty_match",
+    {
+      description: `Score open bounties against an agent's capability profile.
+
+Fetches all open bounties and ranks them by tag overlap with the provided
+capability_tags. Returns bounties sorted by match score (highest first),
+with a match_score field showing how many tags matched.
+
+Use this to discover which open bounties are most relevant to your skills.
+Provide tags that describe your capabilities (e.g. ["stacks", "clarity", "defi"]).
+
+No authentication required.`,
+      inputSchema: {
+        capability_tags: z
+          .array(z.string())
+          .min(1)
+          .describe("Array of capability tags to match against (e.g. ['stacks', 'clarity', 'defi'])"),
+        limit: z
+          .number()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe("Max results to return (default 10)"),
+      },
+    },
+    async ({ capability_tags, limit }) => {
+      try {
+        const res = await fetch(`${BOUNTY_BASE}/bounties?status=open&limit=100`);
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(`Failed to fetch open bounties (${res.status}): ${text}`);
+        }
+
+        const data = await res.json() as { bounties?: Array<Record<string, unknown>> };
+        const bounties = data.bounties ?? [];
+
+        const capabilitySet = new Set(capability_tags.map((t: string) => t.toLowerCase()));
+
+        const scored = bounties.map((bounty) => {
+          const bountyTags: string[] = Array.isArray(bounty.tags)
+            ? (bounty.tags as string[]).map((t: string) => t.toLowerCase())
+            : [];
+          const matchScore = bountyTags.filter((tag: string) => capabilitySet.has(tag)).length;
+          return { ...bounty, match_score: matchScore };
+        });
+
+        scored.sort((a, b) => b.match_score - a.match_score);
+
+        const maxResults = limit ?? 10;
+        return createJsonResponse({
+          matches: scored.slice(0, maxResults),
+          total_open: bounties.length,
+          capability_tags,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // --------------------------------------------------------------------------
+  // bounty_claim — Claim a bounty (requires bc1q wallet, BIP-322 auth)
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "bounty_claim",
+    {
+      description: `Claim a bounty on bounty.drx4.xyz.
+
+Submits a claim for an open bounty. Requires an unlocked wallet with BTC keys.
+The request is authenticated via BIP-322 signing.
+
+After claiming, use bounty_get to see the bounty detail and track next steps.
+The status flow is: open → claimed → submitted → approved → paid.
+
+Fields:
+- id: bounty UUID to claim
+- notes: optional notes about your approach or qualifications`,
+      inputSchema: {
+        id: z
+          .string()
+          .describe("Bounty UUID to claim"),
+        notes: z
+          .string()
+          .optional()
+          .describe("Optional notes about your approach or qualifications"),
+      },
+    },
+    async ({ id, notes }) => {
+      try {
+        const account = await getAccount();
+
+        if (!account.btcAddress || !account.btcPrivateKey || !account.btcPublicKey) {
+          throw new Error(
+            "Bitcoin keys not available. Unlock a wallet with BTC key derivation to claim bounties."
+          );
+        }
+
+        const resource = `bounties/${id}`;
+        const authHeaders = buildBountyAuthHeaders("claim-bounty", resource, account as AccountForAuth);
+
+        const payload: Record<string, unknown> = {
+          btc_address: account.btcAddress,
+        };
+        if (account.address) {
+          payload.stx_address = account.address;
+        }
+        if (notes) {
+          payload.notes = notes;
+        }
+
+        const res = await fetch(`${BOUNTY_BASE}/bounties/${encodeURIComponent(id)}/claim`, {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify(payload),
+        });
+
+        const responseText = await res.text();
+        let responseData: unknown;
+        try {
+          responseData = JSON.parse(responseText);
+        } catch {
+          responseData = { raw: responseText };
+        }
+
+        if (!res.ok) {
+          throw new Error(`Failed to claim bounty ${id} (${res.status}): ${responseText}`);
+        }
+
+        return createJsonResponse({
+          success: true,
+          message: "Bounty claimed successfully",
+          claim: responseData,
+          claimed_by: account.btcAddress,
+          bounty_id: id,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // --------------------------------------------------------------------------
+  // bounty_status — Check claim/submission status for a bounty
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "bounty_status",
+    {
+      description: `Check the current status of a bounty on bounty.drx4.xyz.
+
+Returns the bounty's current status in the workflow, along with any claims
+and submission details. The status flow is:
+open → claimed → submitted → approved → paid (or cancelled at any point by creator).
+
+No authentication required.`,
+      inputSchema: {
+        id: z
+          .string()
+          .describe("Bounty UUID to check status for"),
+      },
+    },
+    async ({ id }) => {
+      try {
+        const res = await fetch(`${BOUNTY_BASE}/bounties/${encodeURIComponent(id)}`);
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(`Failed to fetch bounty status for ${id} (${res.status}): ${text}`);
+        }
+
+        const data = await res.json() as Record<string, unknown>;
+
+        // Extract and surface the most relevant status fields
+        return createJsonResponse({
+          id: data.id,
+          status: data.status,
+          title: data.title,
+          reward_sats: data.reward_sats,
+          creator: data.creator,
+          tags: data.tags,
+          claims: data.claims,
+          submissions: data.submissions,
+          payments: data.payments,
+          created_at: data.created_at,
+          updated_at: data.updated_at,
+          status_flow: "open → claimed → submitted → approved → paid (or cancelled)",
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // --------------------------------------------------------------------------
+  // bounty_my_claims — List all claims/submissions for current wallet
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "bounty_my_claims",
+    {
+      description: `List all bounty claims and submissions for the current wallet's BTC address.
+
+Returns the agent profile from bounty.drx4.xyz including all bounties created
+and claims submitted. If no address is provided, uses the current wallet's BTC address.
+
+No authentication required.`,
+      inputSchema: {
+        btc_address: z
+          .string()
+          .optional()
+          .describe("BTC address to look up (bc1q...). Omit to use the current wallet's BTC address."),
+      },
+    },
+    async ({ btc_address }) => {
+      try {
+        let address = btc_address;
+
+        if (!address) {
+          const account = await getAccount();
+          if (!account.btcAddress) {
+            throw new Error(
+              "No BTC address found. Provide a btc_address or unlock a wallet with BTC key derivation."
+            );
+          }
+          address = account.btcAddress;
+        }
+
+        const res = await fetch(`${BOUNTY_BASE}/agents/${encodeURIComponent(address)}`);
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(`Failed to fetch agent profile for ${address} (${res.status}): ${text}`);
+        }
+
+        const data = await res.json();
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // --------------------------------------------------------------------------
+  // bounty_stats — Platform aggregate stats
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "bounty_stats",
+    {
+      description: `Get aggregate platform statistics from bounty.drx4.xyz.
+
+Returns totals for bounties, agents, claims, submissions, and sBTC paid out.
+
+No authentication required.`,
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const res = await fetch(`${BOUNTY_BASE}/stats`);
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(`Failed to fetch bounty stats (${res.status}): ${text}`);
+        }
+
+        const data = await res.json();
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -38,6 +38,7 @@ import { registerNewsTools } from "./news.tools.js";
 import { registerIdentityTools } from "./identity.tools.js";
 import { registerCredentialsTools } from "./credentials.tools.js";
 import { registerSouldinalsTools } from "./souldinals.tools.js";
+import { registerBountyScannerTools } from "./bounty-scanner.tools.js";
 import { getSkillForTool } from "./skill-mappings.js";
 
 /**
@@ -183,6 +184,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Souldinals (soul.md child inscriptions — inscribe, reveal, list, load, display traits)
   registerSouldinalsTools(server);
+
+  // Bounty Scanner (bounty.drx4.xyz — list, match, claim, status, my-claims)
+  registerBountyScannerTools(server);
 
   restoreRegisterTool();
 }

--- a/src/tools/skill-mappings.ts
+++ b/src/tools/skill-mappings.ts
@@ -311,6 +311,15 @@ export const TOOL_SKILL_MAP: Record<string, string> = {
   souldinals_list_souls: "souldinals",
   souldinals_load_soul: "souldinals",
   souldinals_display_soul: "souldinals",
+
+  // bounty-scanner skill — sBTC bounty board (bounty.drx4.xyz)
+  bounty_list: "bounty-scanner",
+  bounty_get: "bounty-scanner",
+  bounty_match: "bounty-scanner",
+  bounty_claim: "bounty-scanner",
+  bounty_status: "bounty-scanner",
+  bounty_my_claims: "bounty-scanner",
+  bounty_stats: "bounty-scanner",
 };
 
 /**


### PR DESCRIPTION
## Summary

- Implements 7 MCP tools for the [bounty.drx4.xyz](https://bounty.drx4.xyz) sBTC bounty board
- Provides full parity with the existing \`bounty-scanner\` skill (6 subcommands + stats)
- All read-only tools require no authentication; \`bounty_claim\` uses BIP-322 signing

## Tools Added

| Tool | Description |
|------|-------------|
| \`bounty_list\` | List bounties with status/tags/creator/amount filters |
| \`bounty_get\` | Full detail for a single bounty by ID |
| \`bounty_match\` | Score open bounties against agent capability tags |
| \`bounty_claim\` | Claim a bounty (BIP-322 signed, requires unlocked wallet) |
| \`bounty_status\` | Check claim/submission status and workflow state |
| \`bounty_my_claims\` | List all claims for current wallet via agent profile endpoint |
| \`bounty_stats\` | Platform aggregate stats (total bounties, agents, sats paid) |

## Implementation Notes

- Auth pattern follows \`news.tools.ts\` (BIP-322 signing with P2WPKH scriptPubKey)
- Bounty signing format: \`"agent-bounties | {action} | {btc_address} | {resource} | {timestamp}"\`
- \`bounty_match\` accepts \`capability_tags\` string array as explicit input (per arc0btc's recommendation in issue comments — stateless and composable)
- All tools registered in \`src/tools/index.ts\` and mapped to \`"bounty-scanner"\` skill in \`src/tools/skill-mappings.ts\`

## Test Plan

- [ ] \`npm run build\` passes (verified)
- [ ] \`bounty_stats\` returns platform aggregate stats from \`https://bounty.drx4.xyz/api/stats\`
- [ ] \`bounty_list\` returns paginated bounty list
- [ ] \`bounty_match\` with \`capability_tags: ["stacks", "defi"]\` scores and sorts results
- [ ] \`bounty_claim\` requires unlocked wallet with BTC keys

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)