### PR TITLE
feat(jingswap): update contract names to sbtc-stx-jing / sbtc-usdcx-jing

### DIFF
--- a/src/tools/jingswap.tools.ts
+++ b/src/tools/jingswap.tools.ts
@@ -510,6 +510,14 @@ export function registerJingswapTools(server: McpServer): void {
         if (data.phase === 0) {
           throw new Error("Cannot settle — auction is still in deposit phase. Close deposits first.");
         }
+        if (data.phase === 1) {
+          const BUFFER_BLOCKS = 30;
+          const blocksIntoBuffer = data.blocksElapsed - 150;
+          const blocksRemaining = Math.max(0, BUFFER_BLOCKS - blocksIntoBuffer);
+          throw new Error(
+            `Cannot settle — auction is in buffer phase. Wait ${blocksRemaining} more blocks (~${blocksRemaining * 2}s) before settling.`
+          );
+        }
         const account = await getAccount();
 
         const result = await callContract(account, {
@@ -564,6 +572,14 @@ export function registerJingswapTools(server: McpServer): void {
         const data = await jingswapGet(`/api/auction/cycle-state${apiContractParam(m)}`);
         if (data.phase === 0) {
           throw new Error("Cannot settle — auction is still in deposit phase. Close deposits first.");
+        }
+        if (data.phase === 1) {
+          const BUFFER_BLOCKS = 30;
+          const blocksIntoBuffer = data.blocksElapsed - 150;
+          const blocksRemaining = Math.max(0, BUFFER_BLOCKS - blocksIntoBuffer);
+          throw new Error(
+            `Cannot settle — auction is in buffer phase. Wait ${blocksRemaining} more blocks (~${blocksRemaining * 2}s) before settling.`
+          );
         }
 
         // Fetch fresh Pyth VAAs from backend


### PR DESCRIPTION
## Summary
- Update MCP tool market configs from sbtc-stx-jingswap to sbtc-stx-jing / sbtc-usdcx-jing
- Fix wormhole-core-v2 → wormhole-core-v4 for settle-with-refresh
- Fix close-deposits to use PostConditionMode.Deny with empty post-conditions
- Add buffer phase check before settle — tells user how many blocks to wait

New contracts: SPV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RCJDC22.sbtc-stx-jing and SPV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RCJDC22.sbtc-usdcx-jing

## Tested on mainnet (both markets)
Deposit, cancel, close-deposits, settle-with-refresh all verified working on both sbtc-stx and sbtc-usdcx markets.