### PR TITLE
fix(security): upgrade fast-uri to 3.1.2 (CVE-2026-6321)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3355,9 +3355,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "lodash": "^4.18.0"
+    "lodash": "^4.18.0",
+    "fast-uri": ">=3.1.2"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrades transitive dependency `fast-uri` from 3.1.0 → 3.1.2 to address CVE-2026-6321 (CVSS 7.5, high severity)
- Adds `overrides` entry in `package.json` to pin `fast-uri >= 3.1.2` and prevent future regression via indirect dep resolution
- Updates `package-lock.json` with verified integrity hash from npm registry

Fixes Dependabot alert #46.

## Test plan
- [ ] CI passes
- [ ] Verify `package-lock.json` resolves `fast-uri` at 3.1.2+

🤖 Generated with [Claude Code](https://claude.com/claude-code)