### PR TITLE
feat(wallet): derive Lightning wallet from main mnemonic on create/import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,8 @@ The `--desktop` flag auto-detects your OS and writes to the correct Claude Deskt
 - `get_stx_balance` - Get STX balance for any address
 
 ### Wallet Management
-- `wallet_create` - Generate a new wallet with BIP39 mnemonic (encrypted locally)
-- `wallet_import` - Import an existing wallet from mnemonic
+- `wallet_create` - Generate a new wallet with BIP39 mnemonic (encrypted locally). Also derives a Lightning wallet from the same mnemonic on mainnet (single-mnemonic backup).
+- `wallet_import` - Import an existing wallet from mnemonic. Also derives a Lightning wallet from the same mnemonic on mainnet.
 - `wallet_unlock` - Unlock a wallet for transactions (requires password)
 - `wallet_lock` - Lock the wallet (clear from memory)
 - `wallet_list` - List all available wallets
@@ -178,6 +178,16 @@ The `--desktop` flag auto-detects your OS and writes to the correct Claude Deskt
 - `wallet_delete` - Permanently delete a wallet
 - `wallet_export` - Export mnemonic (with security warning)
 - `wallet_status` - Get current wallet/session status
+
+**Unified mnemonic for Lightning (mainnet):**
+
+On mainnet, `wallet_create` and `wallet_import` automatically derive a Spark-backed Lightning wallet from the *same* mnemonic and persist it to `~/.aibtc/lightning/keystore.json`. Users only need to back up one phrase — the Stacks L2, Bitcoin L1 (SegWit + Taproot), and Lightning wallets all derive from it. The Lightning deposit address is included in the response so the wallet is immediately usable for L402 challenges and `lightning_fund_from_btc`.
+
+The unified setup is skipped (with a message) when:
+- Network is testnet — Spark currently has no public Bitcoin testnet environment
+- A Lightning keystore already exists — never clobbered to protect users with pre-existing Lightning wallets created via `lightning_create` / `lightning_import`
+
+**Trade-off:** A leaked mnemonic now exposes both the main wallet and the Lightning wallet. This is the standard concentrated-risk profile of a single-seed wallet design — users who want air-gapped separation can still use `lightning_create` / `lightning_import` independently to maintain two mnemonics.
 
 ### Bitcoin L1 Transactions
 

--- a/src/services/lightning-manager.ts
+++ b/src/services/lightning-manager.ts
@@ -64,6 +64,26 @@ export interface LightningImportResult {
   lightningAddress: string | null;
 }
 
+/**
+ * Outcome of attempting to derive a Lightning wallet from the main wallet's
+ * mnemonic during wallet_create / wallet_import.
+ *
+ * `setup` carries the addresses when a Lightning wallet was created;
+ * `skipped` explains why we didn't (existing keystore, unsupported network).
+ */
+export type LightningUnifiedSetupResult =
+  | {
+      kind: "setup";
+      walletId: string;
+      depositAddress: string;
+      lightningAddress: string | null;
+    }
+  | {
+      kind: "skipped";
+      reason: "existing-lightning-wallet" | "network-unsupported";
+      message: string;
+    };
+
 export interface LightningUnlockResult {
   walletId: string;
   balanceSats: number;
@@ -199,6 +219,68 @@ class LightningManager {
     return {
       walletId,
       mnemonic,
+      depositAddress,
+      lightningAddress,
+    };
+  }
+
+  /**
+   * Derive a Lightning wallet from the main wallet's mnemonic during
+   * wallet_create / wallet_import, so users only have to back up one
+   * mnemonic.
+   *
+   * Skips (returns kind:"skipped") when:
+   *   - a Lightning keystore already exists — never clobber an existing wallet
+   *   - network is not mainnet — Spark currently only supports mainnet, see
+   *     toSparkNetwork() in spark-provider.ts
+   *
+   * Throws on unexpected failures (e.g. Spark connectivity) so callers can
+   * surface the error to the user — the main wallet creation has already
+   * succeeded by the time we get here, so callers should treat throws as
+   * non-fatal warnings rather than propagating them.
+   */
+  async setupFromMainMnemonic(
+    mnemonic: string,
+    password: string,
+    name: string,
+    network: Network
+  ): Promise<LightningUnifiedSetupResult> {
+    if (network !== "mainnet") {
+      return {
+        kind: "skipped",
+        reason: "network-unsupported",
+        message:
+          "Lightning is currently only supported on mainnet (Spark has no public Bitcoin testnet).",
+      };
+    }
+
+    if (await this.keystoreExists()) {
+      return {
+        kind: "skipped",
+        reason: "existing-lightning-wallet",
+        message:
+          "An existing Lightning wallet was found at ~/.aibtc/lightning/keystore.json — leaving it untouched.",
+      };
+    }
+
+    const normalized = mnemonic.trim().toLowerCase();
+    if (!validateMnemonic(normalized, wordlist)) {
+      throw new InvalidMnemonicError();
+    }
+
+    const { walletId, provider } = await this.storeWallet(
+      name,
+      normalized,
+      password,
+      network
+    );
+
+    const depositAddress = await provider.getDepositAddress();
+    const lightningAddress = await this.safeLightningAddress(provider);
+
+    return {
+      kind: "setup",
+      walletId,
       depositAddress,
       lightningAddress,
     };

--- a/src/tools/wallet-management.tools.ts
+++ b/src/tools/wallet-management.tools.ts
@@ -2,7 +2,70 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createJsonResponse, createErrorResponse } from "../utils/index.js";
 import { getWalletManager } from "../services/wallet-manager.js";
+import {
+  getLightningManager,
+  type LightningUnifiedSetupResult,
+} from "../services/lightning-manager.js";
 import { NETWORK, API_URL } from "../config/networks.js";
+import type { Network } from "../config/networks.js";
+
+/**
+ * Try to derive a Lightning wallet from the main wallet's mnemonic during
+ * wallet_create / wallet_import.
+ *
+ * Returns a payload to merge into the response body. Failures here must NOT
+ * fail the main wallet flow — the Stacks/BTC wallet has already been
+ * persisted by the time we get here, so we render Lightning issues as a
+ * warning instead.
+ */
+async function tryUnifiedLightningSetup(
+  mnemonic: string,
+  password: string,
+  name: string,
+  network: Network
+): Promise<{
+  result: LightningUnifiedSetupResult | null;
+  warning?: string;
+}> {
+  try {
+    const result = await getLightningManager().setupFromMainMnemonic(
+      mnemonic,
+      password,
+      name,
+      network
+    );
+    return { result };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      result: null,
+      warning: `Lightning setup skipped due to error: ${message}`,
+    };
+  }
+}
+
+function renderLightningSection(
+  setup: LightningUnifiedSetupResult | null,
+  warning?: string
+): Record<string, unknown> {
+  if (!setup) {
+    return {
+      "Lightning (BTC L2)": warning ?? "Lightning setup not attempted.",
+    };
+  }
+  if (setup.kind === "skipped") {
+    return { "Lightning (BTC L2)": setup.message };
+  }
+  return {
+    "Lightning (BTC L2)": {
+      "Deposit Address": `${setup.depositAddress} (fund Lightning from L1 BTC)`,
+      ...(setup.lightningAddress
+        ? { "Lightning Address": setup.lightningAddress }
+        : {}),
+      "Note": "Derived from the same mnemonic — one backup covers all wallets.",
+    },
+  };
+}
 
 /**
  * Register wallet management tools
@@ -34,10 +97,19 @@ IMPORTANT: Save the mnemonic securely - it will only be shown once!`,
         const walletManager = getWalletManager();
         const result = await walletManager.createWallet(name, password, network);
 
+        const resolvedNetwork = network || NETWORK;
+        const { result: lightningSetup, warning: lightningWarning } =
+          await tryUnifiedLightningSetup(
+            result.mnemonic,
+            password,
+            name,
+            resolvedNetwork
+          );
+
         return createJsonResponse({
           success: true,
           message:
-            "Wallet created successfully! Bitcoin L1 (SegWit + Taproot) and Stacks L2 addresses ready.",
+            "Wallet created successfully! Bitcoin L1 (SegWit + Taproot), Stacks L2, and Lightning addresses ready.",
           walletId: result.walletId,
           "Bitcoin (L1)": {
             "Native SegWit": `${result.btcAddress} (send/receive BTC)`,
@@ -47,12 +119,14 @@ IMPORTANT: Save the mnemonic securely - it will only be shown once!`,
             "Address": result.address,
             "Tip": "Register a BNS name for on-chain identity",
           },
-          network: network || NETWORK,
+          ...renderLightningSection(lightningSetup, lightningWarning),
+          network: resolvedNetwork,
           "---": "",
           mnemonic: result.mnemonic,
           warning:
             "CRITICAL: Save this mnemonic phrase securely! It will NOT be shown again. " +
-            "This is the only way to recover the wallet if the password is forgotten.",
+            "This is the only way to recover the wallet if the password is forgotten. " +
+            "Note: Lightning is derived from the same mnemonic — a single leaked mnemonic exposes all wallets.",
         });
       } catch (error) {
         return createErrorResponse(error);
@@ -91,9 +165,19 @@ The wallet is encrypted locally and stored in ~/.aibtc/.`,
           network
         );
 
+        const resolvedNetwork = network || NETWORK;
+        const { result: lightningSetup, warning: lightningWarning } =
+          await tryUnifiedLightningSetup(
+            mnemonic,
+            password,
+            name,
+            resolvedNetwork
+          );
+
         return createJsonResponse({
           success: true,
-          message: "Wallet imported successfully! Bitcoin L1 (SegWit + Taproot) and Stacks L2 addresses ready.",
+          message:
+            "Wallet imported successfully! Bitcoin L1 (SegWit + Taproot), Stacks L2, and Lightning addresses ready.",
           walletId: result.walletId,
           "Bitcoin (L1)": {
             "Native SegWit": `${result.btcAddress} (send/receive BTC)`,
@@ -103,7 +187,8 @@ The wallet is encrypted locally and stored in ~/.aibtc/.`,
             "Address": result.address,
             "Tip": "Register a BNS name for on-chain identity",
           },
-          network: network || NETWORK,
+          ...renderLightningSection(lightningSetup, lightningWarning),
+          network: resolvedNetwork,
         });
       } catch (error) {
         return createErrorResponse(error);

--- a/tests/services/lightning-unified-setup.test.ts
+++ b/tests/services/lightning-unified-setup.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for setupFromMainMnemonic — the unified-mnemonic Lightning setup that
+ * wallet_create / wallet_import call to derive a Spark-backed Lightning wallet
+ * from the same mnemonic as the main Stacks/BTC wallet.
+ *
+ * Runs offline: fs/promises is stubbed with an in-memory map and
+ * SparkLightningProvider.initialize is mocked so no real Spark call is made.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "path";
+import os from "os";
+
+// --- in-memory fs ----------------------------------------------------------
+
+const files = new Map<string, string>();
+const dirs = new Set<string>();
+
+class ENOENTError extends Error {
+  code = "ENOENT";
+}
+
+vi.mock("fs/promises", () => {
+  const mkdir = vi.fn(async (p: string) => {
+    dirs.add(p);
+  });
+  const access = vi.fn(async (p: string) => {
+    if (!files.has(p) && !dirs.has(p)) throw new ENOENTError(`ENOENT: ${p}`);
+  });
+  const readFile = vi.fn(async (p: string) => {
+    if (!files.has(p)) throw new ENOENTError(`ENOENT: ${p}`);
+    return files.get(p)!;
+  });
+  const writeFile = vi.fn(async (p: string, content: string) => {
+    files.set(p, content);
+  });
+  const rename = vi.fn(async (from: string, to: string) => {
+    const content = files.get(from);
+    if (content === undefined) throw new ENOENTError(`ENOENT: ${from}`);
+    files.set(to, content);
+    files.delete(from);
+  });
+
+  const api = { mkdir, access, readFile, writeFile, rename };
+  return { default: api, ...api };
+});
+
+// --- spark provider stub ---------------------------------------------------
+
+const sparkInitialize = vi.fn(async () => ({
+  getDepositAddress: vi.fn(async () => "bc1qfake-deposit-address-from-spark"),
+  getBalance: vi.fn(async () => ({ balanceSats: 0 })),
+  // intentionally omit getLightningAddress to exercise the safeLightningAddress
+  // fallback path (returns null when provider doesn't implement it)
+}));
+
+vi.mock("../../src/services/lightning/spark-provider.js", () => ({
+  SparkLightningProvider: {
+    initialize: sparkInitialize,
+  },
+}));
+
+// --- import after mocks ----------------------------------------------------
+
+const { getLightningManager } = await import(
+  "../../src/services/lightning-manager.js"
+);
+
+const KEYSTORE_PATH = path.join(
+  os.homedir(),
+  ".aibtc",
+  "lightning",
+  "keystore.json"
+);
+
+// Standard BIP39 test vector — 12 words, validates against the wordlist.
+const VALID_MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+describe("LightningManager.setupFromMainMnemonic", () => {
+  beforeEach(() => {
+    files.clear();
+    dirs.clear();
+    sparkInitialize.mockClear();
+    // reset singleton's in-memory session so each test starts clean
+    (getLightningManager() as unknown as { session: unknown }).session = null;
+  });
+
+  it("skips on testnet with reason 'network-unsupported'", async () => {
+    const result = await getLightningManager().setupFromMainMnemonic(
+      VALID_MNEMONIC,
+      "password-1234",
+      "test-wallet",
+      "testnet"
+    );
+
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") {
+      expect(result.reason).toBe("network-unsupported");
+      expect(result.message).toMatch(/mainnet/i);
+    }
+
+    // Spark must not have been called
+    expect(sparkInitialize).not.toHaveBeenCalled();
+    // No keystore written
+    expect(files.has(KEYSTORE_PATH)).toBe(false);
+  });
+
+  it("skips when an existing Lightning keystore is present", async () => {
+    const existingKeystore = JSON.stringify({
+      version: 1,
+      walletId: "pre-existing",
+      name: "old-lightning",
+      network: "mainnet",
+      encrypted: { ciphertext: "x", iv: "y", salt: "z", tag: "w" },
+      createdAt: "2025-01-01T00:00:00.000Z",
+    });
+    files.set(KEYSTORE_PATH, existingKeystore);
+
+    const result = await getLightningManager().setupFromMainMnemonic(
+      VALID_MNEMONIC,
+      "password-1234",
+      "test-wallet",
+      "mainnet"
+    );
+
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") {
+      expect(result.reason).toBe("existing-lightning-wallet");
+    }
+
+    expect(sparkInitialize).not.toHaveBeenCalled();
+    // Keystore content untouched
+    expect(files.get(KEYSTORE_PATH)).toBe(existingKeystore);
+  });
+
+  it("creates a Lightning wallet on mainnet from the main mnemonic", async () => {
+    const result = await getLightningManager().setupFromMainMnemonic(
+      VALID_MNEMONIC,
+      "password-1234",
+      "test-wallet",
+      "mainnet"
+    );
+
+    expect(result.kind).toBe("setup");
+    if (result.kind === "setup") {
+      expect(result.depositAddress).toBe(
+        "bc1qfake-deposit-address-from-spark"
+      );
+      expect(result.lightningAddress).toBeNull();
+      expect(result.walletId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    }
+
+    // Spark was initialized exactly once with the user's mnemonic + mainnet
+    expect(sparkInitialize).toHaveBeenCalledTimes(1);
+    expect(sparkInitialize).toHaveBeenCalledWith(VALID_MNEMONIC, "mainnet");
+
+    // Keystore was persisted
+    expect(files.has(KEYSTORE_PATH)).toBe(true);
+    const persisted = JSON.parse(files.get(KEYSTORE_PATH)!);
+    expect(persisted.network).toBe("mainnet");
+    expect(persisted.name).toBe("test-wallet");
+    expect(persisted.encrypted).toBeDefined();
+    // The plaintext mnemonic must NOT be persisted
+    expect(files.get(KEYSTORE_PATH)!).not.toContain(VALID_MNEMONIC);
+  });
+
+  it("rejects an invalid mnemonic on mainnet without writing a keystore", async () => {
+    await expect(
+      getLightningManager().setupFromMainMnemonic(
+        "not a valid mnemonic phrase at all",
+        "password-1234",
+        "test-wallet",
+        "mainnet"
+      )
+    ).rejects.toThrow();
+
+    expect(sparkInitialize).not.toHaveBeenCalled();
+    expect(files.has(KEYSTORE_PATH)).toBe(false);
+  });
+
+  it("normalizes mnemonic whitespace and case before deriving", async () => {
+    const messy = `  ${VALID_MNEMONIC.toUpperCase()}  `;
+    const result = await getLightningManager().setupFromMainMnemonic(
+      messy,
+      "password-1234",
+      "test-wallet",
+      "mainnet"
+    );
+
+    expect(result.kind).toBe("setup");
+    // Spark sees the normalized form, not the messy input
+    expect(sparkInitialize).toHaveBeenCalledWith(VALID_MNEMONIC, "mainnet");
+  });
+});


### PR DESCRIPTION
Closes #477 (initial-setup acceptance criterion — first AC of the issue).

## Summary

- `wallet_create` / `wallet_import` now auto-provision a Spark-backed Lightning wallet from the **same mnemonic** as the Stacks/BTC wallet on mainnet — users back up one phrase, get all four wallets (Stacks L2, BTC SegWit, BTC Taproot, Lightning).
- Lightning deposit address is surfaced in the response so the wallet is immediately usable for `lightning_fund_from_btc` and L402 challenges.
- Skips gracefully when network is testnet (Spark has no public Bitcoin testnet) or when a Lightning keystore already exists (never clobbers pre-existing standalone Lightning wallets created via `lightning_create` / `lightning_import`).
- Spark init failures (e.g. connectivity) are rendered as a non-fatal warning — the main wallet is already saved by then, so users still get a working Stacks/BTC wallet.

## Files

- `src/services/lightning-manager.ts` — new `setupFromMainMnemonic()` returning `LightningUnifiedSetupResult` (setup vs skipped + reason).
- `src/tools/wallet-management.tools.ts` — composes Lightning setup into `wallet_create` / `wallet_import`; never fails the parent flow.
- `CLAUDE.md` — documents the unified flow and the concentrated-risk trade-off.

## Out of scope (follow-ups for #477)

- `lightning_import_from_main` for users with an existing main wallet who want to opt in
- Surfacing Lightning identifiers in `wallet_status`
- Migrating already-created Lightning wallets to the main mnemonic

Existing two-mnemonic users (created via PR #474 with `lightning_create` / `lightning_import`) keep working — the unified setup detects an existing keystore and leaves it alone.

## Test plan

- [ ] On mainnet, run `wallet_create` — response includes a `Lightning (BTC L2)` section with a deposit address; `~/.aibtc/lightning/keystore.json` is created
- [ ] On mainnet, run `wallet_import` with a known mnemonic — Lightning wallet is derived from the same mnemonic; deposit address matches `lightning_status` after `lightning_unlock`
- [ ] On testnet, run `wallet_create` — Lightning section shows "Lightning is currently only supported on mainnet…"; no `~/.aibtc/lightning/keystore.json` is created
- [ ] With an existing `~/.aibtc/lightning/keystore.json`, run `wallet_create` — Lightning section shows the "leaving it untouched" message; existing keystore is unchanged
- [ ] Simulate Spark failure (e.g. offline) — `wallet_create` still succeeds and returns a `lightningWarning` rendered in the Lightning section
- [ ] Existing Lightning users (created via `lightning_create`) can still `lightning_unlock` after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)