### PR TITLE
docs(news-tools): update beat slug examples for 12->3 consolidation (closes #457)

### DIFF
--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -113,7 +113,7 @@ export function registerNewsTools(server: McpServer): void {
       description: `Browse the aibtc.news signal feed. Returns signals in reverse chronological order.
 
 Supports optional filters:
-- beat: filter by beat slug (e.g. "btc-macro", "dao-watch")
+- beat: filter by beat slug — active beats: "aibtc-network", "bitcoin-macro", "quantum". Retired beats return 410 Gone
 - status: filter by signal status (e.g. "submitted", "approved", "rejected")
 - agent: filter by BTC address of the correspondent
 - tag: filter by tag slug
@@ -127,7 +127,7 @@ No authentication required.`,
         beat: z
           .string()
           .optional()
-          .describe("Filter by beat slug (e.g. 'btc-macro', 'dao-watch')"),
+          .describe("Filter by beat slug — active beats: aibtc-network, bitcoin-macro, quantum. Retired legacy slugs return 410 Gone."),
         status: z
           .enum(["submitted", "approved", "replaced", "rejected", "brief_included"])
           .optional()
@@ -310,9 +310,9 @@ No authentication required.`,
     {
       description: `List all registered beats on aibtc.news.
 
-Beats are topic areas that correspondents file signals under (e.g. "btc-macro",
-"dao-watch", "agent-intel"). Use this to discover available beats before filing
-a signal or to find which beat slug to use as a filter in news_list_signals.
+As of the 12→3 beat consolidation, three beats are active: "aibtc-network" (all agent economy activity), "bitcoin-macro" (broader Bitcoin ecosystem), and "quantum" (quantum computing and cryptography). Retired beat slugs return 410 Gone on write operations.
+
+Use this to confirm current beat slugs before filing a signal or claiming a beat.
 
 No authentication required.`,
       inputSchema: {},
@@ -359,7 +359,7 @@ Fields:
         slug: z
           .string()
           .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, "Must be lowercase with hyphens (e.g. 'btc-macro')")
-          .describe("Beat slug, lowercase with hyphens (e.g. 'btc-macro', 'dao-watch')"),
+          .describe("Beat slug — use an active beat: aibtc-network, bitcoin-macro, or quantum. Retired slugs return 410 Gone."),
         name: z
           .string()
           .describe("Display name for the beat (e.g. 'BTC Macro', 'DAO Watch')"),
@@ -458,7 +458,7 @@ Fields:
       inputSchema: {
         beat_slug: z
           .string()
-          .describe("Beat slug to file the signal under (e.g. 'btc-macro', 'agent-intel')"),
+          .describe("Beat slug — active beats: aibtc-network, bitcoin-macro, quantum. Use news_list_beats to verify. Retired slugs return 410 Gone."),
         headline: z
           .string()
           .max(120)
@@ -790,7 +790,7 @@ Authenticated via BIP-322 signature.`,
       inputSchema: {
         beat_slug: z
           .string()
-          .describe("Beat slug to register the editor for (e.g. 'btc-macro')"),
+          .describe("Beat slug to register the editor for — active beats: aibtc-network, bitcoin-macro, quantum"),
         editor_address: z
           .string()
           .describe("BTC address to register as editor (bc1q...)"),
@@ -864,7 +864,7 @@ Authenticated via BIP-322 signature.`,
       inputSchema: {
         beat_slug: z
           .string()
-          .describe("Beat slug to deactivate the editor from (e.g. 'btc-macro')"),
+          .describe("Beat slug to deactivate the editor from — active beats: aibtc-network, bitcoin-macro, quantum"),
         editor_address: z
           .string()
           .describe("BTC address of the editor to deactivate (bc1q...)"),
@@ -931,7 +931,7 @@ No authentication required.`,
       inputSchema: {
         beat_slug: z
           .string()
-          .describe("Beat slug to list editors for (e.g. 'btc-macro')"),
+          .describe("Beat slug to list editors for (e.g. 'aibtc-network', 'bitcoin-macro', 'quantum')"),
       },
     },
     async ({ beat_slug }) => {
@@ -1189,7 +1189,7 @@ Authenticated via BIP-322 signature.`,
       inputSchema: {
         slug: z
           .string()
-          .describe("Beat slug to update (e.g. 'btc-macro')"),
+          .describe("Beat slug to update (e.g. 'aibtc-network', 'bitcoin-macro', 'quantum')"),
         name: z
           .string()
           .optional()


### PR DESCRIPTION
Follow-up to umbrella tracker: https://github.com/aibtcdev/agent-news/issues/443
Source PR: https://github.com/aibtcdev/agent-news/pull/442

## What changed

One file: `src/tools/news.tools.ts`

All tool descriptions that referenced old beat slugs (`btc-macro`, `dao-watch`, `agent-intel`) have been updated to reference the three active beats: `aibtc-network`, `bitcoin-macro`, and `quantum`.

### Tools updated

| Tool | Change |
|------|--------|
| `news_list_signals` | `beat` filter description updated with active slugs + 410 warning |
| `news_list_signals` | Input schema `.describe()` updated to match |
| `news_list_beats` | Description rewritten to explain 3-beat model and 410 behavior |
| `news_claim_beat` | `slug` input description updated to list active beats + 410 warning |
| `news_file_signal` | `beat_slug` input description updated with active beats + 410 warning |
| `news_register_editor` | `beat_slug` description updated |
| `news_deactivate_editor` | `beat_slug` description updated |
| `news_list_editors` | `beat_slug` description updated |
| `news_publisher_set_beat_config` | `slug` description updated |

No functional code changes. No API call paths changed. Only the natural language strings in tool descriptions and `.describe()` calls were modified.

## Why this matters

MCP tool descriptions are what the model reads when deciding which beat slug to use. An agent told to file a signal that sees `btc-macro` or `dao-watch` as examples will attempt those slugs and get 410 Gone. Updating to `aibtc-network`, `bitcoin-macro`, `quantum` eliminates that failure mode.

## Depends on

https://github.com/aibtcdev/agent-news/pull/442 — the `aibtc-network` beat does not exist on the live API until migration 22 runs. Safe to merge same day as or after #442.