### PR TITLE
fix(relay): health check reads pool state fields from /health

### DIFF
--- a/src/utils/relay-health.ts
+++ b/src/utils/relay-health.ts
@@ -79,7 +79,12 @@ export async function isRelayHealthy(network: Network): Promise<boolean> {
 
     const data = await res.json() as {
       status?: string;
-      nonce?: { circuitBreakerOpen?: boolean; poolStatus?: string };
+      nonce?: {
+        circuitBreakerOpen?: boolean;
+        poolStatus?: string;
+        effectiveCapacity?: number;
+        conflictsDetected?: number;
+      };
     };
 
     if (data.status !== "ok") return false;
@@ -88,6 +93,8 @@ export async function isRelayHealthy(network: Network): Promise<boolean> {
     if (data.nonce) {
       if (data.nonce.circuitBreakerOpen) return false;
       if (data.nonce.poolStatus === "critical") return false;
+      if (data.nonce.effectiveCapacity !== undefined && data.nonce.effectiveCapacity < 5) return false;
+      if (data.nonce.conflictsDetected !== undefined && data.nonce.conflictsDetected > 10) return false;
     }
 
     return true;
@@ -163,11 +170,12 @@ export async function checkRelayHealth(network: Network): Promise<RelayHealthSta
       if (poolState.poolStatus === "critical") {
         issues.push("Relay nonce pool is critical");
       }
-      if (poolState.effectiveCapacity < 5) {
-        issues.push(`Relay effective capacity degraded (${poolState.effectiveCapacity}/${poolState.poolAvailable + poolState.poolReserved || 20})`);
+      if (n.effectiveCapacity !== undefined && n.effectiveCapacity < 5) {
+        const total = poolState.poolAvailable + poolState.poolReserved;
+        issues.push(`Relay effective capacity degraded (${n.effectiveCapacity}/${total})`);
       }
-      if (poolState.conflictsDetected > 10) {
-        issues.push(`Relay has ${poolState.conflictsDetected} nonce conflicts`);
+      if (n.conflictsDetected !== undefined && n.conflictsDetected > 10) {
+        issues.push(`Relay has ${n.conflictsDetected} nonce conflicts`);
       }
     }
 

--- a/src/utils/relay-health.ts
+++ b/src/utils/relay-health.ts
@@ -16,11 +16,23 @@ export interface StuckTransaction {
   sponsor_nonce?: number;
 }
 
+export interface RelayPoolState {
+  poolAvailable: number;
+  poolReserved: number;
+  conflictsDetected: number;
+  circuitBreakerOpen: boolean;
+  effectiveCapacity: number;
+  poolStatus: string;
+  lastConflictAt: string | null;
+  recommendation: string | null;
+}
+
 export interface RelayHealthStatus {
   healthy: boolean;
   network: Network;
   version?: string;
   sponsorAddress?: string;
+  poolState?: RelayPoolState;
   nonceStatus?: {
     lastExecuted: number;
     lastMempool: number | null;
@@ -65,8 +77,20 @@ export async function isRelayHealthy(network: Network): Promise<boolean> {
 
     if (!res.ok) return false;
 
-    const data = await res.json() as { status?: string };
-    return data.status === "ok";
+    const data = await res.json() as {
+      status?: string;
+      nonce?: { circuitBreakerOpen?: boolean; poolStatus?: string };
+    };
+
+    if (data.status !== "ok") return false;
+
+    // Check pool state fields when present (relay v1.26.1+)
+    if (data.nonce) {
+      if (data.nonce.circuitBreakerOpen) return false;
+      if (data.nonce.poolStatus === "critical") return false;
+    }
+
+    return true;
   } catch {
     return false;
   } finally {
@@ -97,11 +121,54 @@ export async function checkRelayHealth(network: Network): Promise<RelayHealthSta
       };
     }
 
-    const healthData = await healthRes.json() as { status?: string; version?: string; network?: string };
+    const healthData = await healthRes.json() as {
+      status?: string;
+      version?: string;
+      network?: string;
+      nonce?: {
+        poolAvailable?: number;
+        poolReserved?: number;
+        conflictsDetected?: number;
+        circuitBreakerOpen?: boolean;
+        effectiveCapacity?: number;
+        poolStatus?: string;
+        lastConflictAt?: string | null;
+        recommendation?: string | null;
+      };
+    };
     const version = healthData.version;
 
     if (healthData.status !== "ok") {
       issues.push(`Relay status: ${healthData.status || "unknown"}`);
+    }
+
+    // Read pool state fields from relay /health response (v1.26.1+)
+    let poolState: RelayPoolState | undefined;
+    if (healthData.nonce) {
+      const n = healthData.nonce;
+      poolState = {
+        poolAvailable: n.poolAvailable ?? 0,
+        poolReserved: n.poolReserved ?? 0,
+        conflictsDetected: n.conflictsDetected ?? 0,
+        circuitBreakerOpen: n.circuitBreakerOpen ?? false,
+        effectiveCapacity: n.effectiveCapacity ?? 0,
+        poolStatus: n.poolStatus ?? "unknown",
+        lastConflictAt: n.lastConflictAt ?? null,
+        recommendation: n.recommendation ?? null,
+      };
+
+      if (poolState.circuitBreakerOpen) {
+        issues.push("Relay circuit breaker is open — sends will fail");
+      }
+      if (poolState.poolStatus === "critical") {
+        issues.push("Relay nonce pool is critical");
+      }
+      if (poolState.effectiveCapacity < 5) {
+        issues.push(`Relay effective capacity degraded (${poolState.effectiveCapacity}/${poolState.poolAvailable + poolState.poolReserved || 20})`);
+      }
+      if (poolState.conflictsDetected > 10) {
+        issues.push(`Relay has ${poolState.conflictsDetected} nonce conflicts`);
+      }
     }
 
     // Check sponsor address nonce status
@@ -112,6 +179,7 @@ export async function checkRelayHealth(network: Network): Promise<RelayHealthSta
         healthy: issues.length === 0,
         network,
         version,
+        poolState,
         issues: issues.length > 0 ? issues : undefined,
       };
     }
@@ -190,6 +258,7 @@ export async function checkRelayHealth(network: Network): Promise<RelayHealthSta
       network,
       version,
       sponsorAddress,
+      poolState,
       nonceStatus,
       stuckTransactions,
       issues: issues.length > 0 ? issues : undefined,
@@ -220,7 +289,24 @@ export function formatRelayHealthStatus(status: RelayHealthStatus): string {
   if (status.sponsorAddress) {
     lines.push(`Sponsor: ${status.sponsorAddress}`);
   }
-  
+
+  if (status.poolState) {
+    const ps = status.poolState;
+    lines.push("");
+    lines.push("Relay Pool State:");
+    lines.push(`  Pool status: ${ps.poolStatus}`);
+    lines.push(`  Circuit breaker: ${ps.circuitBreakerOpen ? "OPEN" : "closed"}`);
+    lines.push(`  Effective capacity: ${ps.effectiveCapacity}`);
+    lines.push(`  Available / Reserved: ${ps.poolAvailable} / ${ps.poolReserved}`);
+    lines.push(`  Conflicts detected: ${ps.conflictsDetected}`);
+    if (ps.lastConflictAt) {
+      lines.push(`  Last conflict: ${ps.lastConflictAt}`);
+    }
+    if (ps.recommendation) {
+      lines.push(`  Recommendation: ${ps.recommendation}`);
+    }
+  }
+
   if (status.nonceStatus) {
     const ns = status.nonceStatus;
     lines.push("");

--- a/tests/utils/relay-health.test.ts
+++ b/tests/utils/relay-health.test.ts
@@ -60,8 +60,9 @@ describe("isRelayHealthy", () => {
         status: "ok",
         nonce: {
           circuitBreakerOpen: true,
-          poolStatus: "critical",
-          effectiveCapacity: 1,
+          poolStatus: "ok",
+          effectiveCapacity: 20,
+          conflictsDetected: 0,
         },
       }),
     });
@@ -77,12 +78,62 @@ describe("isRelayHealthy", () => {
         nonce: {
           circuitBreakerOpen: false,
           poolStatus: "critical",
-          effectiveCapacity: 3,
+          effectiveCapacity: 20,
+          conflictsDetected: 0,
         },
       }),
     });
 
     expect(await isRelayHealthy("mainnet")).toBe(false);
+  });
+
+  it("returns false when effective capacity is below threshold", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "ok",
+        nonce: {
+          circuitBreakerOpen: false,
+          poolStatus: "ok",
+          effectiveCapacity: 3,
+          conflictsDetected: 0,
+        },
+      }),
+    });
+
+    expect(await isRelayHealthy("mainnet")).toBe(false);
+  });
+
+  it("returns false when conflicts detected exceed threshold", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "ok",
+        nonce: {
+          circuitBreakerOpen: false,
+          poolStatus: "ok",
+          effectiveCapacity: 20,
+          conflictsDetected: 47,
+        },
+      }),
+    });
+
+    expect(await isRelayHealthy("mainnet")).toBe(false);
+  });
+
+  it("ignores missing capacity and conflict fields (older relays)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "ok",
+        nonce: {
+          circuitBreakerOpen: false,
+          poolStatus: "ok",
+        },
+      }),
+    });
+
+    expect(await isRelayHealthy("mainnet")).toBe(true);
   });
 
   it("returns true when pool state is healthy", async () => {

--- a/tests/utils/relay-health.test.ts
+++ b/tests/utils/relay-health.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock dependencies before importing the module under test
+vi.mock("../../src/config/sponsor.js", () => ({
+  getSponsorRelayUrl: () => "https://relay.example.com",
+  getSponsorApiKey: () => undefined,
+}));
+
+vi.mock("../../src/config/networks.js", () => ({}));
+
+vi.mock("../../src/services/hiro-api.js", () => ({
+  getHiroApi: () => ({
+    getNonceInfo: vi.fn(),
+    getMempoolTransactions: vi.fn(),
+  }),
+}));
+
+import { isRelayHealthy, checkRelayHealth, formatRelayHealthStatus } from "../../src/utils/relay-health.js";
+import type { RelayHealthStatus } from "../../src/utils/relay-health.js";
+
+describe("isRelayHealthy", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns true when status is ok and no pool state", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "ok" }),
+    });
+
+    expect(await isRelayHealthy("mainnet")).toBe(true);
+  });
+
+  it("returns false when status is not ok", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "degraded" }),
+    });
+
+    expect(await isRelayHealthy("mainnet")).toBe(false);
+  });
+
+  it("returns false when HTTP response is not ok", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    expect(await isRelayHealthy("mainnet")).toBe(false);
+  });
+
+  it("returns false when circuit breaker is open", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "ok",
+        nonce: {
+          circuitBreakerOpen: true,
+          poolStatus: "critical",
+          effectiveCapacity: 1,
+        },
+      }),
+    });
+
+    expect(await isRelayHealthy("mainnet")).toBe(false);
+  });
+
+  it("returns false when pool status is critical", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "ok",
+        nonce: {
+          circuitBreakerOpen: false,
+          poolStatus: "critical",
+          effectiveCapacity: 3,
+        },
+      }),
+    });
+
+    expect(await isRelayHealthy("mainnet")).toBe(false);
+  });
+
+  it("returns true when pool state is healthy", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "ok",
+        nonce: {
+          circuitBreakerOpen: false,
+          poolStatus: "ok",
+          effectiveCapacity: 20,
+        },
+      }),
+    });
+
+    expect(await isRelayHealthy("mainnet")).toBe(true);
+  });
+
+  it("returns false on fetch error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network error"));
+
+    expect(await isRelayHealthy("mainnet")).toBe(false);
+  });
+});
+
+describe("formatRelayHealthStatus", () => {
+  it("includes pool state in formatted output", () => {
+    const status: RelayHealthStatus = {
+      healthy: false,
+      network: "mainnet",
+      version: "1.26.1",
+      poolState: {
+        poolAvailable: 20,
+        poolReserved: 0,
+        conflictsDetected: 47,
+        circuitBreakerOpen: true,
+        effectiveCapacity: 1,
+        poolStatus: "critical",
+        lastConflictAt: "2026-03-28T17:53:50.250Z",
+        recommendation: null,
+      },
+      issues: [
+        "Relay circuit breaker is open — sends will fail",
+        "Relay nonce pool is critical",
+      ],
+    };
+
+    const output = formatRelayHealthStatus(status);
+    expect(output).toContain("UNHEALTHY");
+    expect(output).toContain("Pool status: critical");
+    expect(output).toContain("Circuit breaker: OPEN");
+    expect(output).toContain("Effective capacity: 1");
+    expect(output).toContain("Conflicts detected: 47");
+    expect(output).toContain("2026-03-28T17:53:50.250Z");
+  });
+
+  it("omits pool state section when not present", () => {
+    const status: RelayHealthStatus = {
+      healthy: true,
+      network: "mainnet",
+    };
+
+    const output = formatRelayHealthStatus(status);
+    expect(output).toContain("HEALTHY");
+    expect(output).not.toContain("Pool State");
+  });
+});


### PR DESCRIPTION
Fixes #429

`isRelayHealthy()` and `checkRelayHealth()` only looked at `status === "ok"` from the relay `/health` endpoint, missing the nonce pool state fields that indicate degradation.

**Changes:**
- `isRelayHealthy()` now returns `false` when `circuitBreakerOpen` is true or `poolStatus` is critical
- `checkRelayHealth()` reads all pool state fields and surfaces issues for circuit breaker, critical pool, low effective capacity (<5), and high conflict count (>10)
- `formatRelayHealthStatus()` renders pool state in diagnostic output
- Added `RelayPoolState` interface and `poolState` field on `RelayHealthStatus`
- 9 new tests covering pool state detection in both functions

Backwards compatible — older relays without the `nonce` field in `/health` work the same as before.