### PR TITLE
fix: point Zest data helper to protocol-data for v0-4-market positions

### DIFF
--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -26,7 +26,7 @@ export const MAINNET_CONTRACTS = {
 
   // Zest Protocol v2
   ZEST_MARKET: "SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7.v0-4-market",
-  ZEST_DATA: "SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7.v0-1-data",
+  ZEST_DATA: "SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7.protocol-data", // read-only helper for v0-4-market positions
   ZEST_MARKET_VAULT: "SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7.v0-market-vault",
   ZEST_VAULT_STX: "SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7.v0-vault-stx",
   ZEST_VAULT_SBTC: "SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7.v0-vault-sbtc",
@@ -51,7 +51,7 @@ export interface ZestAssetConfig {
   /** FT asset name for the underlying (e.g. "sbtc-token" from sbtc-token::sbtc-token). null for wSTX which uses native STX transfers. */
   tokenAssetName: string | null;
   vault: string;
-  assetId: number; // v2 asset index from v0-1-data: STX=0, zSTX=1, sBTC=2, zsBTC=3, stSTX=4, etc. Evens=underlying, odds=zTokens
+  assetId: number; // asset index from protocol-data: STX=0, zSTX=1, sBTC=2, zsBTC=3, stSTX=4, etc. Evens=underlying, odds=zTokens
   decimals: number;
   symbol: string;
   name: string;

--- a/src/services/defi.service.ts
+++ b/src/services/defi.service.ts
@@ -379,7 +379,7 @@ export class ZestProtocolService {
   }
 
   /**
-   * Get all supported assets from Zest Protocol v2
+   * Get all supported assets from Zest Protocol (v0-4-market)
    */
   async getAssets(): Promise<ZestAsset[]> {
     this.ensureMainnet();
@@ -404,7 +404,7 @@ export class ZestProtocolService {
   }
 
   /**
-   * Get user's full position on Zest v2 via the data helper contract.
+   * Get user's full position on Zest via the protocol-data helper contract.
    * Returns collateral, debt, health factor, and LTV data in a single call.
    */
   async getUserPosition(
@@ -575,7 +575,7 @@ export class ZestProtocolService {
   }
 
   /**
-   * Supply assets to Zest v2 via market's supply-collateral-add.
+   * Supply assets to Zest Protocol via market's supply-collateral-add.
    * Atomically deposits into vault and adds zTokens as collateral.
    * This earns yield AND provides borrowing power.
    *
@@ -630,7 +630,7 @@ export class ZestProtocolService {
   }
 
   /**
-   * Add existing zTokens as collateral on Zest v2.
+   * Add existing zTokens as collateral on Zest Protocol.
    * Use this when you deposited directly to a vault (via depositToVault)
    * and need to register those zTokens as collateral for borrowing.
    *
@@ -677,7 +677,7 @@ export class ZestProtocolService {
   }
 
   /**
-   * Withdraw assets from Zest v2 via market's collateral-remove-redeem.
+   * Withdraw assets from Zest Protocol via market's collateral-remove-redeem.
    * Atomically removes zToken collateral and redeems for underlying.
    *
    * Token flow (3 ft-transfers):

--- a/src/tools/defi.tools.ts
+++ b/src/tools/defi.tools.ts
@@ -214,14 +214,14 @@ Note: ALEX DEX is only available on mainnet.`,
   );
 
   // ==========================================================================
-  // Zest Protocol v2 Tools
+  // Zest Protocol Tools (v0-4-market + v0-market-vault)
   // ==========================================================================
 
   // List available assets
   server.registerTool(
     "zest_list_assets",
     {
-      description: `List all supported assets on Zest Protocol v2.
+      description: `List all supported assets on Zest Protocol (v0-4-market).
 
 Returns the list of assets that can be supplied, borrowed, or used as collateral.
 Each asset includes its symbol, name, and contract ID.
@@ -245,7 +245,7 @@ Note: Zest Protocol is only available on mainnet.`,
 
         return createJsonResponse({
           network: NETWORK,
-          version: "v2",
+          version: "v0-4-market",
           assetCount: assets.length,
           assets: assets.map((a) => ({
             symbol: a.symbol,
@@ -265,7 +265,7 @@ Note: Zest Protocol is only available on mainnet.`,
   server.registerTool(
     "zest_get_position",
     {
-      description: `Get user's lending position on Zest Protocol v2.
+      description: `Get user's lending position on Zest Protocol (v0-4-market).
 
 Returns collateral, debt, health factor, and LTV data across all assets.
 The position query returns USD-denominated totals.
@@ -304,7 +304,7 @@ Note: Zest Protocol is only available on mainnet.`,
 
         return createJsonResponse({
           network: NETWORK,
-          version: "v2",
+          version: "v0-4-market",
           address: userAddress,
           position,
         });
@@ -318,7 +318,7 @@ Note: Zest Protocol is only available on mainnet.`,
   server.registerTool(
     "zest_supply",
     {
-      description: `Supply assets to Zest Protocol v2.
+      description: `Supply assets to Zest Protocol (v0-4-market).
 
 Deposits assets and adds them as collateral in one atomic operation.
 The supplied assets earn yield AND provide borrowing power.
@@ -369,7 +369,7 @@ Note: Zest Protocol is only available on mainnet.`,
   server.registerTool(
     "zest_withdraw",
     {
-      description: `Withdraw assets from Zest Protocol v2.
+      description: `Withdraw assets from Zest Protocol (v0-4-market).
 
 Removes collateral and redeems for underlying assets in one atomic operation.
 You can use the asset symbol (e.g., 'sBTC', 'USDC') or full contract ID.
@@ -413,7 +413,7 @@ Note: Amount is in zToken shares. Zest Protocol is only available on mainnet.`,
   server.registerTool(
     "zest_borrow",
     {
-      description: `Borrow assets from Zest Protocol v2.
+      description: `Borrow assets from Zest Protocol (v0-4-market).
 
 Borrows assets against your supplied collateral.
 Ensure you have sufficient collateral to maintain a healthy LTV.
@@ -507,7 +507,7 @@ Mainnet only.`,
   server.registerTool(
     "zest_repay",
     {
-      description: `Repay borrowed assets to Zest Protocol v2.
+      description: `Repay borrowed assets to Zest Protocol (v0-4-market).
 
 Repays borrowed assets plus accrued interest.
 You can use the asset symbol (e.g., 'USDC', 'sBTC') or full contract ID.


### PR DESCRIPTION
Fixes #438

- ZEST_DATA was pointing to v0-1-data which does not track positions in the current v0-4-market
- Updated to protocol-data (SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7.protocol-data), the correct read-only helper for the active market
- Makes zest_get_position, zest_withdraw, and zest_repay visible to positions on v0-4-market
- Updated tool and service descriptions to reflect the current market contract