### PR TITLE
fix(x402): break payment interceptor spiral, surface errors, extract payment_txid

### DIFF
--- a/src/services/x402.service.ts
+++ b/src/services/x402.service.ts
@@ -114,6 +114,14 @@ function createBaseAxiosInstance(baseURL?: string): AxiosInstance {
         return Promise.reject(error);
       }
 
+      // Never retry 429s once a payment has been attempted on this instance.
+      // Without this guard, a spiral forms: the 429 retry re-enters the full
+      // interceptor chain, triggers a new 402 → payment → 429 → retry loop
+      // that fires onBeforePayment repeatedly and drains the rate-limit budget.
+      if (paymentAttempts.get(instance)) {
+        return Promise.reject(error);
+      }
+
       const retries = rateLimitRetries.get(instance) ?? 0;
 
       // Parse Retry-After header; default to 0 when absent so the backoff delay governs
@@ -233,12 +241,19 @@ export async function createApiClient(baseUrl?: string, options?: CreateApiClien
       const attempts = paymentAttempts.get(axiosInstance) || 0;
 
       if (attempts >= 1) {
-        // Reject retry - payment already attempted once
-        return Promise.reject(
-          new Error(
-            "Payment retry limit exceeded (max 1 attempt). This endpoint may have payment/settlement issues. Check balance and try again."
-          )
+        // Reject retry - payment already attempted once.
+        // Include the second 402's response details so callers can see WHY settlement failed.
+        // IMPORTANT: Do NOT copy error.response onto retryError — the payment handler
+        // (Interceptor 2) checks error.response?.status === 402 and would re-process it,
+        // creating an infinite loop. Only copy .config for txid recovery via payment-signature header.
+        const settleDetails = error.response?.data
+          ? ` Settlement response: ${JSON.stringify(error.response.data)}`
+          : '';
+        const retryError = new Error(
+          `Payment retry limit exceeded (max 1 attempt). The endpoint returned 402 again after payment, meaning settlement failed.${settleDetails}`
         );
+        (retryError as any).config = error.config;
+        return Promise.reject(retryError);
       }
 
       // Increment counter and pass through to the native payment interceptor

--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -335,7 +335,8 @@ For aibtc.com inbox messages, use send_inbox_message instead — it uses sponsor
         });
         const response = await api.request({ method, url: parsed.requestPath, params, data });
 
-        const rawTxid = (response.data as { txid?: string })?.txid ||
+        const rawTxid = (response.data as { txid?: string; payment_txid?: string })?.txid ||
+                     (response.data as { payment_txid?: string })?.payment_txid ||
                      response.headers?.['x-transaction-id'] ||
                      undefined;
 

--- a/tests/scripts/test-x402-classifieds.ts
+++ b/tests/scripts/test-x402-classifieds.ts
@@ -1,0 +1,195 @@
+/**
+ * Test x402 payment flow against aibtc.news classifieds endpoint.
+ *
+ * Uses direct fetch (like test-sponsored-inbox.ts) instead of the
+ * axios interceptor chain — simpler, no retry spiral risk.
+ *
+ * Flow: POST → 402 → parse requirements → build sponsored tx → encode payload → POST with payment header
+ *
+ * Modes:
+ *   --dry-run   (default) Probe only — shows payment requirements without paying
+ *   --pay       Execute full flow — pays 30k sats sBTC
+ *
+ * Usage:
+ *   TEST_WALLET_PASSWORD=<password> TEST_WALLET_NAME=<name> npx tsx tests/scripts/test-x402-classifieds.ts [--dry-run|--pay]
+ */
+
+import {
+  makeContractCall,
+  uintCV,
+  principalCV,
+  noneCV,
+} from "@stacks/transactions";
+import { decodePaymentRequired, encodePaymentPayload, X402_HEADERS } from "x402-stacks";
+import { getWalletManager, type WalletManager } from "../../src/services/wallet-manager.js";
+import { getAccount, NETWORK, checkSufficientBalance } from "../../src/services/x402.service.js";
+import { getStacksNetwork } from "../../src/config/networks.js";
+import { getContracts, parseContractId } from "../../src/config/contracts.js";
+
+const CLASSIFIEDS_URL = "https://aibtc.news/api/classifieds";
+
+const TEST_CLASSIFIED = {
+  category: "agents",
+  headline: "AIBTC MCP Server — give your AI agent a Bitcoin wallet and 200+ tools",
+  body: "npx @aibtc/mcp-server@latest --install. Trade on ALEX, Zest, Bitflow. Transfer STX/BTC. File signals on aibtc.news. Deploy x402 paid APIs. All from Claude Code or any MCP client.",
+};
+
+const WALLET_PASSWORD = process.env.TEST_WALLET_PASSWORD || "";
+const WALLET_NAME = process.env.TEST_WALLET_NAME || "";
+const PAY_MODE = process.argv.includes("--pay");
+
+async function main() {
+  if (!WALLET_PASSWORD) {
+    console.error("Set TEST_WALLET_PASSWORD env var");
+    process.exit(1);
+  }
+
+  // 1. Unlock wallet
+  console.log("[1] Unlocking wallet...");
+  const wm = getWalletManager();
+  const wallets = await wm.listWallets();
+  if (wallets.length === 0) throw new Error("No wallets found");
+  console.log("  available wallets:", wallets.map(w => `${w.name} (${w.id})`).join(", "));
+  const target = WALLET_NAME
+    ? wallets.find(w => w.name === WALLET_NAME) || wallets[0]
+    : wallets[0];
+  console.log("  using wallet:", target.name, `(${target.id})`);
+  await wm.unlock(target.id, WALLET_PASSWORD);
+  const account = await getAccount();
+  const btcAddress = wm.getSessionInfo()?.btcAddress;
+  console.log("  address:", account.address);
+  console.log("  btcAddress:", btcAddress);
+  console.log("  network:", account.network);
+
+  // Build body with btc_address (required by classifieds API)
+  const postBody = { ...TEST_CLASSIFIED, btc_address: btcAddress };
+
+  // 2. POST without payment → 402
+  console.log("\n[2] POST without payment...");
+  const initialRes = await fetch(CLASSIFIEDS_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(postBody),
+    signal: AbortSignal.timeout(30000),
+  });
+  console.log("  status:", initialRes.status);
+
+  if (initialRes.status !== 402) {
+    console.log("  body:", await initialRes.text());
+    console.log("  Expected 402, got", initialRes.status);
+    return;
+  }
+
+  // 3. Parse payment requirements
+  console.log("\n[3] Parsing payment-required header...");
+  const paymentHeader = initialRes.headers.get(X402_HEADERS.PAYMENT_REQUIRED);
+  if (!paymentHeader) throw new Error("Missing payment-required header");
+  const paymentRequired = decodePaymentRequired(paymentHeader);
+  if (!paymentRequired?.accepts?.length) throw new Error("No accepted payment methods");
+  const accept = paymentRequired.accepts[0];
+  const amount = BigInt(accept.amount);
+  console.log("  amount:", accept.amount, "asset:", accept.asset);
+  console.log("  payTo:", accept.payTo);
+  console.log("  network:", accept.network);
+
+  // 4. Balance check
+  console.log("\n[4] Balance check...");
+  await checkSufficientBalance(account, accept.amount, accept.asset, true);
+  console.log("  OK — sufficient balance");
+
+  if (!PAY_MODE) {
+    console.log("\n  DRY RUN — skipping payment. Use --pay to execute.");
+    console.log("\nPROBE TEST PASSED");
+    return;
+  }
+
+  // 5. Build sponsored sBTC transfer
+  console.log("\n[5] Building sponsored tx...");
+  const contracts = getContracts(NETWORK);
+  const { address: contractAddress, name: contractName } = parseContractId(contracts.SBTC_TOKEN);
+  const transaction = await makeContractCall({
+    contractAddress,
+    contractName,
+    functionName: "transfer",
+    functionArgs: [
+      uintCV(amount),
+      principalCV(account.address),
+      principalCV(accept.payTo),
+      noneCV(),
+    ],
+    senderKey: account.privateKey,
+    network: getStacksNetwork(NETWORK),
+    sponsored: true,
+    fee: 0n,
+  });
+  const txHex = "0x" + transaction.serialize();
+  console.log("  txHex length:", txHex.length, "prefix:", txHex.substring(0, 12));
+
+  // 6. Encode PaymentPayloadV2
+  console.log("\n[6] Encoding PaymentPayloadV2...");
+  const resourceUrl = paymentRequired.resource?.url || CLASSIFIEDS_URL;
+  const paymentSignature = encodePaymentPayload({
+    x402Version: 2,
+    resource: {
+      url: resourceUrl,
+      description: paymentRequired.resource?.description || "",
+      mimeType: paymentRequired.resource?.mimeType || "application/json",
+    },
+    accepted: {
+      scheme: accept.scheme || "exact",
+      network: accept.network,
+      asset: accept.asset,
+      amount: accept.amount,
+      payTo: accept.payTo,
+      maxTimeoutSeconds: accept.maxTimeoutSeconds || 300,
+      extra: accept.extra || {},
+    },
+    payload: { transaction: txHex },
+  } as Parameters<typeof encodePaymentPayload>[0]);
+  console.log("  signature length:", paymentSignature.length);
+
+  // 7. POST with payment header
+  console.log("\n[7] Sending with payment-signature...");
+  const finalRes = await fetch(CLASSIFIEDS_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      [X402_HEADERS.PAYMENT_SIGNATURE]: paymentSignature,
+    },
+    body: JSON.stringify(postBody),
+    signal: AbortSignal.timeout(120000),
+  });
+
+  console.log("  status:", finalRes.status);
+  const responseData = await finalRes.text();
+  let parsed: unknown;
+  try { parsed = JSON.parse(responseData); } catch { parsed = responseData; }
+  console.log("  data:", JSON.stringify(parsed, null, 2));
+
+  const paymentResponse = finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE);
+  if (paymentResponse) {
+    try {
+      const decoded = JSON.parse(Buffer.from(paymentResponse, "base64").toString());
+      console.log("  payment-response:", JSON.stringify(decoded, null, 2));
+    } catch {
+      console.log("  payment-response (raw):", paymentResponse);
+    }
+  }
+
+  if (finalRes.status === 200 || finalRes.status === 201) {
+    console.log("\nSUCCESS — classified ad placed!");
+  } else {
+    // Log payment-required header if present (helps debug settlement failures)
+    const retryPaymentHeader = finalRes.headers.get(X402_HEADERS.PAYMENT_REQUIRED);
+    if (retryPaymentHeader) {
+      console.log("  payment-required header present (settlement rejected by relay)");
+    }
+    console.log("\nFAILED — status", finalRes.status);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("\nERROR:", err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Fix infinite loop between payment guard and payment handler interceptors
- Block 429 retries after payment has been attempted
- Surface settlement failure details in error messages
- Extract `payment_txid` from response for dedup tracking
- Add fetch-based test script for classifieds endpoint

## How we found this

While testing the new classifieds API on aibtc.news, every payment attempt failed. Investigation revealed:

1. **agent-news was using `/settle` instead of `/relay`** (aibtcdev/agent-news#215) — the relay's `/settle` endpoint doesn't sponsor transactions, but x402 clients build with `sponsored:true, fee:0` (empty sponsor auth). The relay rejected every tx with `signature_validation_failed`.

2. **agent-news returned 402 again** after the payment failed — a generic "Payment verification failed" with no error details (fixed by aibtcdev/agent-news#214 to surface relay reason).

3. **The MCP interceptor spiraled** — the payment guard tried to block the second 402 but its rejection error still had `.response.status = 402`, causing the payment handler to re-process it as a fresh 402. This looped 20+ times, exhausting the endpoint's rate limit (20 req/10min per IP) in seconds.

4. **The 429 retry handler made it worse** — when the rate limit hit, the 429 handler retried the request, which re-entered the payment flow, building yet another tx.

## Fixes

### 1. Don't copy `error.response` onto guard error (`x402.service.ts`)
The payment handler checks `.response?.status === 402` — copying the response made it think the guard's rejection was a fresh 402. Now only `.config` is copied (for txid recovery via payment-signature header).

### 2. Block 429 retries after payment (`x402.service.ts`)
Check `paymentAttempts.get(instance)` in the 429 handler — if a payment was already attempted, don't retry (the retry would just re-enter the payment flow).

### 3. Extract `payment_txid` from response (`endpoint.tools.ts`)
Some endpoints (e.g. aibtc.news classifieds) return the transaction ID as `payment_txid` instead of `txid`. Without this, the dedup cache stored `unknown-txid-{timestamp}`.

## Related
- Root cause (upstream): aibtcdev/agent-news#215
- Relay auto-sponsor fix: aibtcdev/x402-sponsor-relay#205
- Error surfacing: aibtcdev/agent-news#214

## Test plan
- [x] Verified spiral is broken: `onBeforePayment` fires exactly once
- [x] 429 handler blocks retry after payment
- [x] Settlement error details visible in error message
- [x] Successfully placed classified ad via `execute_x402_endpoint` MCP tool

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)