### PR TITLE
feat(bitflow): enable Bitflow DEX tools for trading competition

### DIFF
--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -242,35 +242,34 @@ export const BITFLOW_CONTRACTS = {
  */
 export interface BitflowConfig {
   apiHost: string;
-  apiKey: string | undefined;
   readOnlyCallApiHost: string;
-  keeperApiHost?: string;
-  keeperApiKey?: string;
+  keeperApiHost: string;
 }
 
 /**
- * Get Bitflow configuration from environment.
- *
- * As of @bitflowlabs/core-sdk v2.4.2, API keys are fully optional.
- * All public endpoints (tokens, quotes, routes, swaps) are accessible
- * without a key at 500 req/min per IP. Keys only needed for higher limits.
- *
- * Optional env vars:
- * - BITFLOW_API_KEY: Core API key (higher rate limits)
- * - BITFLOW_API_HOST: Override default API host
- * - BITFLOW_KEEPER_API_KEY: Keeper automation features
- * - BITFLOW_KEEPER_API_HOST: Override Keeper API host
- * - BITFLOW_READONLY_API_HOST: Override Stacks read-only node (default: api.hiro.so)
+ * Bitflow public API base URL (also used for SDK calls — same gateway).
+ * All endpoints are publicly accessible; no API key required.
+ * Per docs: https://docs.bitflow.finance/bitflow-documentation/developers/bitflow-sdk
  */
-export function getBitflowConfig(): BitflowConfig {
-  const readOnlyCallApiHost = process.env.BITFLOW_READONLY_API_HOST || "https://api.hiro.so";
+export const BITFLOW_PUBLIC_API = "https://bitflow-sdk-api-gateway-7owjsmt8.uc.gateway.dev";
 
+/**
+ * Stacks read-only node used by the SDK to compute quotes (reads pool reserves).
+ * Per Bitflow SDK docs.
+ */
+export const BITFLOW_READONLY_HOST = "https://node.bitflowapis.finance";
+
+/**
+ * Keeper API host for automated swap orders.
+ * Per Bitflow SDK docs.
+ */
+export const BITFLOW_KEEPER_HOST = "https://bitflow-keeper-test-7owjsmt8.uc.gateway.dev";
+
+export function getBitflowConfig(): BitflowConfig {
   return {
-    apiHost: process.env.BITFLOW_API_HOST || "https://bitflowsdk-api-test-7owjsmt8.uk.gateway.dev",
-    apiKey: process.env.BITFLOW_API_KEY,
-    readOnlyCallApiHost,
-    keeperApiHost: process.env.BITFLOW_KEEPER_API_HOST || "https://bitflow-keeper-test-7owjsmt8.uc.gateway.dev",
-    keeperApiKey: process.env.BITFLOW_KEEPER_API_KEY,
+    apiHost: BITFLOW_PUBLIC_API,
+    readOnlyCallApiHost: BITFLOW_READONLY_HOST,
+    keeperApiHost: BITFLOW_KEEPER_HOST,
   };
 }
 
@@ -280,11 +279,6 @@ export function getBitflowConfig(): BitflowConfig {
 export function getBitflowContracts(network: Network) {
   return BITFLOW_CONTRACTS[network];
 }
-
-/**
- * Bitflow public API base URL (no API key required)
- */
-export const BITFLOW_PUBLIC_API = "https://bitflow-sdk-api-gateway-7owjsmt8.uc.gateway.dev";
 
 /**
  * Get ERC-8004 contract addresses for the network

--- a/src/services/bitflow.service.ts
+++ b/src/services/bitflow.service.ts
@@ -91,17 +91,8 @@ export interface BitflowToken {
 /**
  * Bitflow Service
  *
- * As of @bitflowlabs/core-sdk v2.4.2, all API keys are optional.
- * The SDK works out of the box with public rate limits (500 req/min per IP).
- *
- * Optional env vars for higher rate limits:
- *   - BITFLOW_API_KEY: Core API (tokens, quotes, routes)
- *   - BITFLOW_API_HOST: Override API host
- *   - BITFLOW_KEEPER_API_KEY: Keeper automation features
- *   - BITFLOW_KEEPER_API_HOST: Override Keeper API host
- *   - BITFLOW_READONLY_API_HOST: Override Stacks read-only node
- *
- * Request higher limits: help@bitflow.finance
+ * All Bitflow endpoints are public — no API key required.
+ * Public rate limit is 500 req/min per IP, which is per-agent (each MCP runs locally).
  */
 export class BitflowService {
   private sdk: BitflowSDK | null = null;
@@ -112,10 +103,6 @@ export class BitflowService {
     this.initializeSdk();
   }
 
-  /**
-   * Initialize the Bitflow SDK.
-   * API keys are optional — public endpoints work without them.
-   */
   private initializeSdk(): void {
     if (this.sdkInitialized) return;
     this.sdkInitialized = true;
@@ -125,12 +112,10 @@ export class BitflowService {
     try {
       this.sdk = new BitflowSDK({
         BITFLOW_API_HOST: config.apiHost,
-        ...(config.apiKey && { BITFLOW_API_KEY: config.apiKey }),
         READONLY_CALL_API_HOST: config.readOnlyCallApiHost,
         BITFLOW_PROVIDER_ADDRESS: "",
         READONLY_CALL_API_KEY: "",
-        KEEPER_API_HOST: config.keeperApiHost || "",
-        ...(config.keeperApiKey && { KEEPER_API_KEY: config.keeperApiKey }),
+        KEEPER_API_HOST: config.keeperApiHost,
       });
     } catch (error) {
       console.error("Failed to initialize Bitflow SDK:", error);
@@ -153,7 +138,7 @@ export class BitflowService {
   private ensureSdk(): BitflowSDK {
     if (!this.sdk) {
       throw new Error(
-        "Bitflow SDK failed to initialize. Check BITFLOW_API_HOST / BITFLOW_READONLY_API_HOST configuration and server logs."
+        "Bitflow SDK failed to initialize. See server logs."
       );
     }
     return this.sdk;
@@ -255,9 +240,8 @@ export class BitflowService {
     functionName: string,
     args: string[] = []
   ): Promise<any> {
-    const config = getBitflowConfig();
-    const host = config?.readOnlyCallApiHost || process.env.BITFLOW_READONLY_API_HOST || "https://node.bitflowapis.finance";
-    const url = `${host}/v2/contracts/call-read/${contractAddress}/${contractName}/${functionName}`;
+    const { readOnlyCallApiHost } = getBitflowConfig();
+    const url = `${readOnlyCallApiHost}/v2/contracts/call-read/${contractAddress}/${contractName}/${functionName}`;
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,8 +16,7 @@ import { registerQueryTools } from "./query.tools.js";
 import { registerReputationTools } from "./reputation.tools.js";
 import { registerEndpointTools } from "./endpoint.tools.js";
 import { registerDefiTools } from "./defi.tools.js";
-// TODO: Re-enable when Bitflow API key integration is complete
-// import { registerBitflowTools } from "./bitflow.tools.js";
+import { registerBitflowTools } from "./bitflow.tools.js";
 import { registerScaffoldTools } from "./scaffold.tools.js";
 import { registerOpenRouterTools } from "./openrouter.tools.js";
 import { registerYieldHunterTools } from "./yield-hunter.tools.js";
@@ -125,8 +124,8 @@ export function registerAllTools(server: McpServer): void {
   // DeFi (ALEX DEX, Zest Protocol)
   registerDefiTools(server);
 
-  // Bitflow DEX (disabled until API key integration is complete)
-  // registerBitflowTools(server);
+  // Bitflow DEX (public API — no key required, key only raises rate limits)
+  registerBitflowTools(server);
 
   // Styx BTC→sBTC conversion
   registerStyxTools(server);

--- a/tests/services/bitflow.test.ts
+++ b/tests/services/bitflow.test.ts
@@ -175,7 +175,7 @@ describe("bitflow.service", () => {
       (service as any).sdk = null;
 
       await expect(service.getAvailableTokens()).rejects.toThrow(
-        "Bitflow SDK failed to initialize. Check BITFLOW_API_HOST / BITFLOW_READONLY_API_HOST configuration and server logs."
+        "Bitflow SDK failed to initialize. See server logs."
       );
     });
 


### PR DESCRIPTION
## Summary

Re-enables the 11 `bitflow_*` MCP tools for all agents. Bitflow tool registration was previously gated behind a `TODO: Re-enable when Bitflow API key integration is complete` comment in `src/tools/index.ts`. Per the [Bitflow SDK docs](https://docs.bitflow.finance/bitflow-documentation/developers/bitflow-sdk):

> All Bitflow API endpoints are publicly accessible without an API key.

API keys exist purely to raise the default **500 req/min/IP** rate limit. Since each agent runs its own MCP server locally, the rate limit is per-agent — no shared bottleneck even at 1000+ agents. The blocker was bogus.

This unblocks trading on Bitflow for the upcoming agent trading competition. Agents now have access to a DEX aggregator (in addition to the existing direct-to-pool ALEX integration).

## Why the existing `.env` config was broken

The repo `.env` had four `BITFLOW_*` vars that were either redundant or pointing at dead infrastructure:

| Var | Issue |
|-----|-------|
| `BITFLOW_API_KEY` | Not required by the API; carrying a stale credential in repo |
| `BITFLOW_API_HOST` | Already hardcoded as `BITFLOW_PUBLIC_API` constant — overrode itself with the same value |
| `BITFLOW_STACKS_API_HOST` | Not read anywhere in the code (dead config) |
| `BITFLOW_READONLY_CALL_API_HOST` | **Pointed at `wvzrnmxqmi.execute-api.us-east-2.amazonaws.com` which returns `ENOTFOUND`.** This is the host the SDK uses to read pool reserves during quotes — its failure caused every `bitflow_get_quote` call to silently return `undefined`. |

The third issue is what made every Bitflow quote silently fail before this PR.

## Changes

- **`src/tools/index.ts`** — uncomment `registerBitflowTools(server)` and its import. Comment now explains the rate-limit reality instead of an obsolete TODO.
- **`src/config/contracts.ts`** — drop all `process.env.BITFLOW_*` reads. Replace with three hardcoded constants documented to the Bitflow SDK docs:
  - `BITFLOW_PUBLIC_API` — `https://bitflow-sdk-api-gateway-7owjsmt8.uc.gateway.dev` (existing prod gateway, also used for the public `/ticker` endpoint)
  - `BITFLOW_READONLY_HOST` — `https://node.bitflowapis.finance` (the SDK's documented Stacks read-only node, was previously a dead AWS URL via `.env`)
  - `BITFLOW_KEEPER_HOST` — `https://bitflow-keeper-test-7owjsmt8.uc.gateway.dev`
- **`src/services/bitflow.service.ts`** — remove key-handling branches in SDK init, drop the dead-host env fallback in `callReadOnly`, simplify the docstring/error messages.

After this PR: zero `BITFLOW_*` env vars exist or are read anywhere in `src/` (verified with `grep -rn 'process.env.BITFLOW' src/` → no matches).

## Tools enabled (all 11)

| Tool | Purpose |
|------|---------|
| `bitflow_get_ticker` | Public market data (no key needed, was already callable via the service) |
| `bitflow_get_tokens` | Token discovery |
| `bitflow_get_swap_targets` | All possible Y tokens for a given X |
| `bitflow_get_quote` | Best-route quote with price impact + slippage |
| `bitflow_get_routes` | All routes between two tokens |
| `bitflow_swap` | Sign + broadcast a swap (Pattern A: SDK returns params, we sign with `@stacks/transactions`) |
| `bitflow_get_keeper_contract` | Keeper automation: get/create user keeper contract |
| `bitflow_create_order` | Keeper: create automated swap order |
| `bitflow_get_order` | Keeper: read order |
| `bitflow_cancel_order` | Keeper: cancel order |
| `bitflow_get_keeper_user` | Keeper: list user's orders |

## Trading flow per Bitflow docs

```
bitflow_get_tokens                  → cache once per session
bitflow_get_quote(x, y, amount)     → returns bestRoute, expectedAmountOut, priceImpact
bitflow_swap(x, y, amount, slip)    → signs + broadcasts in one shot
```

`src/services/bitflow.service.ts:swap()` follows the docs-prescribed Pattern A exactly: `getQuoteForRoute` → build `SwapExecutionData` → `getSwapParams` → `makeContractCall` (with the unlocked wallet's private key) → `broadcastTransaction`. No `@stacks/connect`, no browser handoff, suitable for headless agents.

## Test plan

- [x] `npm run build` — clean
- [x] No remaining `process.env.BITFLOW_*` reads in `src/` (`grep -rn`)
- [x] SDK init succeeds with all `BITFLOW_*` env vars unset (`env -u BITFLOW_API_HOST -u BITFLOW_API_KEY ... node …`)
- [x] `getAvailableTokens()` returns 202 tokens
- [x] Quote path verified for 4 pairs: STX→stSTX, STX→sBTC, sBTC→STX, stSTX→STX — all return real numbers (previously silently `undefined`)
- [x] **Real on-chain swap on mainnet** — txid [`5f7e4c6518568614fb334dd81911eca829d83552f632f714e802654513efe4cc`](https://explorer.hiro.so/txid/5f7e4c6518568614fb334dd81911eca829d83552f632f714e802654513efe4cc?chain=mainnet)
  - Pre-swap quote: 1 STX → 0.860152 stSTX
  - On-chain `tx_result`: `(ok u860152)` → exactly 0.860152 stSTX received (zero slippage hit)
  - Block 7,862,311

## Out of scope / known non-issues

- **ALEX is unrouted on Bitflow.** `getAllPossibleTokenY('token-alex')` returns 0 — Bitflow doesn't list ALEX. Agents needing STX↔ALEX should use the existing `alex_swap` tool. Not a regression; this was already the state before this PR.
- **Keeper host is the `*-test-*` URL** as shown in the Bitflow docs example. Functional, but if Bitflow later publishes a separate prod keeper host we'd swap it.
- **`BITFLOW_PROVIDER_ADDRESS` is empty.** Docs mark it required, but the SDK only logs a warning (`Value for provider is null`) and quotes/swaps still succeed. Worth setting later for fee attribution; not needed for the competition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)