### PR TITLE
fix(runes): restore Unisat wallet tools and rune transfer infrastructure

### DIFF
--- a/src/services/unisat-indexer.ts
+++ b/src/services/unisat-indexer.ts
@@ -1,0 +1,327 @@
+/**
+ * Unisat Indexer Service
+ *
+ * Provides rune and inscription indexing via Unisat Open API:
+ * - Mainnet: https://open-api.unisat.io
+ * - Testnet: https://open-api-testnet.unisat.io
+ *
+ * Auth: Authorization: Bearer ${UNISAT_API_KEY}
+ */
+
+import type { Network } from "../config/networks.js";
+import type { UTXO } from "./mempool-api.js";
+import { MempoolApi } from "./mempool-api.js";
+
+// ---------------------------------------------------------------------------
+// Unisat API types
+// ---------------------------------------------------------------------------
+
+export interface UnisatInscription {
+  inscriptionId: string;
+  inscriptionNumber: number;
+  address: string;
+  outputValue: number;
+  contentType: string;
+  contentLength: number;
+  timestamp: number;
+  genesisTransaction: string;
+  location: string;
+  output: string;
+  offset: number;
+}
+
+interface UnisatInscriptionDataResponse {
+  code: number;
+  msg: string;
+  data: {
+    cursor: number;
+    total: number;
+    totalConfirmed: number;
+    totalUnconfirmed: number;
+    totalUnconfirmedSpend: number;
+    inscription: UnisatInscription[];
+  };
+}
+
+export interface UnisatRuneBalance {
+  rune: string;
+  runeid: string;
+  spacedRune: string;
+  amount: string;
+  symbol: string;
+  divisibility: number;
+}
+
+interface UnisatRuneBalanceResponse {
+  code: number;
+  msg: string;
+  data: {
+    start: number;
+    total: number;
+    detail: UnisatRuneBalance[];
+  };
+}
+
+export interface UnisatRuneUtxo {
+  txid: string;
+  vout: number;
+  satoshi: number;
+  scriptType: string;
+  scriptPk: string;
+  codeType: number;
+  address: string;
+  height: number;
+  idx: number;
+  isOpInRBF: boolean;
+  isSpent: boolean;
+  runes: {
+    rune: string;
+    runeid: string;
+    spacedRune: string;
+    amount: string;
+    symbol: string;
+    divisibility: number;
+  }[];
+}
+
+interface UnisatRuneUtxoResponse {
+  code: number;
+  msg: string;
+  data: {
+    start: number;
+    total: number;
+    utxo: UnisatRuneUtxo[];
+  };
+}
+
+export interface ClassifiedUtxos {
+  /** Cardinal UTXOs — safe to spend (no inscriptions or runes) */
+  cardinal: UTXO[];
+  /** Inscription UTXOs — contain ordinal inscriptions */
+  inscription: UTXO[];
+  /** Rune UTXOs — contain rune balances */
+  rune: UTXO[];
+}
+
+export class UnisatApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number
+  ) {
+    super(message);
+    this.name = "UnisatApiError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// UnisatIndexer
+// ---------------------------------------------------------------------------
+
+export class UnisatIndexer {
+  private readonly network: Network;
+  private readonly mempoolApi: MempoolApi;
+  private readonly apiBase: string;
+
+  constructor(network: Network) {
+    this.network = network;
+    this.mempoolApi = new MempoolApi(network);
+    this.apiBase =
+      network === "mainnet"
+        ? "https://open-api.unisat.io"
+        : "https://open-api-testnet.unisat.io";
+  }
+
+  private headers(): HeadersInit {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (process.env.UNISAT_API_KEY) {
+      headers["Authorization"] = `Bearer ${process.env.UNISAT_API_KEY}`;
+    }
+    return headers;
+  }
+
+  // -------------------------------------------------------------------------
+  // Runes
+  // -------------------------------------------------------------------------
+
+  /**
+   * Get rune balances for a Bitcoin address.
+   */
+  async getRuneBalances(address: string): Promise<UnisatRuneBalance[]> {
+    const all: UnisatRuneBalance[] = [];
+    let start = 0;
+    const limit = 100;
+
+    while (true) {
+      const url = `${this.apiBase}/v1/indexer/address/${address}/runes/balance-list?start=${start}&limit=${limit}`;
+      const response = await fetch(url, { headers: this.headers() });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "Unknown error");
+        throw new UnisatApiError(
+          `Unisat API error: ${response.status} ${response.statusText} - ${errorText}`,
+          response.status
+        );
+      }
+
+      const json = (await response.json()) as UnisatRuneBalanceResponse;
+
+      if (json.code !== 0) {
+        throw new UnisatApiError(`Unisat API error: ${json.msg}`, json.code);
+      }
+
+      all.push(...json.data.detail);
+
+      if (all.length >= json.data.total) {
+        break;
+      }
+
+      start += limit;
+    }
+
+    return all;
+  }
+
+  /**
+   * Get rune-bearing UTXOs for a specific rune on a Bitcoin address.
+   */
+  async getRuneUtxos(address: string, runeid: string): Promise<UnisatRuneUtxo[]> {
+    const all: UnisatRuneUtxo[] = [];
+    let start = 0;
+    const limit = 100;
+
+    while (true) {
+      const url = `${this.apiBase}/v1/indexer/address/${address}/runes/${runeid}/utxo?start=${start}&limit=${limit}`;
+      const response = await fetch(url, { headers: this.headers() });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "Unknown error");
+        throw new UnisatApiError(
+          `Unisat API error: ${response.status} ${response.statusText} - ${errorText}`,
+          response.status
+        );
+      }
+
+      const json = (await response.json()) as UnisatRuneUtxoResponse;
+
+      if (json.code !== 0) {
+        throw new UnisatApiError(`Unisat API error: ${json.msg}`, json.code);
+      }
+
+      all.push(...json.data.utxo);
+
+      if (all.length >= json.data.total) {
+        break;
+      }
+
+      start += limit;
+    }
+
+    return all;
+  }
+
+  /**
+   * Get all rune-bearing UTXOs for all runes on a Bitcoin address.
+   */
+  async getAllRuneUtxos(address: string): Promise<UnisatRuneUtxo[]> {
+    const balances = await this.getRuneBalances(address);
+    const allUtxos: UnisatRuneUtxo[] = [];
+
+    for (const balance of balances) {
+      const utxos = await this.getRuneUtxos(address, balance.runeid);
+      allUtxos.push(...utxos);
+    }
+
+    return allUtxos;
+  }
+
+  // -------------------------------------------------------------------------
+  // Inscriptions
+  // -------------------------------------------------------------------------
+
+  /**
+   * Get all inscriptions for a Bitcoin address via Unisat API.
+   */
+  async getInscriptionsForAddress(address: string): Promise<UnisatInscription[]> {
+    const all: UnisatInscription[] = [];
+    let cursor = 0;
+    const size = 100;
+
+    while (true) {
+      const url = `${this.apiBase}/v1/indexer/address/${address}/inscription-data?cursor=${cursor}&size=${size}`;
+      const response = await fetch(url, { headers: this.headers() });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "Unknown error");
+        throw new UnisatApiError(
+          `Unisat API error: ${response.status} ${response.statusText} - ${errorText}`,
+          response.status
+        );
+      }
+
+      const json = (await response.json()) as UnisatInscriptionDataResponse;
+
+      if (json.code !== 0) {
+        throw new UnisatApiError(`Unisat API error: ${json.msg}`, json.code);
+      }
+
+      all.push(...json.data.inscription);
+
+      if (all.length >= json.data.total) {
+        break;
+      }
+
+      cursor += size;
+    }
+
+    return all;
+  }
+
+  // -------------------------------------------------------------------------
+  // UTXO Classification
+  // -------------------------------------------------------------------------
+
+  /**
+   * Classify UTXOs into cardinal, inscription, and rune categories.
+   */
+  async classifyUtxos(address: string): Promise<ClassifiedUtxos> {
+    const [utxos, inscriptions, runeUtxos] = await Promise.all([
+      this.mempoolApi.getUtxos(address),
+      this.getInscriptionsForAddress(address),
+      this.getAllRuneUtxos(address),
+    ]);
+
+    const inscriptionOutputs = new Set<string>(
+      inscriptions.map((ins) => ins.output)
+    );
+    const runeOutputs = new Set<string>(
+      runeUtxos.map((u) => `${u.txid}:${u.vout}`)
+    );
+
+    const cardinal: UTXO[] = [];
+    const inscription: UTXO[] = [];
+    const rune: UTXO[] = [];
+
+    for (const utxo of utxos) {
+      const outputRef = `${utxo.txid}:${utxo.vout}`;
+      if (inscriptionOutputs.has(outputRef)) {
+        inscription.push(utxo);
+      } else if (runeOutputs.has(outputRef)) {
+        rune.push(utxo);
+      } else {
+        cardinal.push(utxo);
+      }
+    }
+
+    return { cardinal, inscription, rune };
+  }
+
+  /**
+   * Get cardinal UTXOs (safe to spend — no inscriptions or runes).
+   */
+  async getCardinalUtxos(address: string): Promise<UTXO[]> {
+    const classified = await this.classifyUtxos(address);
+    return classified.cardinal;
+  }
+}

--- a/src/tools/runes.tools.ts
+++ b/src/tools/runes.tools.ts
@@ -2,10 +2,9 @@
  * Runes tools
  *
  * MCP tools for the Bitcoin Runes protocol — a Bitcoin-native fungible token
- * standard introduced by Casey Rodarmor. Provides read-only access to rune
- * etchings, holders, activity, and address balances via the Hiro Runes API.
+ * standard introduced by Casey Rodarmor.
  *
- * Tools:
+ * Read-only tools (Hiro Runes API):
  * - runes_list_etchings: List all rune etchings with pagination
  * - runes_get_etching: Get details for a specific rune by name or numeric ID
  * - runes_get_holders: Get holder list for a rune
@@ -13,8 +12,13 @@
  * - runes_get_address_balances: Get all rune balances for a Bitcoin address
  * - runes_get_address_activity: Get rune activity for a Bitcoin address
  *
- * Data is fetched from the Hiro Runes API (api.hiro.so/runes/v1).
- * Set HIRO_API_KEY environment variable to increase rate limits.
+ * Wallet tools (Unisat API — requires UNISAT_API_KEY):
+ * - get_rune_balances: Fetch rune token balances at a Bitcoin address
+ * - get_rune_utxos: List UTXOs containing a specific rune (block:tx format)
+ * - transfer_rune: Transfer runes via Runestone OP_RETURN encoding
+ *
+ * Set HIRO_API_KEY to increase Hiro rate limits.
+ * Set UNISAT_API_KEY for Unisat indexer access (5 req/s free tier).
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -22,6 +26,24 @@ import { z } from "zod";
 import { NETWORK, getApiBaseUrl } from "../config/networks.js";
 import { createJsonResponse, createErrorResponse } from "../utils/index.js";
 import { getHiroApiKey } from "../utils/storage.js";
+import { getWalletManager } from "../services/wallet-manager.js";
+import { MempoolApi, getMempoolAddressUrl, getMempoolTxUrl } from "../services/mempool-api.js";
+import { UnisatIndexer } from "../services/unisat-indexer.js";
+import { buildRuneTransfer, signRuneTransfer } from "../transactions/rune-transfer-builder.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRuneAmount(amount: string, divisibility: number, symbol: string): string {
+  if (divisibility === 0) return `${amount} ${symbol}`;
+  const num = BigInt(amount);
+  const divisor = 10n ** BigInt(divisibility);
+  const whole = num / divisor;
+  const frac = num % divisor;
+  const fracStr = frac.toString().padStart(divisibility, "0").replace(/0+$/, "");
+  return fracStr ? `${whole}.${fracStr} ${symbol}` : `${whole} ${symbol}`;
+}
 
 // ---------------------------------------------------------------------------
 // API helpers
@@ -276,6 +298,286 @@ export function registerRunesTools(server: McpServer): void {
           `/runes/v1/addresses/${encoded}/activity?limit=${limit}&offset=${offset}`
         );
         return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // --------------------------------------------------------------------------
+  // get_rune_balances — Unisat: on-chain rune balances at a Bitcoin address
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "get_rune_balances",
+    {
+      description:
+        "Fetch all rune token balances held at a Bitcoin address via the Unisat indexer.\n\n" +
+        "Returns rune IDs, amounts, symbols, and divisibility for all runes at the address.\n\n" +
+        "If no address is provided, uses the active wallet's Taproot address.\n" +
+        "Set UNISAT_API_KEY for higher rate limits (5 req/s on free tier).",
+      inputSchema: {
+        address: z
+          .string()
+          .optional()
+          .describe(
+            "Bitcoin address to check (uses active wallet's Taproot address if omitted)"
+          ),
+      },
+    },
+    async ({ address }) => {
+      try {
+        let resolvedAddress = address;
+
+        if (!resolvedAddress) {
+          const walletManager = getWalletManager();
+          const sessionInfo = walletManager.getSessionInfo();
+          if (!sessionInfo?.taprootAddress) {
+            return createErrorResponse(
+              new Error(
+                "No address provided and wallet is not unlocked. " +
+                  "Either provide an address or unlock your wallet first."
+              )
+            );
+          }
+          resolvedAddress = sessionInfo.taprootAddress;
+        }
+
+        const indexer = new UnisatIndexer(NETWORK);
+        const balances = await indexer.getRuneBalances(resolvedAddress);
+
+        const formattedBalances = balances.map((b) => ({
+          rune: b.rune,
+          runeId: b.runeid,
+          spacedRune: b.spacedRune,
+          amount: b.amount,
+          formatted: formatRuneAmount(b.amount, b.divisibility, b.symbol),
+          symbol: b.symbol,
+          divisibility: b.divisibility,
+        }));
+
+        return createJsonResponse({
+          address: resolvedAddress,
+          network: NETWORK,
+          balances: formattedBalances,
+          summary: { runeCount: balances.length },
+          explorerUrl: getMempoolAddressUrl(resolvedAddress, NETWORK),
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // --------------------------------------------------------------------------
+  // get_rune_utxos — Unisat: list UTXOs containing a specific rune
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "get_rune_utxos",
+    {
+      description:
+        "List UTXOs containing a specific rune at a Bitcoin address via the Unisat indexer.\n\n" +
+        "Rune ID format: 'block:tx' (e.g., '840000:1' for UNCOMMONGOODS).\n\n" +
+        "If no address is provided, uses the active wallet's Taproot address.",
+      inputSchema: {
+        runeId: z
+          .string()
+          .describe("Rune ID in 'block:tx' format (e.g., '840000:1')"),
+        address: z
+          .string()
+          .optional()
+          .describe(
+            "Bitcoin address to check (uses active wallet's Taproot address if omitted)"
+          ),
+      },
+    },
+    async ({ runeId, address }) => {
+      try {
+        let resolvedAddress = address;
+
+        if (!resolvedAddress) {
+          const walletManager = getWalletManager();
+          const sessionInfo = walletManager.getSessionInfo();
+          if (!sessionInfo?.taprootAddress) {
+            return createErrorResponse(
+              new Error(
+                "No address provided and wallet is not unlocked. " +
+                  "Either provide an address or unlock your wallet first."
+              )
+            );
+          }
+          resolvedAddress = sessionInfo.taprootAddress;
+        }
+
+        const indexer = new UnisatIndexer(NETWORK);
+        const utxos = await indexer.getRuneUtxos(resolvedAddress, runeId);
+
+        const formattedUtxos = utxos.map((u) => ({
+          txid: u.txid,
+          vout: u.vout,
+          satoshis: u.satoshi,
+          address: u.address,
+          height: u.height,
+          runes: u.runes.map((r) => ({
+            runeId: r.runeid,
+            spacedRune: r.spacedRune,
+            amount: r.amount,
+            formatted: formatRuneAmount(r.amount, r.divisibility, r.symbol),
+            symbol: r.symbol,
+          })),
+        }));
+
+        return createJsonResponse({
+          address: resolvedAddress,
+          network: NETWORK,
+          runeId,
+          utxos: formattedUtxos,
+          summary: {
+            utxoCount: utxos.length,
+            totalSatoshis: utxos.reduce((sum, u) => sum + u.satoshi, 0),
+          },
+          explorerUrl: getMempoolAddressUrl(resolvedAddress, NETWORK),
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // --------------------------------------------------------------------------
+  // transfer_rune — build and broadcast a rune transfer via Runestone OP_RETURN
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "transfer_rune",
+    {
+      description:
+        "Transfer runes to a recipient address using Runestone OP_RETURN encoding.\n\n" +
+        "Builds a Bitcoin transaction with a Runestone, sends runes to the recipient, " +
+        "and returns remaining runes to the sender Taproot address.\n\n" +
+        "Requires wallet to be unlocked. Amount is in smallest rune units (raw integer).\n" +
+        "Uses Unisat indexer to fetch rune UTXOs (UNISAT_API_KEY recommended).",
+      inputSchema: {
+        runeId: z
+          .string()
+          .describe("Rune ID in 'block:tx' format (e.g., '840000:1')"),
+        amount: z
+          .string()
+          .describe("Amount of runes to transfer in smallest unit (integer string, e.g., '1000')"),
+        toAddress: z
+          .string()
+          .describe("Recipient Bitcoin address"),
+        feeRate: z
+          .union([z.enum(["fast", "medium", "slow"]), z.number().positive()])
+          .optional()
+          .describe(
+            "Fee rate: 'fast' (~10 min), 'medium' (~30 min), 'slow' (~1 hr), or sat/vB number (default: medium)"
+          ),
+      },
+    },
+    async ({ runeId, amount, toAddress, feeRate }) => {
+      try {
+        const walletManager = getWalletManager();
+        const account = walletManager.getAccount();
+
+        if (!account) {
+          return createErrorResponse(
+            new Error("Wallet is not unlocked. Use wallet_unlock first.")
+          );
+        }
+
+        if (
+          !account.btcAddress ||
+          !account.btcPrivateKey ||
+          !account.btcPublicKey ||
+          !account.taprootPrivateKey ||
+          !account.taprootPublicKey ||
+          !account.taprootAddress
+        ) {
+          return createErrorResponse(
+            new Error(
+              "Bitcoin and Taproot keys not available. Please unlock your wallet again."
+            )
+          );
+        }
+
+        const transferAmount = BigInt(amount);
+        if (transferAmount <= 0n) {
+          return createErrorResponse(new Error("amount must be a positive integer"));
+        }
+
+        const indexer = new UnisatIndexer(NETWORK);
+        const mempoolApi = new MempoolApi(NETWORK);
+
+        // Resolve fee rate
+        let actualFeeRate: number;
+        if (typeof feeRate === "string" || feeRate === undefined) {
+          const fees = await mempoolApi.getFeeEstimates();
+          if (!feeRate || feeRate === "medium") actualFeeRate = fees.halfHourFee;
+          else if (feeRate === "fast") actualFeeRate = fees.fastestFee;
+          else actualFeeRate = fees.hourFee;
+        } else {
+          actualFeeRate = feeRate;
+        }
+
+        const runeUtxos = await indexer.getRuneUtxos(account.taprootAddress, runeId);
+        if (runeUtxos.length === 0) {
+          return createErrorResponse(
+            new Error(
+              `No UTXOs found for rune ${runeId} at address ${account.taprootAddress}`
+            )
+          );
+        }
+
+        const runeUtxosFormatted = runeUtxos.map((u) => ({
+          txid: u.txid,
+          vout: u.vout,
+          value: u.satoshi,
+          status: { confirmed: true, block_height: u.height, block_hash: "", block_time: 0 },
+        }));
+
+        const cardinalUtxos = await indexer.getCardinalUtxos(account.btcAddress);
+        if (cardinalUtxos.length === 0) {
+          return createErrorResponse(
+            new Error(
+              `No cardinal UTXOs available at ${account.btcAddress} to pay fees. ` +
+                `Send some BTC to your SegWit address first.`
+            )
+          );
+        }
+
+        const transferResult = buildRuneTransfer({
+          runeId,
+          amount: transferAmount,
+          runeUtxos: runeUtxosFormatted,
+          feeUtxos: cardinalUtxos,
+          recipientAddress: toAddress,
+          feeRate: actualFeeRate,
+          senderPubKey: account.btcPublicKey,
+          senderTaprootPubKey: account.taprootPublicKey,
+          senderAddress: account.btcAddress,
+          senderTaprootAddress: account.taprootAddress,
+          network: NETWORK,
+        });
+
+        const signed = signRuneTransfer(
+          transferResult.tx,
+          account.taprootPrivateKey,
+          account.btcPrivateKey,
+          transferResult.taprootInputIndices,
+          transferResult.feeInputIndices
+        );
+
+        const txid = await mempoolApi.broadcastTransaction(signed.txHex);
+
+        return createJsonResponse({
+          success: true,
+          txid,
+          explorerUrl: getMempoolTxUrl(txid, NETWORK),
+          rune: { runeId, amount },
+          recipient: toAddress,
+          fee: { satoshis: transferResult.fee, rateUsed: `${actualFeeRate} sat/vB` },
+          btcChange: { satoshis: transferResult.btcChange },
+          network: NETWORK,
+        });
       } catch (error) {
         return createErrorResponse(error);
       }

--- a/src/transactions/rune-transfer-builder.ts
+++ b/src/transactions/rune-transfer-builder.ts
@@ -1,0 +1,205 @@
+/**
+ * Rune Transfer Builder
+ *
+ * Builds a transaction to transfer runes from one address to another.
+ * Transaction structure:
+ * - P2TR inputs: rune UTXOs (signed with taproot key)
+ * - P2WPKH inputs: cardinal UTXOs for fees (signed with segwit key)
+ * - OP_RETURN output: Runestone with edict + change pointer
+ * - P2TR output: recipient receives runes (dust amount)
+ * - P2TR output: rune change back to sender (if partial transfer)
+ * - P2WPKH output: BTC change back to sender
+ */
+
+import * as btc from "@scure/btc-signer";
+import type { Network } from "../config/networks.js";
+import {
+  P2WPKH_INPUT_VBYTES,
+  P2WPKH_OUTPUT_VBYTES,
+  P2TR_OUTPUT_VBYTES,
+  P2TR_INPUT_BASE_VBYTES,
+  TX_OVERHEAD_VBYTES,
+  DUST_THRESHOLD,
+} from "../config/bitcoin-constants.js";
+import type { UTXO } from "../services/mempool-api.js";
+import { buildRunestoneScript, parseRuneId, type RuneEdict } from "./runestone-builder.js";
+
+export interface RuneTransferOptions {
+  runeId: string;
+  amount: bigint;
+  runeUtxos: UTXO[];
+  feeUtxos: UTXO[];
+  recipientAddress: string;
+  feeRate: number;
+  senderPubKey: Uint8Array;
+  senderTaprootPubKey: Uint8Array;
+  senderAddress: string;
+  senderTaprootAddress: string;
+  network: Network;
+}
+
+export interface RuneTransferResult {
+  tx: btc.Transaction;
+  fee: number;
+  btcChange: number;
+  vsize: number;
+  taprootInputIndices: number[];
+  feeInputIndices: number[];
+}
+
+function getBtcNetwork(network: Network): typeof btc.NETWORK {
+  return network === "testnet" ? btc.TEST_NETWORK : btc.NETWORK;
+}
+
+const OP_RETURN_VBYTES = 50;
+
+export function buildRuneTransfer(options: RuneTransferOptions): RuneTransferResult {
+  const {
+    runeId,
+    amount,
+    runeUtxos,
+    feeUtxos,
+    recipientAddress,
+    feeRate,
+    senderPubKey,
+    senderTaprootPubKey,
+    senderAddress,
+    senderTaprootAddress,
+    network,
+  } = options;
+
+  if (runeUtxos.length === 0) throw new Error("No rune UTXOs provided");
+  if (feeUtxos.length === 0) throw new Error("No fee UTXOs provided");
+  if (feeRate <= 0) throw new Error("Fee rate must be positive");
+  if (amount <= 0n) throw new Error("Amount must be positive");
+
+  const btcNetwork = getBtcNetwork(network);
+  const tx = new btc.Transaction();
+
+  const { block, txIndex } = parseRuneId(runeId);
+
+  // Rune UTXOs (P2TR inputs)
+  const taprootPayment = btc.p2tr(senderTaprootPubKey, undefined, btcNetwork);
+  const taprootInputIndices: number[] = [];
+
+  for (let i = 0; i < runeUtxos.length; i++) {
+    const utxo = runeUtxos[i];
+    tx.addInput({
+      txid: utxo.txid,
+      index: utxo.vout,
+      witnessUtxo: { script: taprootPayment.script, amount: BigInt(utxo.value) },
+    });
+    taprootInputIndices.push(i);
+  }
+
+  // Fee UTXOs (P2WPKH inputs)
+  const senderP2wpkh = btc.p2wpkh(senderPubKey, btcNetwork);
+  const sortedFeeUtxos = [...feeUtxos]
+    .filter((u) => u.status.confirmed)
+    .sort((a, b) => b.value - a.value);
+
+  if (sortedFeeUtxos.length === 0) throw new Error("No confirmed fee UTXOs available");
+
+  const selectedFeeUtxos: UTXO[] = [];
+  let feeTotal = 0;
+  const feeInputIndices: number[] = [];
+
+  for (const utxo of sortedFeeUtxos) {
+    selectedFeeUtxos.push(utxo);
+    feeTotal += utxo.value;
+
+    const estimatedVsize =
+      TX_OVERHEAD_VBYTES +
+      runeUtxos.length * P2TR_INPUT_BASE_VBYTES +
+      selectedFeeUtxos.length * P2WPKH_INPUT_VBYTES +
+      OP_RETURN_VBYTES +
+      P2TR_OUTPUT_VBYTES + // recipient
+      P2TR_OUTPUT_VBYTES + // rune change
+      P2WPKH_OUTPUT_VBYTES; // BTC change
+
+    if (feeTotal >= Math.ceil(estimatedVsize * feeRate) + DUST_THRESHOLD) {
+      break;
+    }
+  }
+
+  const feeInputStartIdx = runeUtxos.length;
+  for (let i = 0; i < selectedFeeUtxos.length; i++) {
+    const utxo = selectedFeeUtxos[i];
+    tx.addInput({
+      txid: utxo.txid,
+      index: utxo.vout,
+      witnessUtxo: { script: senderP2wpkh.script, amount: BigInt(utxo.value) },
+    });
+    feeInputIndices.push(feeInputStartIdx + i);
+  }
+
+  // Outputs:
+  // 0: OP_RETURN Runestone
+  // 1: Recipient
+  // 2: Rune change (sender taproot)
+  // 3: BTC change (sender segwit)
+
+  const edict: RuneEdict = { block, txIndex, amount, outputIndex: 1 };
+  const runestoneScript = buildRunestoneScript({ edict, changeOutput: 2 });
+
+  tx.addOutput({ script: runestoneScript, amount: 0n });
+  tx.addOutputAddress(recipientAddress, BigInt(DUST_THRESHOLD), btcNetwork);
+
+  const runeSats = runeUtxos.reduce((sum, u) => sum + u.value, 0);
+  const runeChangeSats = runeSats - DUST_THRESHOLD;
+  if (runeChangeSats >= DUST_THRESHOLD) {
+    tx.addOutputAddress(senderTaprootAddress, BigInt(runeChangeSats), btcNetwork);
+  }
+
+  const actualOutputCount = 3 + (runeChangeSats >= DUST_THRESHOLD ? 1 : 0);
+  const finalVsize =
+    TX_OVERHEAD_VBYTES +
+    runeUtxos.length * P2TR_INPUT_BASE_VBYTES +
+    selectedFeeUtxos.length * P2WPKH_INPUT_VBYTES +
+    OP_RETURN_VBYTES +
+    (actualOutputCount - 1) * P2TR_OUTPUT_VBYTES +
+    P2WPKH_OUTPUT_VBYTES;
+
+  const finalFee = Math.ceil(finalVsize * feeRate);
+  const btcChange = feeTotal - finalFee;
+
+  if (btcChange < 0) {
+    throw new Error(
+      `Insufficient fee UTXOs: have ${feeTotal} sats, need ${finalFee} sats for fee`
+    );
+  }
+
+  if (btcChange >= DUST_THRESHOLD) {
+    tx.addOutputAddress(senderAddress, BigInt(btcChange), btcNetwork);
+  }
+
+  return {
+    tx,
+    fee: finalFee,
+    btcChange: btcChange >= DUST_THRESHOLD ? btcChange : 0,
+    vsize: Math.ceil(finalVsize),
+    taprootInputIndices,
+    feeInputIndices,
+  };
+}
+
+/**
+ * Sign a rune transfer transaction with mixed key types (P2TR + P2WPKH).
+ */
+export function signRuneTransfer(
+  tx: btc.Transaction,
+  taprootPrivateKey: Uint8Array,
+  btcPrivateKey: Uint8Array,
+  taprootInputIndices: number[],
+  feeInputIndices: number[]
+): { txHex: string; txid: string; vsize: number } {
+  for (const idx of taprootInputIndices) {
+    tx.signIdx(taprootPrivateKey, idx);
+  }
+  for (const idx of feeInputIndices) {
+    tx.signIdx(btcPrivateKey, idx);
+  }
+  tx.finalize();
+
+  return { txHex: tx.hex, txid: tx.id, vsize: tx.vsize };
+}

--- a/src/transactions/runestone-builder.ts
+++ b/src/transactions/runestone-builder.ts
@@ -1,0 +1,107 @@
+/**
+ * Runestone Builder
+ *
+ * Minimal Runestone OP_RETURN encoder for single-edict rune transfers.
+ * Encodes a Runestone message as an OP_RETURN output script.
+ *
+ * Protocol spec: https://docs.ordinals.com/runes.html
+ */
+
+// ---------------------------------------------------------------------------
+// LEB128 encoding
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode a bigint as unsigned LEB128 bytes.
+ */
+export function encodeLEB128(value: bigint): Uint8Array {
+  if (value < 0n) throw new Error("LEB128 only encodes unsigned values");
+
+  const bytes: number[] = [];
+  do {
+    let byte = Number(value & 0x7fn);
+    value >>= 7n;
+    if (value !== 0n) {
+      byte |= 0x80;
+    }
+    bytes.push(byte);
+  } while (value !== 0n);
+
+  return new Uint8Array(bytes);
+}
+
+// ---------------------------------------------------------------------------
+// Runestone encoding
+// ---------------------------------------------------------------------------
+
+export interface RuneEdict {
+  /** Rune ID block height (e.g., 840000) */
+  block: bigint;
+  /** Rune ID transaction index within block */
+  txIndex: bigint;
+  /** Amount of runes to transfer (in smallest unit) */
+  amount: bigint;
+  /** Output index to send runes to */
+  outputIndex: number;
+}
+
+export interface RunestoneOptions {
+  edict: RuneEdict;
+  /** Output index for remaining rune balance (change pointer) */
+  changeOutput: number;
+}
+
+/**
+ * Build a Runestone OP_RETURN script for a single-edict rune transfer.
+ * Always includes an explicit change pointer to avoid burning remaining runes.
+ */
+export function buildRunestoneScript(options: RunestoneOptions): Uint8Array {
+  const { edict, changeOutput } = options;
+
+  const parts: Uint8Array[] = [];
+
+  // Tag 0: edicts body
+  const tag0 = encodeLEB128(0n);
+  parts.push(tag0, encodeLEB128(edict.block));
+  parts.push(tag0, encodeLEB128(edict.txIndex));
+  parts.push(tag0, encodeLEB128(edict.amount));
+  parts.push(tag0, encodeLEB128(BigInt(edict.outputIndex)));
+
+  // Tag 22: default output (change pointer)
+  parts.push(encodeLEB128(22n), encodeLEB128(BigInt(changeOutput)));
+
+  const payloadLength = parts.reduce((sum, p) => sum + p.length, 0);
+
+  // OP_RETURN (0x6a) OP_13 (0x5d) <pushdata>
+  const script: number[] = [0x6a, 0x5d];
+
+  if (payloadLength < 76) {
+    script.push(payloadLength);
+  } else if (payloadLength < 256) {
+    script.push(0x4c, payloadLength);
+  } else {
+    script.push(0x4d, payloadLength & 0xff, (payloadLength >> 8) & 0xff);
+  }
+
+  for (const part of parts) {
+    for (const byte of part) {
+      script.push(byte);
+    }
+  }
+
+  return new Uint8Array(script);
+}
+
+/**
+ * Parse a rune ID string (e.g., "840000:1") into block and tx components.
+ */
+export function parseRuneId(runeId: string): { block: bigint; txIndex: bigint } {
+  const [blockStr, txStr] = runeId.split(":");
+  if (!blockStr || !txStr) {
+    throw new Error(`Invalid rune ID format: "${runeId}". Expected "block:tx" (e.g., "840000:1")`);
+  }
+  return {
+    block: BigInt(blockStr),
+    txIndex: BigInt(txStr),
+  };
+}


### PR DESCRIPTION
## Summary

The squash merge of PR #377 only captured the first commit (6 Hiro read-only rune tools). This PR restores the second commit's additions that were dropped during the rebase:

- `src/services/unisat-indexer.ts`: Unisat Open API client for rune balances, UTXOs, and inscription data
- `src/transactions/runestone-builder.ts`: LEB128 Runestone OP_RETURN encoder for single-edict transfers
- `src/transactions/rune-transfer-builder.ts`: builds and signs mixed P2TR+P2WPKH rune transfer transactions
- `src/tools/runes.tools.ts`: extended with `get_rune_balances`, `get_rune_utxos`, `transfer_rune` wallet tools
- `src/tools/skill-mappings.ts`: restored `bounty-scanner` entries (inadvertently dropped) + added rune wallet tool mappings

## Test plan

- [ ] Verify `src/services/unisat-indexer.ts` exists and exports `UnisatIndexer` class
- [ ] Verify `src/transactions/runestone-builder.ts` exports `buildRunestoneScript`, `encodeLEB128`, `parseRuneId`
- [ ] Verify `src/transactions/rune-transfer-builder.ts` exports `buildRuneTransfer`, `signRuneTransfer`
- [ ] Verify `src/tools/runes.tools.ts` includes `get_rune_balances`, `get_rune_utxos`, `transfer_rune` tools
- [ ] Verify skill-mappings contains both `bounty-scanner` and full `runes` wallet tool entries
- [ ] CI passes (build + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)