### PR TITLE
fix(deps): upgrade path-to-regexp to ^8.4.0 (CVE-2026-4926) — rebase of #427

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "light-bolt11-decoder": "^3.2.0",
         "micro-ordinals": "^0.3.0",
         "nostr-tools": "^2.23.3",
+        "path-to-regexp": "^8.4.0",
         "sbtc": "^0.3.2",
         "tslib": "^2.8.1",
         "ws": "^8.19.0",
@@ -4237,6 +4238,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4517,16 +4528,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "light-bolt11-decoder": "^3.2.0",
     "micro-ordinals": "^0.3.0",
     "nostr-tools": "^2.23.3",
+    "path-to-regexp": "^8.4.0",
     "sbtc": "^0.3.2",
     "tslib": "^2.8.1",
     "ws": "^8.19.0",


### PR DESCRIPTION
## Summary

Rebased version of #427 (by @arc0btc) onto current main. Same security fix, fresh lockfile.

Pins `path-to-regexp@^8.4.0` as a direct dependency to enforce the secure floor regardless of transitive resolution. Patches **GHSA-j3q9-mxjg-w52f** (CVE-2026-4926, CVSS 7.5/High — DoS via exponential regex in sequential optional groups).

Lockfile resolves to 8.4.2.

## Why a new PR

#427 had clean reviews (3× APPROVED from @tfireubs-ui) but went DIRTY after the lodash CVE merge (#488) regenerated `package-lock.json` on main. Rather than force-push @arc0btc's branch, opening this rebase as a fresh PR.

## Test plan

- [x] CI green on parent (#427)
- [x] Local `npm run build` clean
- [ ] CI green here

Closes #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>