### PR TITLE
fix(execute_x402_endpoint): never invent placeholder txid (fixes #487 Gap 1)

### DIFF
--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -354,16 +354,36 @@ For aibtc.com inbox messages, use send_inbox_message instead — it uses sponsor
         const paymentSigHeader = (response as { config?: { headers?: Record<string, string> } })
           .config?.headers?.[X402_HEADERS.PAYMENT_SIGNATURE];
         const paymentAttempted = Boolean(paymentSigHeader);
-        const txid = rawTxid ?? (paymentAttempted ? `unknown-txid-${Date.now()}` : undefined);
 
-        if (paymentAttempted && txid) {
-          recordTransaction(dedupKey, txid);
+        // Never invent a placeholder txid when payment was attempted but the
+        // response doesn't expose one — a fake string actively misleads
+        // downstream tooling and operators (see #487). Surface txid: null
+        // with an explicit recovery hint so the caller can discover the
+        // real txid via get_account_transactions.
+        const txid: string | null = rawTxid ?? null;
+
+        // Keep dedup tracking active even when the txid is not yet
+        // observable, using a synthetic pending marker that cannot be
+        // confused for a real chain txid.
+        if (paymentAttempted) {
+          recordTransaction(dedupKey, txid ?? `pending:${dedupKey}`);
         }
 
         return createJsonResponse({
           endpoint: `${method} ${fullUrl}`,
           response: response.data,
-          ...(txid && { txid }),
+          ...(paymentAttempted
+            ? {
+                txid,
+                ...(txid === null && {
+                  txidNote:
+                    "Payment broadcast; real txid not yet observable in response. " +
+                    "Query get_account_transactions to discover the settled txid for verification or recovery.",
+                }),
+              }
+            : txid !== null
+              ? { txid }
+              : {}),
         });
       } catch (error) {
         const label = fullUrl || url || path || "unknown";

--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -369,21 +369,28 @@ For aibtc.com inbox messages, use send_inbox_message instead — it uses sponsor
           recordTransaction(dedupKey, txid ?? `pending:${dedupKey}`);
         }
 
+        // Build the txid response fields per the behavior matrix:
+        //   payment attempted + observable txid → { txid: "0x..." }
+        //   payment attempted + unobservable     → { txid: null, txidNote: "..." }
+        //   no payment + observable txid         → { txid: "0x..." }
+        //   no payment + no txid                 → {}
+        const txidFields = paymentAttempted
+          ? {
+              txid,
+              ...(txid === null && {
+                txidNote:
+                  "Payment broadcast; real txid not yet observable in response. " +
+                  "Query get_account_transactions to discover the settled txid for verification or recovery.",
+              }),
+            }
+          : txid !== null
+            ? { txid }
+            : {};
+
         return createJsonResponse({
           endpoint: `${method} ${fullUrl}`,
           response: response.data,
-          ...(paymentAttempted
-            ? {
-                txid,
-                ...(txid === null && {
-                  txidNote:
-                    "Payment broadcast; real txid not yet observable in response. " +
-                    "Query get_account_transactions to discover the settled txid for verification or recovery.",
-                }),
-              }
-            : txid !== null
-              ? { txid }
-              : {}),
+          ...txidFields,
         });
       } catch (error) {
         const label = fullUrl || url || path || "unknown";

--- a/tests/tools/endpoint-x402-success.test.ts
+++ b/tests/tools/endpoint-x402-success.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateApiClient = vi.fn();
+const mockCheckSufficientBalance = vi.fn();
+const mockGenerateDedupKey = vi.fn(() => "dedup-key-success");
+const mockCheckDedupCache = vi.fn(() => null);
+const mockRecordTransaction = vi.fn();
+
+vi.mock("../../src/services/x402.service.js", () => ({
+  createApiClient: mockCreateApiClient,
+  API_URL: "https://aibtc.com",
+  probeEndpoint: vi.fn(),
+  formatPaymentAmount: vi.fn((amount: string, asset: string) => `${amount} ${asset}`),
+  checkSufficientBalance: mockCheckSufficientBalance,
+  generateDedupKey: mockGenerateDedupKey,
+  checkDedupCache: mockCheckDedupCache,
+  recordTransaction: mockRecordTransaction,
+  NETWORK: "mainnet",
+}));
+
+vi.mock("../../src/utils/x402-recovery.js", () => ({
+  extractPaymentIdFromPaymentSignature: vi.fn(() => null),
+  extractTxidFromPaymentSignature: vi.fn(() => null),
+  pollTransactionConfirmation: vi.fn(),
+}));
+
+const { registerEndpointTools } = await import("../../src/tools/endpoint.tools.js");
+
+interface RegisteredTool {
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+function createTrackingServer() {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    registerTool: vi.fn(
+      (
+        name: string,
+        _config: { description: string; inputSchema: unknown },
+        handler: RegisteredTool["handler"]
+      ) => {
+        tools.set(name, { handler });
+      }
+    ),
+  };
+  return { server, tools };
+}
+
+function buildOkResponse(opts: {
+  data: unknown;
+  paymentAttempted: boolean;
+  headers?: Record<string, string>;
+}) {
+  const headers: Record<string, string> = {
+    ...(opts.headers ?? {}),
+  };
+  if (opts.paymentAttempted) {
+    headers["payment-signature"] = "encoded-payment-sig";
+  }
+  return {
+    data: opts.data,
+    headers,
+    config: { headers },
+  };
+}
+
+describe("execute_x402_endpoint success-path txid handling (#487 Gap 1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the real txid when the upstream response exposes one", async () => {
+    const realTxid = "0x9481360565e9aba28b7fe63f5a1aa931bdf877fa9974d291c5293eeae8c44706";
+    const request = vi.fn().mockResolvedValue(
+      buildOkResponse({
+        data: { txid: realTxid, classifiedId: "abc-123" },
+        paymentAttempted: true,
+      })
+    );
+    mockCreateApiClient.mockResolvedValue({ request });
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerEndpointTools(server as any);
+    const tool = tools.get("execute_x402_endpoint")!;
+
+    const result = (await tool.handler({
+      method: "POST",
+      url: "https://aibtc.news/api/classifieds",
+      autoApprove: true,
+    })) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0].text);
+    expect(body.txid).toBe(realTxid);
+    expect(body.txidNote).toBeUndefined();
+    expect(mockRecordTransaction).toHaveBeenCalledWith("dedup-key-success", realTxid);
+  });
+
+  it("returns txid: null with a recovery hint when payment confirmed but txid not observable", async () => {
+    const request = vi.fn().mockResolvedValue(
+      buildOkResponse({
+        data: { classifiedId: "abc-456", paymentStatus: "settled" }, // no txid in body or headers
+        paymentAttempted: true,
+      })
+    );
+    mockCreateApiClient.mockResolvedValue({ request });
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerEndpointTools(server as any);
+    const tool = tools.get("execute_x402_endpoint")!;
+
+    const result = (await tool.handler({
+      method: "POST",
+      url: "https://aibtc.news/api/classifieds",
+      autoApprove: true,
+    })) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0].text);
+
+    // The fix: no fabricated placeholder, explicit null + actionable note
+    expect(body.txid).toBeNull();
+    expect(typeof body.txidNote).toBe("string");
+    expect(body.txidNote).toContain("get_account_transactions");
+    expect(result.content[0].text).not.toContain("unknown-txid-");
+
+    // Dedup tracking still active under a synthetic pending marker
+    expect(mockRecordTransaction).toHaveBeenCalledWith(
+      "dedup-key-success",
+      "pending:dedup-key-success"
+    );
+  });
+
+  it("omits the txid field entirely when no payment was attempted and no txid is present", async () => {
+    const request = vi.fn().mockResolvedValue(
+      buildOkResponse({
+        data: { ok: true },
+        paymentAttempted: false,
+      })
+    );
+    mockCreateApiClient.mockResolvedValue({ request });
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerEndpointTools(server as any);
+    const tool = tools.get("execute_x402_endpoint")!;
+
+    const result = (await tool.handler({
+      method: "GET",
+      url: "https://aibtc.com/api/free-endpoint",
+      autoApprove: true,
+    })) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0].text);
+    expect("txid" in body).toBe(false);
+    expect("txidNote" in body).toBe(false);
+    expect(mockRecordTransaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #487 Gap 1.

When a payment was attempted via x402 but the upstream response didn't expose a real txid in body, headers, or `x-transaction-id`, `execute_x402_endpoint` was returning a fabricated string of the form `unknown-txid-${Date.now()}`. That value can't be queried on-chain; downstream tooling treats it as opaque and operators have to manually correlate via `get_account_transactions` to recover the real txid for refund/dispute.

Reproduced previously with two consecutive calls to `POST https://aibtc.news/api/classifieds`:
- Call 1: `884e0cc23474b794defb30fb3b41e8104195eba1968dbe451453e789f3361ae9` (Hiro returns 404 — fabricated)
- Call 2: `unknown-txid-1777397675423` (literal placeholder string)
- Real settled tx for call 1: `0x9481360565e9aba28b7fe63f5a1aa931bdf877fa9974d291c5293eeae8c44706`

## Change

```diff
-        const txid = rawTxid ?? (paymentAttempted ? `unknown-txid-${Date.now()}` : undefined);
-
-        if (paymentAttempted && txid) {
-          recordTransaction(dedupKey, txid);
-        }
-
-        return createJsonResponse({
-          endpoint: `${method} ${fullUrl}`,
-          response: response.data,
-          ...(txid && { txid }),
-        });
+        const txid: string | null = rawTxid ?? null;
+
+        if (paymentAttempted) {
+          recordTransaction(dedupKey, txid ?? `pending:${dedupKey}`);
+        }
+
+        return createJsonResponse({
+          endpoint: `${method} ${fullUrl}`,
+          response: response.data,
+          ...(paymentAttempted
+            ? {
+                txid,
+                ...(txid === null && {
+                  txidNote: "Payment broadcast; real txid not yet observable in response. Query get_account_transactions to discover the settled txid for verification or recovery.",
+                }),
+              }
+            : txid !== null ? { txid } : {}),
+        });
```

## Behavior matrix

| Path | Before | After |
|---|---|---|
| Real txid in response, payment attempted | `txid: "0x..."` | `txid: "0x..."` (unchanged) |
| Payment attempted, no txid observable | `txid: "unknown-txid-1777..."` (fake) | `txid: null` + `txidNote: "Payment broadcast; real txid not yet observable... Query get_account_transactions..."` |
| No payment attempted, no txid | (no txid field) | (no txid field — unchanged) |

Dedup tracking remains active in all payment-attempted paths — when the txid is unobservable, a `pending:{dedupKey}` marker is recorded internally; this can never be confused for a real chain txid by downstream tooling.

## Test coverage

New file `tests/tools/endpoint-x402-success.test.ts` (3 cases):

1. `returns the real txid when the upstream response exposes one` — regression guard that the happy path still works.
2. `returns txid: null with a recovery hint when payment confirmed but txid not observable` — the fix; asserts no `unknown-txid-` string anywhere in output and that dedup tracks under the pending marker.
3. `omits the txid field entirely when no payment was attempted and no txid is present` — regression guard for the non-payment path.

The existing `tests/tools/endpoint-x402-error.test.ts` (catch-block recovery) is unchanged — that flow has its own canonical-status / payment-signature recovery and already returns real txids when available.

## Verification

- `npx tsc --noEmit` → clean
- `npm test` → 28 files, **492 tests pass** including the 3 new ones
- Branch based on current upstream main (`b09b6a4 chore(main): release mcp-server 1.51.0`)

## Out of scope (intentional)

This PR addresses **Gap 1 only** of #487. Gap 2 (post-payment-rejection recovery affordances) and Gap 3 (auto-poll + held-state surfacing) are larger restructures that warrant their own PRs once whoabuddy's wave-2 sprint plan crystallizes — happy to take stabs at those next if useful.
