### PR TITLE
feat(nostr): add banner field to nostr_set_profile

### DIFF
--- a/src/tools/nostr.tools.ts
+++ b/src/tools/nostr.tools.ts
@@ -411,6 +411,13 @@ export function registerNostrTools(server: McpServer): void {
         name: z.string().optional().describe("Display name."),
         about: z.string().optional().describe("Bio / about text."),
         picture: z.string().url().optional().describe("Profile picture URL."),
+        banner: z
+          .string()
+          .url()
+          .optional()
+          .describe(
+            "Header/cover image URL. Displayed above the profile picture in most Nostr clients (Primal, Snort, Damus)."
+          ),
         website: z.string().url().optional().describe("Website URL."),
         nip05: z
           .string()
@@ -424,7 +431,7 @@ export function registerNostrTools(server: McpServer): void {
           ),
       },
     },
-    async ({ name, about, picture, website, nip05, relays }) => {
+    async ({ name, about, picture, banner, website, nip05, relays }) => {
       try {
         const { sk, pubkey } = deriveNostrKeys();
         const targetRelays = relays && relays.length > 0 ? relays : DEFAULT_RELAYS;
@@ -451,6 +458,7 @@ export function registerNostrTools(server: McpServer): void {
         if (name !== undefined) updates.name = name;
         if (about !== undefined) updates.about = about;
         if (picture !== undefined) updates.picture = picture;
+        if (banner !== undefined) updates.banner = banner;
         if (website !== undefined) updates.website = website;
         if (nip05 !== undefined) updates.nip05 = nip05;
 


### PR DESCRIPTION
Closes #466.

Nostr kind:0 metadata supports a `banner` field (URL to a header/cover image). Most clients (Primal, Snort, Damus) display it above the profile picture. `nostr_set_profile` already covered `name`, `about`, `picture`, `website`, `nip05`, `relays` — adding `banner` matches the existing `picture` pattern.

## Changes

Three additions in `src/tools/nostr.tools.ts`, mirroring the `picture` field:

```diff
 picture: z.string().url().optional().describe("Profile picture URL."),
+banner: z.string().url().optional().describe("Header/cover image URL. Displayed above the profile picture in most Nostr clients (Primal, Snort, Damus)."),
```

```diff
-async ({ name, about, picture, website, nip05, relays }) => {
+async ({ name, about, picture, banner, website, nip05, relays }) => {
```

```diff
 if (picture !== undefined) updates.picture = picture;
+if (banner !== undefined) updates.banner = banner;
 if (website !== undefined) updates.website = website;
```

## Test plan

- [x] `npm run build` passes clean (tsc).
- [ ] Manual: invoke `nostr_set_profile` with `banner` parameter, verify kind:0 event payload includes `banner` key.
- Backwards-compat: callers that omit `banner` keep working — the merge preserves any existing-profile banner value.

Unblocks the Jing Swap Nostr profile setup the issue reporter mentioned.