### PR TITLE
fix: x402 payment flow — eliminate redundant probe, add 429 retry

### DIFF
--- a/src/services/x402.service.ts
+++ b/src/services/x402.service.ts
@@ -97,9 +97,12 @@ function createBaseAxiosInstance(baseURL?: string): AxiosInstance {
   );
 
   // Handle 429 Too Many Requests with Retry-After header parsing and exponential backoff.
-  // Max 2 retries with minimum delays [2s, 5s] or the Retry-After value if larger.
-  // Runs before payment interceptors so payment flows benefit automatically.
+  // Max 2 retries with minimum delays [2s, 5s]. If Retry-After exceeds the cap (30s),
+  // skip retries and immediately surface the error so interactive calls aren't blocked.
+  // Runs before payment interceptors (response interceptors are FIFO) so payment flows
+  // benefit automatically.
   const MAX_RETRY_DELAYS_MS = [2000, 5000];
+  const MAX_RETRY_AFTER_CAP_S = 30;
   instance.interceptors.response.use(
     (response) => {
       // Reset retry counter on success so later 429s get the full retry budget
@@ -117,9 +120,19 @@ function createBaseAxiosInstance(baseURL?: string): AxiosInstance {
       const parsed = parseInt(error.response.headers?.["retry-after"] ?? "", 10);
       const retryAfterSeconds = isNaN(parsed) ? 0 : parsed;
 
+      // If the server says to wait longer than our cap, don't block — fail immediately
+      if (retryAfterSeconds > MAX_RETRY_AFTER_CAP_S) {
+        return Promise.reject(
+          new X402RateLimitError(
+            `x402 endpoint rate limit exceeded. Server requested ${retryAfterSeconds}s wait (exceeds ${MAX_RETRY_AFTER_CAP_S}s cap). ` +
+              `Retry after ${retryAfterSeconds}s.`,
+            retryAfterSeconds
+          )
+        );
+      }
+
       if (retries >= MAX_RETRY_DELAYS_MS.length) {
-        // Report the server's Retry-After if available, otherwise a sensible default
-        const reportSeconds = retryAfterSeconds > 0 ? retryAfterSeconds : 60;
+        const reportSeconds = retryAfterSeconds > 0 ? retryAfterSeconds : 10;
         return Promise.reject(
           new X402RateLimitError(
             `x402 endpoint rate limit exceeded. All retries exhausted. ` +

--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -335,18 +335,26 @@ For aibtc.com inbox messages, use send_inbox_message instead — it uses sponsor
         });
         const response = await api.request({ method, url: parsed.requestPath, params, data });
 
-        const txid = (response.data as { txid?: string })?.txid ||
+        const rawTxid = (response.data as { txid?: string })?.txid ||
                      response.headers?.['x-transaction-id'] ||
-                     'unknown';
-        // Only record dedup entry if a payment was actually made (txid present)
-        if (txid !== 'unknown') {
+                     undefined;
+
+        // Detect whether a payment was made by checking for the payment-signature
+        // header added by the x402 interceptor. This is more reliable than checking
+        // for a txid, which some endpoints may not return.
+        const paymentSigHeader = (response as { config?: { headers?: Record<string, string> } })
+          .config?.headers?.[X402_HEADERS.PAYMENT_SIGNATURE];
+        const paymentAttempted = Boolean(paymentSigHeader);
+        const txid = rawTxid ?? (paymentAttempted ? `unknown-txid-${Date.now()}` : undefined);
+
+        if (paymentAttempted && txid) {
           recordTransaction(dedupKey, txid);
         }
 
         return createJsonResponse({
           endpoint: `${method} ${fullUrl}`,
           response: response.data,
-          ...(txid !== 'unknown' && { txid }),
+          ...(txid && { txid }),
         });
       } catch (error) {
         const label = fullUrl || url || path || "unknown";


### PR DESCRIPTION
## Summary

Client-side fixes for #394 — agents get rate-limited after 2-3 paid x402 API calls.

- **Eliminate redundant probe**: `autoApprove: true` previously sent a separate probe request before the payment-enabled client (which handles 402 natively). Added `onBeforePayment` callback to the payment interceptor for inline balance validation, cutting HTTP requests from 2 to 1 per paid call.
- **Add 429 retry with backoff**: New response interceptor parses `Retry-After` headers and retries up to 2 times with delays [2s, 5s]. Includes `X402RateLimitError` for clear error surfacing.
- **Simplifier fixes**: Reset retry counter on success, use backoff delays when Retry-After header is absent (was defaulting to 60s), pass account through callback to avoid redundant `getAccount()` call.

## Root Cause

The MCP x402 flow had two compounding issues:
1. Each `autoApprove: true` call sent 2 requests (probe + payment) instead of 1
2. Zero 429 awareness — if rate-limited, just failed with no retry or guidance

Combined with the server-side fix in aibtcdev/agent-news (exempting probes from rate limits), this eliminates the blocking behavior from #394.

## Test plan

- [ ] Verify `autoApprove: true` sends only 1 HTTP request to the endpoint (not 2)
- [ ] Verify 429 responses are retried with appropriate backoff
- [ ] Verify `X402RateLimitError` surfaces retry-after info after retries exhausted
- [ ] Verify balance validation still works via `onBeforePayment` callback
- [ ] Verify TypeScript compiles (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)