### PR TITLE
perf(unisat-indexer): add classifyUtxosFromList to avoid double UTXO fetch on Styx deposits

### DIFF
--- a/src/services/unisat-indexer.ts
+++ b/src/services/unisat-indexer.ts
@@ -318,6 +318,45 @@ export class UnisatIndexer {
   }
 
   /**
+   * Classify a pre-fetched UTXO list without re-fetching from mempool.space.
+   * Use when the caller already holds the full UTXO set (e.g. after a Styx
+   * prepareTransaction call) — saves one network round-trip.
+   */
+  async classifyUtxosFromList(
+    address: string,
+    utxos: UTXO[]
+  ): Promise<ClassifiedUtxos> {
+    const [inscriptions, runeUtxos] = await Promise.all([
+      this.getInscriptionsForAddress(address),
+      this.getAllRuneUtxos(address),
+    ]);
+
+    const inscriptionOutputs = new Set<string>(
+      inscriptions.map((ins) => ins.output)
+    );
+    const runeOutputs = new Set<string>(
+      runeUtxos.map((u) => `${u.txid}:${u.vout}`)
+    );
+
+    const cardinal: UTXO[] = [];
+    const inscription: UTXO[] = [];
+    const rune: UTXO[] = [];
+
+    for (const utxo of utxos) {
+      const outputRef = `${utxo.txid}:${utxo.vout}`;
+      if (inscriptionOutputs.has(outputRef)) {
+        inscription.push(utxo);
+      } else if (runeOutputs.has(outputRef)) {
+        rune.push(utxo);
+      } else {
+        cardinal.push(utxo);
+      }
+    }
+
+    return { cardinal, inscription, rune };
+  }
+
+  /**
    * Get cardinal UTXOs (safe to spend — no inscriptions or runes).
    */
   async getCardinalUtxos(address: string): Promise<UTXO[]> {

--- a/src/tools/styx.tools.ts
+++ b/src/tools/styx.tools.ts
@@ -243,13 +243,11 @@ export function registerStyxTools(server: McpServer): void {
         let safeUtxos = prepared.utxos;
         let ordinalsFiltered = false;
         const indexer = new UnisatIndexer(NETWORK);
-        const cardinalUtxos = await indexer.getCardinalUtxos(resolvedBtcSender);
-        const cardinalSet = new Set(
-          cardinalUtxos.map((u) => `${u.txid}:${u.vout}`)
+        const classified = await indexer.classifyUtxosFromList(
+          resolvedBtcSender,
+          prepared.utxos
         );
-        const filtered = prepared.utxos.filter((u) =>
-          cardinalSet.has(`${u.txid}:${u.vout}`)
-        );
+        const filtered = classified.cardinal;
         if (filtered.length < prepared.utxos.length) {
           const removed = prepared.utxos.length - filtered.length;
           if (filtered.length === 0) {
@@ -481,3 +479,4 @@ export function registerStyxTools(server: McpServer): void {
     }
   );
 }
+


### PR DESCRIPTION
## Summary

Fixes #483.

`styx.tools.ts` already holds `prepared.utxos` from the Styx SDK after `prepareTransaction`. The subsequent `getCardinalUtxos` call re-fetched the same full UTXO set from mempool.space before classifying — one redundant network round-trip per Styx deposit.

### Changes

**`src/services/unisat-indexer.ts`** — adds `classifyUtxosFromList(address, utxos)`:
- Accepts a caller-supplied UTXO list instead of fetching from mempool.space
- Only fetches inscription and rune index data from Unisat (two calls, same as before)
- Existing `classifyUtxos`, `getCardinalUtxos`, and `getOrdinalUtxos` are unchanged

**`src/tools/styx.tools.ts`** — migrates the ordinal-filter step to use the new method:
- Replaces `getCardinalUtxos(resolvedBtcSender)` + manual Set intersection with `classifyUtxosFromList(resolvedBtcSender, prepared.utxos)`
- Saves one `GET /api/address/{addr}/utxo` call to mempool.space on every Styx deposit

### Out of scope

`sbtc-deposit.service.ts` — as noted in #483, that call site doesn't have a pre-fetched list, so the existing `getCardinalUtxos` path is correct there.
