### PR TITLE
docs(endpoint-tools): surface testnet x402 equivalents in tool descriptions

### DIFF
--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -266,9 +266,9 @@ If you're looking to perform a direct blockchain action (transfer STX, call a co
 
 Supported sources:
 - x402.biwas.xyz (default): Use path like "/api/pools/trending"
-- x402.aibtc.com: Use apiUrl="https://x402.aibtc.com" with path like "/inference/openrouter/chat"
+- x402.aibtc.com (mainnet) / x402.aibtc.dev (testnet): Use apiUrl="https://x402.aibtc.com" with path like "/inference/openrouter/chat"
 - stx402.com: Use apiUrl="https://stx402.com" with path like "/ai/dad-joke"
-- aibtc.com: Use apiUrl="https://aibtc.com" with path like "/api/inbox/{address}"
+- aibtc.com (mainnet) / aibtc.dev (testnet): Use apiUrl="https://aibtc.com" with path like "/api/inbox/{address}"
 - Any x402-compatible URL: Use url parameter with full endpoint URL
 
 Use list_x402_endpoints to discover available endpoints.
@@ -472,9 +472,9 @@ After probing a paid endpoint, use execute_x402_endpoint to actually execute and
 
 Supported sources:
 - x402.biwas.xyz (default): Use path like "/api/pools/trending"
-- x402.aibtc.com: Use apiUrl="https://x402.aibtc.com" with path like "/inference/openrouter/chat"
+- x402.aibtc.com (mainnet) / x402.aibtc.dev (testnet): Use apiUrl="https://x402.aibtc.com" with path like "/inference/openrouter/chat"
 - stx402.com: Use apiUrl="https://stx402.com" with path like "/ai/dad-joke"
-- aibtc.com: Use apiUrl="https://aibtc.com" with path like "/api/inbox/{address}"
+- aibtc.com (mainnet) / aibtc.dev (testnet): Use apiUrl="https://aibtc.com" with path like "/api/inbox/{address}"
 - Any x402-compatible URL: Use url parameter with full endpoint URL`,
       inputSchema: {
         method: z


### PR DESCRIPTION
## Summary

Closes #491 (RPC-binding audit minor finding).

`execute_x402_endpoint` and `probe_x402_endpoint` tool descriptions listed mainnet-only x402 service URLs in their examples (`x402.aibtc.com`, `aibtc.com`). Agents on testnet reading these descriptions had no indication that testnet equivalents (`x402.aibtc.dev`, `aibtc.dev`) exist.

## Change

Inline `(mainnet) / (testnet)` annotations alongside the example URLs in both tool descriptions. The actual `apiUrl` parameter still accepts any URL — this only adjusts the LLM-facing prompt text so testnet users discover the right hostnames.

## Why this is small

Tool descriptions are documentation for the consuming agent, not authoritative bindings. The runtime URL resolution is unchanged. Two-line text edit in two places.

## Test plan

- [x] `npm run build` passes (TypeScript compiles)
- [ ] When merged: closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)