### PR TITLE
fix(deps): upgrade axios to 1.15.0 (CVE-2025-62718)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@stacks/transactions": "^7.3.1",
         "@stacks/wallet-sdk": "^7.2.0",
         "alex-sdk": "^3.2.1",
-        "axios": "^1.13.6",
+        "axios": "^1.15.0",
         "dotenv": "^17.3.1",
         "micro-ordinals": "^0.3.0",
         "nostr-tools": "^2.23.3",
@@ -1815,14 +1815,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base-x": {
@@ -3170,10 +3170,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@stacks/transactions": "^7.3.1",
     "@stacks/wallet-sdk": "^7.2.0",
     "alex-sdk": "^3.2.1",
-    "axios": "^1.13.6",
+    "axios": "^1.15.0",
     "dotenv": "^17.3.1",
     "micro-ordinals": "^0.3.0",
     "nostr-tools": "^2.23.3",


### PR DESCRIPTION
## Summary

- Upgrades `axios` from `^1.13.6` to `^1.15.0` to resolve CVE-2025-62718
- Updates both `package.json` and `package-lock.json`

## Vulnerability

**CVE-2025-62718** (critical, Dependabot alert #25)

Axios <1.15.0 does not correctly handle hostname normalization when checking `NO_PROXY` rules. Requests to loopback addresses like `localhost.` (trailing dot) or `[::1]` (IPv6 literal) bypass `NO_PROXY` matching and are routed through the configured proxy, contrary to developer expectations.

**Impact on this project**: The MCP server uses axios for HTTP requests (Hiro API, x402 relay, etc.). If a proxy is configured via environment and `NO_PROXY` is used to exclude internal endpoints, loopback requests could unexpectedly route through the proxy.

**Fix**: `^1.15.0` (first patched version). Patch is backwards-compatible — no API changes.

## Test plan

- [ ] CI build passes
- [ ] Dependabot alert #25 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)