### PR TITLE
Fix noble-hashes startup crash in published package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@faktoryfun/styx-sdk": "^1.3.5",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
         "@scure/base": "^2.0.0",
         "@scure/bip32": "^1.4.0",
         "@scure/bip39": "^2.0.1",
@@ -623,7 +624,7 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+    "node_modules/@noble/hashes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
@@ -634,18 +635,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
-      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@noble/secp256k1": {
       "version": "1.7.2",
@@ -1081,18 +1070,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@scure/btc-signer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@scure/btc-signer/-/btc-signer-2.0.1.tgz",
@@ -1103,18 +1080,6 @@
         "@noble/hashes": "~2.0.0",
         "@scure/base": "~2.0.0",
         "micro-packed": "~0.8.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/btc-signer/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1194,6 +1159,18 @@
         "ripemd160-min": "^0.0.6",
         "varuint-bitcoin": "^1.1.2"
       }
+    },
+    "node_modules/@stacks/encryption/node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@stacks/encryption/node_modules/@noble/secp256k1": {
       "version": "1.7.1",
@@ -1341,6 +1318,18 @@
         "lodash.clonedeep": "^4.5.0"
       }
     },
+    "node_modules/@stacks/transactions-v6/node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@stacks/transactions-v6/node_modules/@noble/secp256k1": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
@@ -1388,6 +1377,18 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/@stacks/transactions/node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@stacks/transactions/node_modules/@noble/secp256k1": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
@@ -1419,6 +1420,18 @@
         "jsontokens": "^4.0.1",
         "zone-file": "^2.0.0-beta.3"
       }
+    },
+    "node_modules/@stacks/wallet-sdk/node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@stacks/wallet-sdk/node_modules/@scure/base": {
       "version": "1.1.9",
@@ -1881,6 +1894,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/c32check/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2773,6 +2798,18 @@
         "base64-js": "^1.5.1"
       }
     },
+    "node_modules/jsontokens/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
@@ -2951,18 +2988,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/nostr-tools/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/nostr-tools/node_modules/@scure/bip32": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@faktoryfun/styx-sdk": "^1.3.5",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@noble/curves": "^2.0.1",
+    "@noble/hashes": "^2.0.1",
     "@scure/base": "^2.0.0",
     "@scure/bip32": "^1.4.0",
     "@scure/bip39": "^2.0.1",

--- a/src/tools/ordinals-p2p.tools.ts
+++ b/src/tools/ordinals-p2p.tools.ts
@@ -20,8 +20,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
-import { sha256 } from "@noble/hashes/sha256";
-import { hexToBytes } from "@noble/hashes/utils";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hexToBytes } from "@noble/hashes/utils.js";
 import { NETWORK } from "../config/networks.js";
 import { getWalletManager } from "../services/wallet-manager.js";
 import { createJsonResponse, createErrorResponse } from "../utils/index.js";


### PR DESCRIPTION
## Summary
Fix startup crashes caused by the published ordinals P2P tool importing non-exported `@noble/hashes` v2 subpaths without declaring `@noble/hashes` as a direct dependency.

Closes #379.

## Changes
- add direct dependency on `@noble/hashes@^2.0.1`
- update `ordinals-p2p.tools.ts` imports to the v2 export paths:
  - `@noble/hashes/sha2.js`
  - `@noble/hashes/utils.js`

## Why
The published package was importing:
- `@noble/hashes/sha256`
- `@noble/hashes/utils`

Those subpaths are not exported by `@noble/hashes@2.x`, and the repo also did not declare `@noble/hashes` directly, which made local resolution inconsistent.

## Verification
- `npm run build`
- `node dist/index.js`
- packed tarball smoke test:
  - `npm pack`
  - install tarball in a clean temp project
  - `npx aibtc-mcp-server --help`

All three now start cleanly without the `ERR_PACKAGE_PATH_NOT_EXPORTED` crash.
