### PR TITLE
fix(inbox): register send_inbox_message tool in registerAllTools (closes #407)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -40,6 +40,7 @@ import { registerCredentialsTools } from "./credentials.tools.js";
 import { registerSouldinalsTools } from "./souldinals.tools.js";
 import { registerBountyScannerTools } from "./bounty-scanner.tools.js";
 import { registerRunesTools } from "./runes.tools.js";
+import { registerInboxTools } from "./inbox.tools.js";
 import { getSkillForTool } from "./skill-mappings.js";
 
 /**
@@ -191,6 +192,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Runes (Bitcoin-native fungible tokens — list, query, holders, activity, balances)
   registerRunesTools(server);
+
+  // Inbox (AIBTC agent messaging — send paid inbox messages)
+  registerInboxTools(server);
 
   restoreRegisterTool();
 }


### PR DESCRIPTION
## Summary
- Adds missing import of `registerInboxTools` to `src/tools/index.ts`
- Adds `registerInboxTools(server)` call to `registerAllTools`

The `send_inbox_message` tool was defined and exported from `inbox.tools.ts` but never wired into the server — agents couldn't use it to send paid inbox messages.

closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)