### PR TITLE
fix: news_file_signal disclosure + @noble/hashes build error

### DIFF
--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -396,7 +396,7 @@ Fields:
         if (body) {
           payload.body = body;
         }
-        if (disclosure) {
+        if (disclosure !== undefined) {
           payload.disclosure = disclosure;
         }
 


### PR DESCRIPTION
## Summary
- **#402**: Add optional `disclosure` parameter to `news_file_signal` tool — signals without disclosure get rejected by editors. The field passes through to the `POST /api/signals` body.
- **#403**: Fix `@noble/hashes` imports in `ordinals-p2p.tools.ts` — wrong module name (`sha2` → `sha256`) and drop `.js` extensions since the package uses subpath exports without them.

## Test plan
- [ ] `npm run build` passes with zero source errors
- [ ] Call `news_file_signal` with `disclosure: "claude-opus-4-6, aibtc MCP tools"` — verify it reaches the API
- [ ] Call `news_file_signal` without `disclosure` — verify it still works (field is optional)

Closes #402
Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)