### PR TITLE
ci: switch npm publish to Trusted Publisher OIDC

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,11 +4,19 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      publish_existing:
+        description: Publish the current package.json version even if no new release is created in this run
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
   pull-requests: write
   packages: write
+  id-token: write
 
 jobs:
   release-please:
@@ -26,7 +34,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created || (github.event_name == 'workflow_dispatch' && inputs.publish_existing) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,10 +43,14 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -49,13 +61,11 @@ jobs:
       - name: Publish to npm
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if npm view "@aibtc/mcp-server@${VERSION}" version 2>/dev/null; then
+          if npm view "@aibtc/mcp-server@${VERSION}" version >/dev/null 2>&1; then
             echo "::notice::@aibtc/mcp-server@${VERSION} already published to npm, skipping"
           else
             npm publish --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Setup Node.js for GitHub Packages
         uses: actions/setup-node@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -81,38 +81,3 @@ jobs:
           npm pkg set name="@aibtc/mcp-server"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Reset npm registry for ClawHub
-        if: ${{ !contains(needs.release-please.outputs.tag_name, '-') }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Publish to ClawHub
-        if: ${{ !contains(needs.release-please.outputs.tag_name, '-') }}
-        continue-on-error: true
-        run: |
-          VERSION="${{ needs.release-please.outputs.version }}"
-
-          # Authenticate with ClawHub
-          npx clawhub login --token "$CLAWHUB_API_TOKEN" --no-browser
-
-          # Get previous tag for changelog
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-
-          # Generate changelog for ClawHub
-          if [ -n "$PREV_TAG" ]; then
-            CHANGELOG=$(git log --pretty=format:"- %s" ${PREV_TAG}..HEAD | head -20)
-          else
-            CHANGELOG="Initial release"
-          fi
-
-          npx clawhub publish ./skill \
-            --slug aibtc-bitcoin-wallet \
-            --name "AIBTC Bitcoin Wallet" \
-            --version "$VERSION" \
-            --changelog "$CHANGELOG" \
-            --tags latest
-        env:
-          CLAWHUB_API_TOKEN: ${{ secrets.CLAWHUB_API_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,12 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created || (github.event_name == 'workflow_dispatch' && inputs.publish_existing) }}
+    # Manual republish (workflow_dispatch + publish_existing) is gated to
+    # refs/heads/main so an attacker with branch-push rights cannot publish
+    # an unreviewed feature-branch build to @aibtc/mcp-server. The npm Trusted
+    # Publisher binding validates org/repo/workflow but not the ref, so this
+    # guard is the defense-in-depth boundary.
+    if: ${{ needs.release-please.outputs.release_created || (github.event_name == 'workflow_dispatch' && inputs.publish_existing && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

The 1.49.0 release publish step failed with `404 Not Found` on the npm PUT — the `NPM_TOKEN` secret (created 2026-01-20) is no longer authorized to publish to `@aibtc/mcp-server`. Switching to **npm Trusted Publishers (OIDC)** to mirror the working setup in [aibtcdev/tx-schemas](https://github.com/aibtcdev/tx-schemas/blob/main/.github/workflows/release-please.yml).

GitHub mints a short-lived OIDC token at workflow runtime; npm validates it against the Trusted Publisher config on the package — no long-lived token to rotate or expire.

## Changes

- Add `id-token: write` permission for OIDC
- Bump `setup-node` to v6, `node-version: 24`, add `cache: npm`
- Add `npm install -g npm@latest` (npm ≥ 11.5.1 is required for OIDC publishing)
- **Remove** `NODE_AUTH_TOKEN: secrets.NPM_TOKEN` from the npm publish step
- Add `workflow_dispatch.inputs.publish_existing` so 1.49.0 (whose tag exists but never made it to npm) can be republished without a version bump
- Tighten the existing `npm view` idempotency check to redirect stdout
- **Drop the ClawHub publish step** — `CLAWHUB_API_TOKEN` is no longer valid; can be re-added later if we decide to publish there again

GitHub Packages publish step is unchanged — it uses `GITHUB_TOKEN`.

## Prerequisites (already done)

The npm Trusted Publisher for `@aibtc/mcp-server` has been configured on npmjs.com to trust:
- Repo: `aibtcdev/aibtc-mcp-server`
- Workflow: `release-please.yml`

## Test plan

- [ ] Merge this PR
- [ ] Manually trigger **Release Please** workflow from the Actions tab with `publish_existing: true` to publish `1.49.0` (the lightning release that failed on the old token)
- [ ] Verify `npm view @aibtc/mcp-server@1.49.0` resolves
- [ ] Verify `provenance` field appears on the published version (OIDC publishes attach provenance by default)
- [ ] Once confirmed working, delete the unused `NPM_TOKEN` and `CLAWHUB_API_TOKEN` repo secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)