### PR TITLE
fix(bitflow): point readonly host at api.hiro.so

### DIFF
--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -255,9 +255,11 @@ export const BITFLOW_PUBLIC_API = "https://bitflow-sdk-api-gateway-7owjsmt8.uc.g
 
 /**
  * Stacks read-only node used by the SDK to compute quotes (reads pool reserves).
- * Per Bitflow SDK docs.
+ * Bitflow's own `node.bitflowapis.finance` was hanging on `POST /v2/contracts/call-read`,
+ * causing every quote to silently return null. Hiro's public node serves the same
+ * standard Stacks API and is reliable.
  */
-export const BITFLOW_READONLY_HOST = "https://node.bitflowapis.finance";
+export const BITFLOW_READONLY_HOST = "https://api.hiro.so";
 
 /**
  * Keeper API host for automated swap orders.

--- a/tests/scripts/verify-bitflow-quote.ts
+++ b/tests/scripts/verify-bitflow-quote.ts
@@ -1,0 +1,28 @@
+import { BitflowService } from "../../src/services/bitflow.service.js";
+import { BITFLOW_READONLY_HOST } from "../../src/config/contracts.js";
+
+(async () => {
+  console.log("readonly host in use:", BITFLOW_READONLY_HOST);
+  const svc = new BitflowService("mainnet");
+
+  const pairs: Array<[string, string, number]> = [
+    ["token-stx", "token-sbtc", 10],
+    ["token-sbtc", "token-stx", 0.001],
+    ["token-stx", "token-ststx", 1],
+    ["token-stx", "token-aeusdc", 10],
+  ];
+
+  for (const [x, y, amount] of pairs) {
+    const t0 = Date.now();
+    try {
+      const q = await svc.getSwapQuote(x, y, amount);
+      const ms = Date.now() - t0;
+      console.log(
+        `OK  ${x} -> ${y} (in=${amount}) → out=${q.expectedAmountOut} route=[${q.route.join(",")}] impact=${q.priceImpact?.combinedImpactPct ?? "n/a"} ${ms}ms`
+      );
+    } catch (e: any) {
+      const ms = Date.now() - t0;
+      console.log(`FAIL ${x} -> ${y} (in=${amount}) → ${e.message} ${ms}ms`);
+    }
+  }
+})();


### PR DESCRIPTION
## Summary

`bitflow_get_quote` and `bitflow_swap` have been silently failing with `"No route found"` since shortly after #500 merged. Root cause is upstream, not in our code:

- #500 hardcoded `READONLY_CALL_API_HOST = "https://node.bitflowapis.finance"` per the Bitflow SDK docs
- That host is currently hanging on `POST /v2/contracts/call-read/...` (the path the SDK uses to read pool reserves while computing quotes)
- The SDK swallows the timeout and returns `bestRoute = null`, surfacing as `"No route found"` even though `bitflow_get_routes` correctly lists valid routes for the same pair

Probe today (12s timeout, identical `POST` and call):

| Host | Result |
|------|--------|
| `node.bitflowapis.finance` | HTTP 000 after 12s (hangs) |
| `api.hiro.so` | HTTP 200 in 1.2s, valid Clarity response |

## Fix

One-line constant change in `src/config/contracts.ts`:

```ts
- export const BITFLOW_READONLY_HOST = "https://node.bitflowapis.finance";
+ export const BITFLOW_READONLY_HOST = "https://api.hiro.so";
```

Hiro's public node serves the standard Stacks read-only API the SDK expects. No API key required. Drop-in replacement for the dead host.

## Verification

`tests/scripts/verify-bitflow-quote.ts` — quotes 4 representative pairs through the live SDK with the new host:

| Pair | Input | Output | Time |
|------|-------|--------|------|
| STX → sBTC | 10 | 0.00003137 sBTC | 7.0s |
| sBTC → STX | 0.001 | 318.00 STX | 3.3s |
| STX → stSTX | 1 | 0.860164 stSTX | 2.8s |
| STX → aeUSDC | 10 | 2.4936 aeUSDC | 2.9s |

Cross-checks:
- STX→sBTC implied rate (318,775 STX/sBTC) is within tick-noise of the public ticker (317,655 STX/sBTC).
- STX→stSTX (`0.860164`) matches #500's on-chain swap result (`0.860152`) within 0.001%, so the SDK is reading reserves correctly through Hiro.

## Out of scope

- The "Value for provider is null" warning is unchanged and unrelated — same `BITFLOW_PROVIDER_ADDRESS` empty issue #500 already flagged as out-of-scope.
- If `node.bitflowapis.finance` recovers later, this can be reverted, but Hiro is a fine permanent default — no auth required and broadly used across the Stacks ecosystem.

## Test plan

- [x] `npm run build` clean
- [x] `verify-bitflow-quote.ts` returns real quotes for 4 pairs
- [x] STX→stSTX matches #500's on-chain swap result within 0.001%
- [ ] After release, exercise `bitflow_swap` end-to-end on mainnet (small STX→stSTX) to confirm the broadcast path also works through Hiro

🤖 Generated with [Claude Code](https://claude.com/claude-code)