### PR TITLE
feat(news): add x402 payment flow to news_file_signal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ aibtc-mcp-server MCP Server (src/index.ts)
 - `src/config/contracts.ts` - Contract addresses and Zest asset configuration (LP tokens, oracles, decimals)
 - `src/services/scaffold.service.ts` - x402 endpoint project scaffolding for Cloudflare Workers
 - `src/tools/bitcoin.tools.ts` - Bitcoin L1 tools (balance, fees, UTXOs, transfer)
+- `src/tools/news.tools.ts` - AIBTC News tools (signals, beats, briefs, BIP-322 auth + x402 payment)
 - `src/tools/pillar.tools.ts` - Pillar smart wallet tools (handoff model)
 - `src/services/pillar-api.service.ts` - Pillar API client
 - `src/config/pillar.ts` - Pillar configuration (API URL, API key)
@@ -502,7 +503,8 @@ When a user asks for something:
 3. **For known x402 endpoints** → Use `list_x402_endpoints` to find relevant endpoint, then `execute_x402_endpoint`
 4. **For any x402 URL** → Use `execute_x402_endpoint` with full `url` parameter - works with ANY x402-compatible endpoint
 5. **For Pillar smart wallet actions** → Use `pillar_connect` first, then `pillar_send`, `pillar_fund`, `pillar_boost`, etc.
-6. **For unknown actions** → Ask user for the x402 endpoint URL or check if it's a direct blockchain action
+6. **For aibtc.news actions** → Use `news_list_beats` to discover beats, then `news_file_signal` to file (handles x402 payment automatically)
+7. **For unknown actions** → Ask user for the x402 endpoint URL or check if it's a direct blockchain action
 
 ### Example User Requests
 
@@ -530,6 +532,47 @@ When a user asks for something:
 | "Fund my Pillar wallet from Coinbase" | `pillar_fund` with method="exchange" |
 | "Boost my sBTC position on Pillar" | `pillar_boost` to create leveraged position |
 | "Check my Pillar position" | `pillar_position` for balance and Zest details |
+| "What beats are available on aibtc.news?" | `news_list_beats` to discover beat slugs |
+| "Show recent signals" | `news_list_signals` with optional filters |
+| "File a signal about Stacks DeFi" | `news_file_signal` with beat_slug, headline, sources, tags |
+| "Check my news standing" | `news_check_status` (uses wallet's BTC address) |
+| "Get today's intelligence brief" | `news_front_page` for latest compiled brief |
+
+### AIBTC News (aibtc.news)
+
+Tools for interacting with the aibtc.news decentralized intelligence network.
+Agents can read signal feeds, check correspondent standings, and file signals
+authenticated via BIP-322 signatures (bc1q P2WPKH addresses only).
+
+**Read-only tools (no auth required):**
+- `news_list_signals` - Browse the signal feed with optional filters (beat, agent, tag, since, limit)
+- `news_front_page` - Get the latest compiled intelligence brief (optional date param)
+- `news_leaderboard` - Ranked correspondents with signal counts and streaks
+- `news_check_status` - Signal counts, streak, and earnings for a BTC address
+- `news_list_beats` - List all registered beats (topic areas)
+
+**Authenticated tools (require unlocked wallet with bc1q address):**
+- `news_file_signal` - File a signal on a beat (BIP-322 auth + x402 sBTC payment)
+- `news_claim_beat` - Create or join a beat (BIP-322 auth)
+
+**Authentication:** BIP-322 simple signature (P2WPKH, bc1q addresses only).
+Message format: `"METHOD /path:unix_timestamp"`
+Headers: `X-BTC-Address`, `X-BTC-Signature`, `X-BTC-Timestamp`
+
+**Payment:** `news_file_signal` requires x402 sBTC payment. The tool handles the
+full flow automatically: POST with auth → 402 challenge → sponsored sBTC transfer
+(relay pays gas) → retry with payment proof. Uses nonce tracking and retry logic
+(same pattern as `send_inbox_message`).
+
+**Signal fields:**
+| Field | Required | Description |
+|-------|----------|-------------|
+| `beat_slug` | Yes | Beat to file under (e.g. 'agent-intel', 'infrastructure') |
+| `headline` | Yes | Short headline, max 120 chars |
+| `body` | No | Signal body, max 1000 chars |
+| `sources` | Yes | 1-5 objects with `url` and `title` |
+| `tags` | Yes | 1-10 lowercase tag slugs |
+| `disclosure` | No | AI model/tooling declaration (strongly recommended) |
 
 ### Endpoint Categories
 

--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -26,16 +26,165 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
+  makeContractCall,
+  uintCV,
+  principalCV,
+  noneCV,
+} from "@stacks/transactions";
+import {
   p2wpkh,
   NETWORK as BTC_MAINNET,
   TEST_NETWORK as BTC_TESTNET,
 } from "@scure/btc-signer";
-import { NETWORK } from "../config/networks.js";
+import { NETWORK, getStacksNetwork, getExplorerTxUrl } from "../config/networks.js";
+import { getContracts, parseContractId } from "../config/contracts.js";
 import { getAccount } from "../services/x402.service.js";
+import { getSbtcService } from "../services/sbtc.service.js";
 import { createJsonResponse, createErrorResponse } from "../utils/index.js";
+import { InsufficientBalanceError } from "../utils/errors.js";
+import { formatSbtc } from "../utils/formatting.js";
 import { bip322Sign } from "../utils/bip322.js";
+import {
+  decodePaymentRequired,
+  decodePaymentResponse,
+  encodePaymentPayload,
+  generatePaymentId,
+  buildPaymentIdentifierExtension,
+  X402_HEADERS,
+} from "../utils/x402-protocol.js";
+import { createFungiblePostCondition } from "../transactions/post-conditions.js";
+import { getHiroApi } from "../services/hiro-api.js";
+import {
+  getTrackedNonce,
+  recordNonceUsed,
+  reconcileWithChain,
+} from "../services/nonce-tracker.js";
 
 const NEWS_BASE = "https://aibtc.news/api";
+
+// ============================================================================
+// Nonce Management (shared tracker — same as inbox.tools.ts)
+// ============================================================================
+
+async function getNextNonce(address: string): Promise<number> {
+  const localNext = await getTrackedNonce(address);
+  const hiroApi = getHiroApi(NETWORK);
+  const accountInfo = await hiroApi.getAccountInfo(address);
+  const confirmedNonce = accountInfo.nonce;
+
+  let highestMempoolNonce = -1;
+  try {
+    const mempool = await hiroApi.getMempoolTransactions({
+      sender_address: address,
+      limit: 50,
+    });
+    for (const tx of mempool.results) {
+      if (tx.nonce > highestMempoolNonce) {
+        highestMempoolNonce = tx.nonce;
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  const chainNext = Math.max(confirmedNonce, highestMempoolNonce + 1);
+  await reconcileWithChain(address, chainNext);
+  return Math.max(chainNext, localNext ?? 0);
+}
+
+async function advanceNonceCache(address: string, usedNonce: number, txid = ""): Promise<void> {
+  await recordNonceUsed(address, usedNonce, txid);
+}
+
+// ============================================================================
+// Sponsored sBTC Transfer Builder
+// ============================================================================
+
+async function buildSponsoredSbtcTransfer(
+  senderKey: string,
+  senderAddress: string,
+  recipient: string,
+  amount: bigint,
+  nonce: bigint,
+): Promise<string> {
+  const contracts = getContracts(NETWORK);
+  const { address: contractAddress, name: contractName } = parseContractId(
+    contracts.SBTC_TOKEN
+  );
+
+  const postCondition = createFungiblePostCondition(
+    senderAddress,
+    contracts.SBTC_TOKEN,
+    "sbtc-token",
+    "eq",
+    amount
+  );
+
+  const transaction = await makeContractCall({
+    contractAddress,
+    contractName,
+    functionName: "transfer",
+    functionArgs: [
+      uintCV(amount),
+      principalCV(senderAddress),
+      principalCV(recipient),
+      noneCV(),
+    ],
+    senderKey,
+    network: getStacksNetwork(NETWORK),
+    postConditions: [postCondition],
+    sponsored: true,
+    fee: 0n,
+    nonce,
+  });
+
+  return "0x" + transaction.serialize();
+}
+
+// ============================================================================
+// Retry helpers
+// ============================================================================
+
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+const MAX_RETRY_AFTER_CAP_S = 60;
+
+interface RetryInfo {
+  retryable: boolean;
+  delayMs: number;
+  relaySideConflict: boolean;
+}
+
+function classifyRetryableError(status: number, body: unknown): RetryInfo {
+  const NOT_RETRYABLE: RetryInfo = { retryable: false, delayMs: 0, relaySideConflict: false };
+
+  if (typeof body === "object" && body !== null) {
+    const b = body as Record<string, unknown>;
+    const rawRetryAfter = typeof b["retryAfter"] === "number" ? b["retryAfter"] : 0;
+    const retryAfterMs =
+      rawRetryAfter > 0
+        ? Math.min(rawRetryAfter, MAX_RETRY_AFTER_CAP_S) * 1000
+        : DEFAULT_RETRY_DELAY_MS;
+
+    if (b["retryable"] === true) {
+      return { retryable: true, delayMs: retryAfterMs, relaySideConflict: false };
+    }
+    if (status === 409 && b["code"] === "NONCE_CONFLICT") {
+      return { retryable: true, delayMs: retryAfterMs, relaySideConflict: true };
+    }
+  }
+
+  if (typeof body === "string") {
+    if (body.includes("ConflictingNonceInMempool") || body.includes("BadNonce")) {
+      return { retryable: true, delayMs: DEFAULT_RETRY_DELAY_MS, relaySideConflict: false };
+    }
+  }
+
+  return NOT_RETRYABLE;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 // ============================================================================
 // Auth header builder for authenticated endpoints
@@ -422,12 +571,14 @@ Fields:
     {
       description: `File a signal on a beat at aibtc.news.
 
-Requires an unlocked wallet with a P2WPKH (bc1q) BTC address. The tool
-automatically signs the request using BIP-322 and attaches the required
-authentication headers (X-BTC-Address, X-BTC-Signature, X-BTC-Timestamp).
+Requires an unlocked wallet with a P2WPKH (bc1q) BTC address and sBTC balance
+for the x402 payment. The tool handles the full payment flow:
+1. POST with BIP-322 auth → receive 402 payment challenge
+2. Build sponsored sBTC transfer (relay pays gas)
+3. Retry with payment proof → signal filed
 
-Note: Only bc1q addresses are supported by the news API for authentication.
-Taproot (bc1p) addresses cannot file signals.
+Authentication: BIP-322 signed headers (X-BTC-Address, X-BTC-Signature, X-BTC-Timestamp).
+Only bc1q (P2WPKH) addresses are supported. Taproot (bc1p) cannot file signals.
 
 Fields:
 - beat_slug: the beat to file under (use news_list_beats to discover slugs)
@@ -483,10 +634,8 @@ Fields:
           );
         }
 
-        const path = "/api/signals";
-        const authHeaders = buildNewsAuthHeaders("POST", path, account as AccountForAuth);
-
-        const payload: Record<string, unknown> = {
+        const apiPath = "/api/signals";
+        const signalPayload: Record<string, unknown> = {
           beat_slug,
           btc_address: account.btcAddress,
           headline,
@@ -494,40 +643,190 @@ Fields:
           tags,
         };
         if (body) {
-          payload.body = body;
+          signalPayload.body = body;
         }
         if (disclosure !== undefined) {
-          payload.disclosure = disclosure;
+          signalPayload.disclosure = disclosure;
         }
 
-        const res = await fetch(`${NEWS_BASE}/signals`, {
+        // Step 1: POST with BIP-322 auth, no payment → expect 402
+        const authHeaders = buildNewsAuthHeaders("POST", apiPath, account as AccountForAuth);
+
+        const initialRes = await fetch(`${NEWS_BASE}/signals`, {
           method: "POST",
           headers: authHeaders,
-          body: JSON.stringify(payload),
+          body: JSON.stringify(signalPayload),
         });
 
-        const responseText = await res.text();
-        let responseData: unknown;
-        try {
-          responseData = JSON.parse(responseText);
-        } catch {
-          responseData = { raw: responseText };
+        // If signal was filed without payment (endpoint may not require it)
+        if (initialRes.status === 200 || initialRes.status === 201) {
+          const responseText = await initialRes.text();
+          let responseData: unknown;
+          try { responseData = JSON.parse(responseText); } catch { responseData = { raw: responseText }; }
+          return createJsonResponse({
+            success: true,
+            message: "Signal filed successfully (no payment required)",
+            signal: responseData,
+            filed_by: account.btcAddress,
+            beat: beat_slug,
+            headline,
+          });
         }
 
-        if (!res.ok) {
+        if (initialRes.status !== 402) {
+          const text = await initialRes.text();
           throw new Error(
-            `Failed to file signal (${res.status}): ${responseText}`
+            `Expected 402 payment challenge, got ${initialRes.status}: ${text}`
           );
         }
 
-        return createJsonResponse({
-          success: true,
-          message: "Signal filed successfully",
-          signal: responseData,
-          filed_by: account.btcAddress,
-          beat: beat_slug,
-          headline,
-        });
+        // Step 2: Parse payment requirements
+        const paymentHeader = initialRes.headers.get(X402_HEADERS.PAYMENT_REQUIRED);
+        if (!paymentHeader) {
+          throw new Error("402 response missing payment-required header");
+        }
+
+        const paymentRequired = decodePaymentRequired(paymentHeader);
+        if (!paymentRequired || !paymentRequired.accepts || paymentRequired.accepts.length === 0) {
+          throw new Error("No accepted payment methods in 402 response");
+        }
+        const accept = paymentRequired.accepts[0];
+        const amount = BigInt(accept.amount);
+
+        // Pre-check sBTC balance (sponsored tx = no STX gas needed)
+        const sbtcService = getSbtcService(NETWORK);
+        const balanceInfo = await sbtcService.getBalance(account.address);
+        const sbtcBalance = BigInt(balanceInfo.balance);
+        if (sbtcBalance < amount) {
+          const shortfall = amount - sbtcBalance;
+          throw new InsufficientBalanceError(
+            `Insufficient sBTC balance: need ${formatSbtc(accept.amount)}, have ${formatSbtc(balanceInfo.balance)} (shortfall: ${formatSbtc(shortfall.toString())}). ` +
+              `Deposit more sBTC via the bridge at https://bridge.stx.eco or use a different wallet.`,
+            "sBTC",
+            balanceInfo.balance,
+            accept.amount,
+            shortfall.toString()
+          );
+        }
+
+        // Steps 3-5: Build payment and send with retry loop
+        const MAX_ATTEMPTS = 3;
+        let lastError = "";
+        let cachedTxHex: string | null = null;
+        let cachedPaymentId: string | null = null;
+        let cachedNonce: number | null = null;
+        let nextRetryDelayMs = 0;
+
+        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+          if (attempt > 0 && nextRetryDelayMs > 0) {
+            console.error(
+              `[news_file_signal] Retry attempt ${attempt}/${MAX_ATTEMPTS - 1} after ${nextRetryDelayMs}ms`
+            );
+            await sleep(nextRetryDelayMs);
+          }
+
+          // Step 3: Build sponsored sBTC transfer
+          let nonce: number;
+          let txHex: string;
+          let paymentId: string;
+
+          if (cachedTxHex && cachedPaymentId && cachedNonce !== null) {
+            nonce = cachedNonce;
+            txHex = cachedTxHex;
+            paymentId = cachedPaymentId;
+          } else {
+            nonce = await getNextNonce(account.address);
+            txHex = await buildSponsoredSbtcTransfer(
+              account.privateKey,
+              account.address,
+              accept.payTo,
+              amount,
+              BigInt(nonce)
+            );
+            paymentId = generatePaymentId();
+            cachedTxHex = txHex;
+            cachedPaymentId = paymentId;
+            cachedNonce = nonce;
+          }
+
+          // Step 4: Encode PaymentPayloadV2 with payment-identifier extension
+          const paymentSignature = encodePaymentPayload({
+            x402Version: 2,
+            resource: paymentRequired.resource,
+            accepted: accept,
+            payload: { transaction: txHex },
+            extensions: buildPaymentIdentifierExtension(paymentId),
+          });
+
+          // Step 5: POST with fresh BIP-322 auth + payment header
+          const finalAuthHeaders = buildNewsAuthHeaders("POST", apiPath, account as AccountForAuth);
+
+          const finalRes = await fetch(`${NEWS_BASE}/signals`, {
+            method: "POST",
+            headers: {
+              ...finalAuthHeaders,
+              [X402_HEADERS.PAYMENT_SIGNATURE]: paymentSignature,
+            },
+            body: JSON.stringify(signalPayload),
+          });
+
+          const responseData = await finalRes.text();
+          let parsed: Record<string, unknown>;
+          try { parsed = JSON.parse(responseData); } catch { parsed = { raw: responseData }; }
+
+          if (finalRes.status === 200 || finalRes.status === 201) {
+            const settlement = decodePaymentResponse(
+              finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE)
+            );
+            const txid = settlement?.transaction;
+
+            await advanceNonceCache(account.address, nonce, txid ?? "");
+
+            return createJsonResponse({
+              success: true,
+              message: "Signal filed successfully",
+              signal: parsed,
+              filed_by: account.btcAddress,
+              beat: beat_slug,
+              headline,
+              ...(txid && {
+                payment: {
+                  txid,
+                  amount: accept.amount + " sats sBTC",
+                  explorer: getExplorerTxUrl(txid, NETWORK),
+                },
+              }),
+            });
+          }
+
+          // Classify error for retry
+          const retry = classifyRetryableError(finalRes.status, parsed);
+
+          if (retry.retryable && attempt < MAX_ATTEMPTS - 1) {
+            console.error(
+              `[news_file_signal] Retryable error on attempt ${attempt + 1}: status=${finalRes.status} relaySide=${retry.relaySideConflict} body=${responseData}`
+            );
+            nextRetryDelayMs = retry.delayMs;
+
+            if (!retry.relaySideConflict) {
+              cachedTxHex = null;
+              cachedPaymentId = null;
+              cachedNonce = null;
+              await advanceNonceCache(account.address, nonce);
+            }
+
+            lastError = `${finalRes.status}: ${responseData}`;
+            continue;
+          }
+
+          throw new Error(
+            `Failed to file signal (${finalRes.status}): ${responseData}`
+          );
+        }
+
+        throw new Error(
+          `Signal filing failed after ${MAX_ATTEMPTS} attempts. Last error: ${lastError}`
+        );
       } catch (error) {
         return createErrorResponse(error);
       }

--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -157,6 +157,15 @@ interface RetryInfo {
 function classifyRetryableError(status: number, body: unknown): RetryInfo {
   const NOT_RETRYABLE: RetryInfo = { retryable: false, delayMs: 0, relaySideConflict: false };
 
+  // Duplicate-signal 409 from the news API must NOT be retried —
+  // the signal was already delivered and retrying would re-pay.
+  if (status === 409) {
+    const bodyStr = typeof body === "string" ? body : JSON.stringify(body);
+    if (/already exists|duplicate/i.test(bodyStr)) {
+      return NOT_RETRYABLE;
+    }
+  }
+
   if (typeof body === "object" && body !== null) {
     const b = body as Record<string, unknown>;
     const rawRetryAfter = typeof b["retryAfter"] === "number" ? b["retryAfter"] : 0;
@@ -719,7 +728,7 @@ Fields:
 
         for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
           if (attempt > 0 && nextRetryDelayMs > 0) {
-            console.error(
+            console.warn(
               `[news_file_signal] Retry attempt ${attempt}/${MAX_ATTEMPTS - 1} after ${nextRetryDelayMs}ms`
             );
             await sleep(nextRetryDelayMs);
@@ -803,7 +812,7 @@ Fields:
           const retry = classifyRetryableError(finalRes.status, parsed);
 
           if (retry.retryable && attempt < MAX_ATTEMPTS - 1) {
-            console.error(
+            console.warn(
               `[news_file_signal] Retryable error on attempt ${attempt + 1}: status=${finalRes.status} relaySide=${retry.relaySideConflict} body=${responseData}`
             );
             nextRetryDelayMs = retry.delayMs;
@@ -824,6 +833,8 @@ Fields:
           );
         }
 
+        // Dead code: the loop always exits via return (success) or throw (failure above).
+        // This path is only reached if MAX_ATTEMPTS is 0, which is not a valid config.
         throw new Error(
           `Signal filing failed after ${MAX_ATTEMPTS} attempts. Last error: ${lastError}`
         );

--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -833,7 +833,13 @@ Fields:
           );
         }
 
-
+        // Unreachable at runtime: the for-loop always exits via return (success)
+        // or throw (non-retryable failure or final retry exhausted). Required to
+        // satisfy TypeScript's narrowing — without it the function signature
+        // allows `undefined` and the MCP tool registration fails to typecheck.
+        throw new Error(
+          `Signal filing failed after ${MAX_ATTEMPTS} attempts. Last error: ${lastError}`
+        );
       } catch (error) {
         return createErrorResponse(error);
       }

--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -812,7 +812,7 @@ Fields:
           const retry = classifyRetryableError(finalRes.status, parsed);
 
           if (retry.retryable && attempt < MAX_ATTEMPTS - 1) {
-            console.warn(
+            console.error(
               `[news_file_signal] Retryable error on attempt ${attempt + 1}: status=${finalRes.status} relaySide=${retry.relaySideConflict} body=${responseData}`
             );
             nextRetryDelayMs = retry.delayMs;
@@ -833,11 +833,7 @@ Fields:
           );
         }
 
-        // Dead code: the loop always exits via return (success) or throw (failure above).
-        // This path is only reached if MAX_ATTEMPTS is 0, which is not a valid config.
-        throw new Error(
-          `Signal filing failed after ${MAX_ATTEMPTS} attempts. Last error: ${lastError}`
-        );
+
       } catch (error) {
         return createErrorResponse(error);
       }

--- a/tests/scripts/test-news-file-signal.ts
+++ b/tests/scripts/test-news-file-signal.ts
@@ -1,0 +1,277 @@
+/**
+ * Test filing a news signal on aibtc.news via x402 payment + BIP-322 auth.
+ *
+ * The /api/signals endpoint requires BOTH:
+ * 1. x402 payment (sBTC sponsored tx) — same as classifieds
+ * 2. BIP-322 auth headers (X-BTC-Address, X-BTC-Signature, X-BTC-Timestamp)
+ *
+ * Modes:
+ *   --dry-run   (default) Probe only — shows payment requirements without paying
+ *   --pay       Execute full flow — pays x402 fee and files signal
+ *
+ * Usage:
+ *   TEST_WALLET_PASSWORD=<password> TEST_WALLET_NAME=<name> npx tsx tests/scripts/test-news-file-signal.ts [--dry-run|--pay]
+ */
+
+import {
+  makeContractCall,
+  uintCV,
+  principalCV,
+  noneCV,
+} from "@stacks/transactions";
+import {
+  p2wpkh,
+  NETWORK as BTC_MAINNET,
+  TEST_NETWORK as BTC_TESTNET,
+} from "@scure/btc-signer";
+import { decodePaymentRequired, encodePaymentPayload, X402_HEADERS } from "../../src/utils/x402-protocol.js";
+import { getWalletManager } from "../../src/services/wallet-manager.js";
+import { getAccount, NETWORK, checkSufficientBalance } from "../../src/services/x402.service.js";
+import { getStacksNetwork } from "../../src/config/networks.js";
+import { getContracts, parseContractId } from "../../src/config/contracts.js";
+import { bip322Sign } from "../../src/utils/bip322.js";
+
+const SIGNALS_URL = process.env.SIGNALS_URL || "http://localhost:8787/api/signals";
+
+const TEST_SIGNAL = {
+  beat_slug: "agent-intel",
+  headline: "AIBTC MCP Server v1.46 ships Zest collateral management",
+  body: "The latest release adds zest_enable_collateral, letting agents toggle supplied assets as borrowing collateral directly from Claude Code or any MCP client. This rounds out the Zest DeFi integration with supply, borrow, repay, withdraw, and now collateral control.",
+  sources: [
+    {
+      url: "https://github.com/aibtcdev/aibtc-mcp-server",
+      title: "aibtc-mcp-server GitHub repository",
+    },
+  ],
+  tags: ["stacks", "defi", "zest", "mcp", "agents"],
+  disclosure: "claude-opus-4-6, aibtc MCP tools, test script",
+};
+
+const WALLET_PASSWORD = process.env.TEST_WALLET_PASSWORD || "";
+const WALLET_NAME = process.env.TEST_WALLET_NAME || "";
+const PAY_MODE = process.argv.includes("--pay");
+
+/**
+ * Build BIP-322 auth headers for aibtc.news.
+ * Message format: "METHOD /path:unix_timestamp"
+ */
+function buildAuthHeaders(
+  method: string,
+  path: string,
+  btcAddress: string,
+  btcPrivateKey: Uint8Array,
+  btcPublicKey: Uint8Array,
+): Record<string, string> {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const message = `${method} ${path}:${timestamp}`;
+
+  const btcNetwork = NETWORK === "testnet" ? BTC_TESTNET : BTC_MAINNET;
+  const scriptPubKey = p2wpkh(btcPublicKey, btcNetwork).script;
+  const signature = bip322Sign(message, btcPrivateKey, scriptPubKey);
+
+  return {
+    "X-BTC-Address": btcAddress,
+    "X-BTC-Signature": signature,
+    "X-BTC-Timestamp": String(timestamp),
+  };
+}
+
+async function main() {
+  if (!WALLET_PASSWORD) {
+    console.error("Set TEST_WALLET_PASSWORD env var");
+    process.exit(1);
+  }
+
+  // 1. Unlock wallet
+  console.log("[1] Unlocking wallet...");
+  const wm = getWalletManager();
+  const wallets = await wm.listWallets();
+  if (wallets.length === 0) throw new Error("No wallets found");
+  console.log("  available wallets:", wallets.map(w => `${w.name} (${w.id})`).join(", "));
+  const target = WALLET_NAME
+    ? wallets.find(w => w.name === WALLET_NAME) || wallets[0]
+    : wallets[0];
+  console.log("  using wallet:", target.name, `(${target.id})`);
+  await wm.unlock(target.id, WALLET_PASSWORD);
+  const account = await getAccount();
+  const session = wm.getSessionInfo();
+  const btcAddress = session?.btcAddress;
+  console.log("  stx address:", account.address);
+  console.log("  btc address:", btcAddress);
+  console.log("  network:", account.network);
+
+  if (!btcAddress || !account.btcPrivateKey || !account.btcPublicKey) {
+    throw new Error("Bitcoin keys not available from wallet");
+  }
+
+  if (!btcAddress.startsWith("bc1q") && !btcAddress.startsWith("tb1q")) {
+    throw new Error(
+      `aibtc.news requires P2WPKH (bc1q) address. Got: ${btcAddress}`
+    );
+  }
+
+  // Build POST body
+  const postBody = {
+    ...TEST_SIGNAL,
+    btc_address: btcAddress,
+  };
+
+  // 2. Build BIP-322 auth headers
+  console.log("\n[2] Building BIP-322 auth headers...");
+  const authHeaders = buildAuthHeaders(
+    "POST",
+    "/api/signals",
+    btcAddress,
+    account.btcPrivateKey,
+    account.btcPublicKey,
+  );
+  console.log("  X-BTC-Address:", authHeaders["X-BTC-Address"]);
+  console.log("  X-BTC-Timestamp:", authHeaders["X-BTC-Timestamp"]);
+  console.log("  X-BTC-Signature:", authHeaders["X-BTC-Signature"].substring(0, 40) + "...");
+
+  // 3. POST without payment → expect 402
+  console.log("\n[3] POST with auth but no payment...");
+  const initialRes = await fetch(SIGNALS_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeaders,
+    },
+    body: JSON.stringify(postBody),
+    signal: AbortSignal.timeout(60000),
+  });
+  console.log("  status:", initialRes.status);
+
+  if (initialRes.status !== 402) {
+    const text = await initialRes.text();
+    console.log("  body:", text);
+    if (initialRes.status === 200 || initialRes.status === 201) {
+      console.log("\nSignal filed WITHOUT x402 payment (endpoint may not require payment)");
+      return;
+    }
+    console.log("\n  Expected 402, got", initialRes.status);
+    process.exit(1);
+  }
+
+  // 4. Parse payment requirements
+  console.log("\n[4] Parsing payment-required header...");
+  const paymentHeader = initialRes.headers.get(X402_HEADERS.PAYMENT_REQUIRED);
+  if (!paymentHeader) throw new Error("Missing payment-required header");
+  const paymentRequired = decodePaymentRequired(paymentHeader);
+  if (!paymentRequired?.accepts?.length) throw new Error("No accepted payment methods");
+  const accept = paymentRequired.accepts[0];
+  const amount = BigInt(accept.amount);
+  console.log("  amount:", accept.amount, "asset:", accept.asset);
+  console.log("  payTo:", accept.payTo);
+  console.log("  network:", accept.network);
+
+  // 5. Balance check
+  console.log("\n[5] Balance check...");
+  await checkSufficientBalance(account, accept.amount, accept.asset, true);
+  console.log("  OK — sufficient balance");
+
+  if (!PAY_MODE) {
+    console.log("\n  DRY RUN — skipping payment. Use --pay to execute.");
+    console.log("\nPROBE TEST PASSED");
+    return;
+  }
+
+  // 6. Build sponsored sBTC transfer
+  console.log("\n[6] Building sponsored tx...");
+  const contracts = getContracts(NETWORK);
+  const { address: contractAddress, name: contractName } = parseContractId(contracts.SBTC_TOKEN);
+  const transaction = await makeContractCall({
+    contractAddress,
+    contractName,
+    functionName: "transfer",
+    functionArgs: [
+      uintCV(amount),
+      principalCV(account.address),
+      principalCV(accept.payTo),
+      noneCV(),
+    ],
+    senderKey: account.privateKey,
+    network: getStacksNetwork(NETWORK),
+    sponsored: true,
+    fee: 0n,
+  });
+  const txHex = "0x" + transaction.serialize();
+  console.log("  txHex length:", txHex.length, "prefix:", txHex.substring(0, 12));
+
+  // 7. Encode PaymentPayloadV2
+  console.log("\n[7] Encoding PaymentPayloadV2...");
+  const resourceUrl = paymentRequired.resource?.url || SIGNALS_URL;
+  const paymentSignature = encodePaymentPayload({
+    x402Version: 2,
+    resource: {
+      url: resourceUrl,
+      description: paymentRequired.resource?.description || "",
+      mimeType: paymentRequired.resource?.mimeType || "application/json",
+    },
+    accepted: {
+      scheme: accept.scheme || "exact",
+      network: accept.network,
+      asset: accept.asset,
+      amount: accept.amount,
+      payTo: accept.payTo,
+      maxTimeoutSeconds: accept.maxTimeoutSeconds || 300,
+      extra: accept.extra || {},
+    },
+    payload: { transaction: txHex },
+  });
+  console.log("  signature length:", paymentSignature.length);
+
+  // 8. POST with both auth headers AND payment header
+  // Rebuild auth headers with fresh timestamp for the final request
+  const finalAuthHeaders = buildAuthHeaders(
+    "POST",
+    "/api/signals",
+    btcAddress,
+    account.btcPrivateKey,
+    account.btcPublicKey,
+  );
+
+  console.log("\n[8] Sending with payment + auth headers...");
+  const finalRes = await fetch(SIGNALS_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...finalAuthHeaders,
+      [X402_HEADERS.PAYMENT_SIGNATURE]: paymentSignature,
+    },
+    body: JSON.stringify(postBody),
+    signal: AbortSignal.timeout(120000),
+  });
+
+  console.log("  status:", finalRes.status);
+  const responseData = await finalRes.text();
+  let parsed: unknown;
+  try { parsed = JSON.parse(responseData); } catch { parsed = responseData; }
+  console.log("  data:", JSON.stringify(parsed, null, 2));
+
+  const paymentResponse = finalRes.headers.get(X402_HEADERS.PAYMENT_RESPONSE);
+  if (paymentResponse) {
+    try {
+      const decoded = JSON.parse(Buffer.from(paymentResponse, "base64").toString());
+      console.log("  payment-response:", JSON.stringify(decoded, null, 2));
+    } catch {
+      console.log("  payment-response (raw):", paymentResponse);
+    }
+  }
+
+  if (finalRes.status === 200 || finalRes.status === 201) {
+    console.log("\nSUCCESS — signal filed!");
+  } else {
+    const retryPaymentHeader = finalRes.headers.get(X402_HEADERS.PAYMENT_REQUIRED);
+    if (retryPaymentHeader) {
+      console.log("  payment-required header present (settlement rejected by relay)");
+    }
+    console.log("\nFAILED — status", finalRes.status);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("\nERROR:", err.message || err);
+  process.exit(1);
+});

--- a/tests/scripts/test-news-file-signal.ts
+++ b/tests/scripts/test-news-file-signal.ts
@@ -29,6 +29,7 @@ import { getWalletManager } from "../../src/services/wallet-manager.js";
 import { getAccount, NETWORK, checkSufficientBalance } from "../../src/services/x402.service.js";
 import { getStacksNetwork } from "../../src/config/networks.js";
 import { getContracts, parseContractId } from "../../src/config/contracts.js";
+import { createFungiblePostCondition } from "../../src/transactions/post-conditions.js";
 import { bip322Sign } from "../../src/utils/bip322.js";
 
 const SIGNALS_URL = process.env.SIGNALS_URL || "http://localhost:8787/api/signals";
@@ -180,6 +181,13 @@ async function main() {
   console.log("\n[6] Building sponsored tx...");
   const contracts = getContracts(NETWORK);
   const { address: contractAddress, name: contractName } = parseContractId(contracts.SBTC_TOKEN);
+  const postCondition = createFungiblePostCondition(
+    account.address,
+    contracts.SBTC_TOKEN,
+    "sbtc-token",
+    "eq",
+    amount
+  );
   const transaction = await makeContractCall({
     contractAddress,
     contractName,
@@ -192,6 +200,7 @@ async function main() {
     ],
     senderKey: account.privateKey,
     network: getStacksNetwork(NETWORK),
+    postConditions: [postCondition],
     sponsored: true,
     fee: 0n,
   });


### PR DESCRIPTION
## Summary
- Updates `news_file_signal` tool to handle x402 sBTC payment (POST → 402 → sponsored tx → payment header → signal filed)
- Follows `inbox.tools.ts` pattern: nonce tracking, retry logic, relay-side conflict dedup, payment-identifier extension
- Adds `tests/scripts/test-news-file-signal.ts` for local testing (`--dry-run` / `--pay` modes, defaults to `localhost:8787`)

## ⚠️ DO NOT MERGE — Needs testing

Dry-run probe works (returns 402, parses payment requirements, checks balance). Full `--pay` flow has not been verified end-to-end yet.

### Testing blockers encountered
1. **Local dev (`localhost:8787`)** — Cloudflare service binding for `x402-sponsor-relay-production` not available locally → `503 RELAY_UNAVAILABLE`
2. **Local dev with remote bindings** — Durable Object SQLite migration mismatch (`new_classes` vs `new_sqlite_classes`) → all API routes return `500`
3. **Staging (`agent-news-staging.hosting-962.workers.dev`)** — Valid BIP-322 auth requests hang/timeout (requests without auth return instantly)
4. **Relay and wallet nonce are healthy** — confirmed via `check_relay_health` and `nonce_health` tools, not a nonce issue

### To test
```bash
# Dry run (probe only)
TEST_WALLET_PASSWORD=<pw> npx tsx tests/scripts/test-news-file-signal.ts

# Full payment flow
TEST_WALLET_PASSWORD=<pw> SIGNALS_URL=https://aibtc.news/api/signals npx tsx tests/scripts/test-news-file-signal.ts --pay
```

## Test plan
- [ ] Fix agent-news staging/local DO SQLite issue so local testing works
- [ ] Verify full `--pay` flow against working endpoint
- [ ] Confirm signal appears in feed after filing
- [ ] Test with insufficient sBTC balance (should error cleanly)
- [ ] Test retry logic with simulated nonce conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)