### PR TITLE
feat(competition): add trading competition tools and Bitflow provider tag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,11 @@ HIRO_API_KEY=
 # Get your key at: https://x402-relay.aibtc.com
 SPONSOR_API_KEY=
 
+# AIBTC Trading Competition API
+# Endpoint that indexes agent trade activity and scores competition P&L.
+# Defaults to https://aibtc.com/api/competition
+AIBTC_CAMPAIGN_API_URL=
+
 # Unisat Open API key (optional but recommended)
 # Recommended for reliable inscription/rune-aware UTXO classification on BTC spends.
 # Used on both mainnet and testnet — testnet flows now route through the same indexer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,10 +502,13 @@ Uses the official `@bitflowlabs/core-sdk` for swap operations. Bitflow is a DEX 
 
 Tools for the AIBTC trading competition (`aibtc.com/api/competition`). The campaign scores agents on P&L from on-chain trades against an allowlisted set of DEX/lending contracts (Bitflow swap helpers, ALEX, Zest). Submission is a fast-path hint — the backend also indexes registered agent addresses passively via a frequent catch-up cron, so a missed submission still gets picked up.
 
-**Prerequisites:**
-- Agent must be registered on aibtc.com (call `identity_register` first)
-- Trades must hit an allowlisted contract+function for the campaign track
-- Mainnet only in v1 (no `network` parameter)
+**Prerequisites (two-step registration, both one-time):**
+1. **aibtc.com website registration** via dual-sig flow (BIP-322 + SIP-018). Not an MCP tool — agents visit https://aibtc.com.
+2. **ERC-8004 on-chain registration** via the `identity_register` MCP tool. Mints the agent ID that the campaign scores against.
+3. Trades must hit an allowlisted contract+function for the campaign track
+4. Mainnet only in v1 (no `network` parameter)
+
+**Why no signed envelope?** The txid is itself a signed Stacks tx — the on-chain payload already carries the agent's address (identity) and trade (intent). No additional signature header is needed; the tx history is the ledger.
 
 **Backend status:** API routes are under implementation in [landing-page#734](https://github.com/aibtcdev/landing-page/issues/734). Tools wire to `AIBTC_CAMPAIGN_API_URL` (default `https://aibtc.com/api/competition`). Until the verifier ships, tools error cleanly against the missing route.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ aibtc-mcp-server MCP Server (src/index.ts)
 - `src/services/scaffold.service.ts` - x402 endpoint project scaffolding for Cloudflare Workers
 - `src/tools/bitcoin.tools.ts` - Bitcoin L1 tools (balance, fees, UTXOs, transfer)
 - `src/tools/news.tools.ts` - AIBTC News tools (signals, beats, briefs, BIP-322 auth + x402 payment)
+- `src/tools/competition.tools.ts` - AIBTC Trading Competition tools (submit_trade with Hiro pre-flight gate, status, list_trades)
 - `src/tools/pillar.tools.ts` - Pillar smart wallet tools (handoff model)
 - `src/services/pillar-api.service.ts` - Pillar API client
 - `src/config/pillar.ts` - Pillar configuration (API URL, API key)
@@ -496,6 +497,31 @@ Uses the official `@bitflowlabs/core-sdk` for swap operations. Bitflow is a DEX 
 - [ ] Test SDK features (quotes, tokens, swaps)
 - [ ] Optionally configure Keeper API keys for automation features
 - [ ] Move API keys to Cloudflare Worker proxy for secure npm distribution
+
+### Trading Competition (Mainnet Only)
+
+Tools for the AIBTC trading competition (`aibtc.com/api/competition`). The campaign scores agents on P&L from on-chain trades against an allowlisted set of DEX/lending contracts (Bitflow swap helpers, ALEX, Zest). Submission is a fast-path hint — the backend also indexes registered agent addresses passively via a frequent catch-up cron, so a missed submission still gets picked up.
+
+**Prerequisites:**
+- Agent must be registered on aibtc.com (call `identity_register` first)
+- Trades must hit an allowlisted contract+function for the campaign track
+- Mainnet only in v1 (no `network` parameter)
+
+**Backend status:** API routes are under implementation in [landing-page#734](https://github.com/aibtcdev/landing-page/issues/734). Tools wire to `AIBTC_CAMPAIGN_API_URL` (default `https://aibtc.com/api/competition`). Until the verifier ships, tools error cleanly against the missing route.
+
+**Tools:**
+- `competition_submit_trade` - Submit a confirmed trade txid. Pre-flight gate: if Hiro reports `tx_status: "pending"`, returns `{ accepted: false, tx_status: "pending", message }` without hitting the backend — wait ~30s for the next Stacks block and resubmit. Terminal status (success or any failure code) forwards to the verifier; backend records terminal failures too (migration 005's CHECK allows all 8 terminal codes).
+- `competition_status` - Get current standing for an agent's Stacks address. Returns `{ address, agent_id, registered, trade_count, verified_trade_count, first_trade_at, last_trade_at, campaign }`. If unregistered, returns `{ registered: false, ... }` — call `identity_register` to onboard.
+- `competition_list_trades` - Paginated trade history (submitted + cron-indexed). Each entry is a swap row with on-chain vocabulary field names (`sender`, `token_in`, `amount_in`, `token_out`, `amount_out`, `burn_block_time`, `tx_status`, `source`). Response: `{ trades, next_cursor }` with opaque cursor pagination.
+
+**Bitflow attribution:** Every Bitflow swap through this MCP is tagged with the AIBTC provider address (`SP1M8KHCJXB3SBRQRDBCG3J3859AA1CN0AWDHN17B`) via the SDK's `provider` Clarity arg on XYK swap-helper routes. This is intentionally not env-configurable — it's baked into the MCP's identity as the campaign attribution tag.
+
+**Example Usage:**
+| Request | Action |
+|---------|--------|
+| "Submit my last swap to the competition" | `competition_submit_trade` with the txid from a recent `bitflow_swap` / `alex_swap` |
+| "How am I ranked in the competition?" | `competition_status` (uses active wallet) |
+| "List my trades" | `competition_list_trades` (uses active wallet) |
 
 ### Pillar Smart Wallet
 

--- a/src/config/competition.ts
+++ b/src/config/competition.ts
@@ -1,0 +1,10 @@
+/**
+ * AIBTC trading competition API configuration.
+ *
+ * The campaign service indexes registered agents' on-chain trade activity from
+ * an allowlisted set of DEX/lending contracts and scores P&L over a time-bound
+ * track. Agents can submit txids as a fast-path hint; the service also
+ * monitors registered addresses passively, so submission is best-effort.
+ */
+export const AIBTC_CAMPAIGN_API_URL =
+  process.env.AIBTC_CAMPAIGN_API_URL || "https://aibtc.com/api/competition";

--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -244,6 +244,7 @@ export interface BitflowConfig {
   apiHost: string;
   readOnlyCallApiHost: string;
   keeperApiHost: string;
+  providerAddress: string;
 }
 
 /**
@@ -267,11 +268,20 @@ export const BITFLOW_READONLY_HOST = "https://api.hiro.so";
  */
 export const BITFLOW_KEEPER_HOST = "https://bitflow-keeper-test-7owjsmt8.uc.gateway.dev";
 
+/**
+ * AIBTC provider address tagged onto every Bitflow swap. The SDK injects this
+ * as the `provider` Clarity arg when the swap function signature accepts one,
+ * so on-chain attribution can distinguish AIBTC-routed trades for campaign
+ * scoring.
+ */
+export const BITFLOW_PROVIDER_ADDRESS = "SP1M8KHCJXB3SBRQRDBCG3J3859AA1CN0AWDHN17B";
+
 export function getBitflowConfig(): BitflowConfig {
   return {
     apiHost: BITFLOW_PUBLIC_API,
     readOnlyCallApiHost: BITFLOW_READONLY_HOST,
     keeperApiHost: BITFLOW_KEEPER_HOST,
+    providerAddress: BITFLOW_PROVIDER_ADDRESS,
   };
 }
 

--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -273,6 +273,10 @@ export const BITFLOW_KEEPER_HOST = "https://bitflow-keeper-test-7owjsmt8.uc.gate
  * as the `provider` Clarity arg when the swap function signature accepts one,
  * so on-chain attribution can distinguish AIBTC-routed trades for campaign
  * scoring.
+ *
+ * Intentionally not env-configurable: this address is the AIBTC campaign's
+ * attribution tag, baked into the MCP server's identity. Any agent installing
+ * @aibtc/mcp-server tags swaps with this address by design.
  */
 export const BITFLOW_PROVIDER_ADDRESS = "SP1M8KHCJXB3SBRQRDBCG3J3859AA1CN0AWDHN17B";
 

--- a/src/services/bitflow.service.ts
+++ b/src/services/bitflow.service.ts
@@ -113,7 +113,7 @@ export class BitflowService {
       this.sdk = new BitflowSDK({
         BITFLOW_API_HOST: config.apiHost,
         READONLY_CALL_API_HOST: config.readOnlyCallApiHost,
-        BITFLOW_PROVIDER_ADDRESS: "",
+        BITFLOW_PROVIDER_ADDRESS: config.providerAddress,
         READONLY_CALL_API_KEY: "",
         KEEPER_API_HOST: config.keeperApiHost,
       });

--- a/src/tools/competition.tools.ts
+++ b/src/tools/competition.tools.ts
@@ -44,7 +44,50 @@ async function resolveAddress(provided?: string): Promise<string> {
 
 function normalizeTxid(txid: string): string {
   const trimmed = txid.trim();
-  return trimmed.startsWith("0x") ? trimmed : `0x${trimmed}`;
+  const withPrefix = trimmed.startsWith("0x") ? trimmed : `0x${trimmed}`;
+  if (!/^0x[0-9a-fA-F]{64}$/.test(withPrefix)) {
+    throw new Error(
+      `Invalid Stacks txid: expected 64 hex chars (with optional 0x prefix), got ${JSON.stringify(txid)}`
+    );
+  }
+  return withPrefix.toLowerCase();
+}
+
+const COMPETITION_FETCH_TIMEOUT_MS = 10_000;
+
+async function competitionFetch(
+  path: string,
+  init?: RequestInit
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    COMPETITION_FETCH_TIMEOUT_MS
+  );
+  let res: Response;
+  try {
+    res = await fetch(`${AIBTC_CAMPAIGN_API_URL}${path}`, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+  const text = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    parsed = text;
+  }
+  if (!res.ok) {
+    throw new Error(
+      `Competition API error (${res.status}): ${
+        typeof parsed === "string" ? parsed : JSON.stringify(parsed)
+      }`
+    );
+  }
+  return parsed;
 }
 
 export function registerCompetitionTools(server: McpServer): void {
@@ -78,25 +121,11 @@ Returns the submission status and (if already verified) the parsed trade details
           txid: normalizeTxid(txid),
           network: network ?? NETWORK,
         };
-        const res = await fetch(`${AIBTC_CAMPAIGN_API_URL}/trades`, {
+        const parsed = await competitionFetch("/trades", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify(body),
         });
-        const text = await res.text();
-        let parsed: unknown;
-        try {
-          parsed = text ? JSON.parse(text) : null;
-        } catch {
-          parsed = text;
-        }
-        if (!res.ok) {
-          throw new Error(
-            `Competition submit failed (${res.status}): ${
-              typeof parsed === "string" ? parsed : JSON.stringify(parsed)
-            }`
-          );
-        }
         return createJsonResponse(parsed);
       } catch (error) {
         return createErrorResponse(error);
@@ -122,22 +151,9 @@ Returns registration status, trade count, current rank within the active campaig
     async ({ address }) => {
       try {
         const target = await resolveAddress(address);
-        const url = `${AIBTC_CAMPAIGN_API_URL}/status?address=${encodeURIComponent(target)}`;
-        const res = await fetch(url);
-        const text = await res.text();
-        let parsed: unknown;
-        try {
-          parsed = text ? JSON.parse(text) : null;
-        } catch {
-          parsed = text;
-        }
-        if (!res.ok) {
-          throw new Error(
-            `Competition status failed (${res.status}): ${
-              typeof parsed === "string" ? parsed : JSON.stringify(parsed)
-            }`
-          );
-        }
+        const parsed = await competitionFetch(
+          `/status?address=${encodeURIComponent(target)}`
+        );
         return createJsonResponse(parsed);
       } catch (error) {
         return createErrorResponse(error);
@@ -176,23 +192,7 @@ Includes both txids the agent submitted directly via competition_submit_trade an
         const params = new URLSearchParams({ address: target });
         if (limit !== undefined) params.set("limit", String(limit));
         if (cursor) params.set("cursor", cursor);
-        const res = await fetch(
-          `${AIBTC_CAMPAIGN_API_URL}/trades?${params.toString()}`
-        );
-        const text = await res.text();
-        let parsed: unknown;
-        try {
-          parsed = text ? JSON.parse(text) : null;
-        } catch {
-          parsed = text;
-        }
-        if (!res.ok) {
-          throw new Error(
-            `Competition list trades failed (${res.status}): ${
-              typeof parsed === "string" ? parsed : JSON.stringify(parsed)
-            }`
-          );
-        }
+        const parsed = await competitionFetch(`/trades?${params.toString()}`);
         return createJsonResponse(parsed);
       } catch (error) {
         return createErrorResponse(error);

--- a/src/tools/competition.tools.ts
+++ b/src/tools/competition.tools.ts
@@ -115,14 +115,20 @@ export function registerCompetitionTools(server: McpServer): void {
     {
       description: `Submit a trade txid to the AIBTC trading competition for verification and P&L scoring.
 
-Prerequisite: the submitting agent must be registered on aibtc.com (call \`identity_register\` first). Mainnet-only in v1.
+**Two-step registration prerequisite** (both required, both one-time):
+1. Register on aibtc.com via the website's dual-sig flow (BIP-322 + SIP-018). This is not an MCP tool — agents go to https://aibtc.com to complete it.
+2. Register on the ERC-8004 identity contract via the \`identity_register\` MCP tool. This mints the on-chain agent ID that the campaign joins against.
+
+Mainnet-only in v1.
 
 The competition service fetches the tx from the Stacks chain and validates:
-- sender matches a registered competitor address
+- sender is registered on aibtc.com AND has an ERC-8004 agent_id
 - contract+function is on the campaign allowlist (e.g. Bitflow swap helpers, ALEX, Zest)
-- transaction status is success
+- transaction status is terminal (success or any of the 7 terminal-failure codes)
 
-Submission is a fast-path hint — the service also indexes registered agent addresses passively (nightly cron), so a missed submission still gets picked up. Submitting the same txid twice is idempotent (\`(txid)\` is the DB primary key; first writer wins).
+**No additional signed message is needed** — the txid itself is the agent's signed intent. The on-chain tx already carries their address (= identity) and the trade (= the on-chain effect). Tx history is the ledger.
+
+Submission is a fast-path hint — the backend also indexes registered agent addresses passively via a frequent catch-up cron, so a missed submission still gets picked up before final scoring. Submitting the same txid twice is idempotent (\`(txid)\` is the DB primary key; first writer wins).
 
 **Pre-flight:** This tool checks tx status on Stacks via Hiro before forwarding to the verifier. If the tx is still \`pending\` (in mempool), the call returns \`{ accepted: false, tx_status: "pending", message: "..." }\` without hitting the verifier — wait ~30s for confirmation and retry. Use \`get_transaction_status\` to poll explicitly.
 
@@ -174,9 +180,9 @@ Response shapes:
     {
       description: `Get the current AIBTC trading competition standing for an agent.
 
-Returns \`{ address, agent_id, registered, trade_count, verified_trade_count, first_trade_at, last_trade_at, campaign }\` per landing-page#734. \`agent_id\` is the ERC-8004 id resolved via JOIN over the \`agents\` table (nullable until the agent registers on-chain). \`campaign\` carries rank + P&L once scoring has run.
+Returns \`{ address, agent_id, registered, trade_count, verified_trade_count, first_trade_at, last_trade_at, campaign }\` per landing-page#734. \`agent_id\` is the ERC-8004 id resolved via JOIN over the \`agents\` table; it stays \`null\` until the agent calls \`identity_register\` on-chain. \`campaign\` carries rank + P&L once scoring has run.
 
-If the address hasn't been registered yet (or the campaign indexer hasn't picked it up), the API returns \`{ registered: false, ... }\` — call \`identity_register\` to onboard, then re-check. If no address is provided, uses the active wallet's Stacks address.`,
+To be eligible for scoring, the agent needs **both** an aibtc.com website registration (dual-sig flow at https://aibtc.com) **and** an ERC-8004 agent_id (via \`identity_register\`). If \`registered: false\` or \`agent_id: null\`, complete the missing step and re-check. If no address is provided, uses the active wallet's Stacks address.`,
       inputSchema: {
         address: stacksAddressSchema
           .optional()

--- a/src/tools/competition.tools.ts
+++ b/src/tools/competition.tools.ts
@@ -37,17 +37,6 @@ import { createErrorResponse } from "../utils/errors.js";
  */
 const PENDING_TX_STATUS = "pending";
 
-/**
- * Stacks blocks settle in ~30s. If the first check shows the tx still
- * pending, wait one block and re-check before giving up. One retry is
- * enough to cover the common "agent submits right after broadcast" case.
- */
-const CONFIRMATION_WAIT_MS = 30_000;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 const stacksAddressSchema = z
   .string()
   .regex(
@@ -135,11 +124,11 @@ The competition service fetches the tx from the Stacks chain and validates:
 
 Submission is a fast-path hint — the service also indexes registered agent addresses passively (nightly cron), so a missed submission still gets picked up. Submitting the same txid twice is idempotent (\`(txid)\` is the DB primary key; first writer wins).
 
-**Pre-flight + auto-wait:** This tool checks tx status on Stacks via Hiro. If the tx is still \`pending\` (in mempool), it waits one Stacks block (~30s) and re-checks once before either submitting or giving up. The response includes a \`progress\` array of human-readable steps describing what happened — **narrate these to the user verbatim** ("Tx confirmed at block X, submitting now…") so they see the flow in real time. Don't summarize \`progress\`; read it line by line as you process the response.
+**Pre-flight:** This tool checks tx status on Stacks via Hiro before forwarding to the verifier. If the tx is still \`pending\` (in mempool), the call returns \`{ accepted: false, tx_status: "pending", message: "..." }\` without hitting the verifier — wait ~30s for confirmation and retry. Use \`get_transaction_status\` to poll explicitly.
 
 Response shapes:
-- Confirmed + submitted (common case): \`{ progress: [...], result: <verifier response> }\` where \`result\` is the swap row \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, ... }\`. Field names follow on-chain vocabulary (migration 005). \`tx_status\` is one of \`success\` or 7 terminal-failure codes (verifier records terminal failures too); \`source\` is \`"agent" | "cron"\`.
-- Still pending after wait: \`{ accepted: false, txid, tx_status: "pending", progress: [...], message }\`. Tx hasn't confirmed in ~30s — retry the tool in a minute, or call \`get_transaction_status\` to poll manually.
+- \`{ accepted: false, txid, tx_status: "pending", message }\` (pre-flight gate): tx not yet confirmed. Retry after ~30s.
+- \`200 OK\` with the swap row once verified: \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, ... }\`. Field names follow on-chain vocabulary (migration 005). \`tx_status\` is one of \`success\` or 7 terminal-failure codes (verifier records terminal failures too); \`source\` is \`"agent" | "cron"\`.
 - Permanent rejection (HTTP 4xx, thrown as error): sender not registered, contract not on allowlist, or txid malformed. Do not retry — fix the inputs.
 - Transient failure (HTTP 5xx or timeout, thrown as error): retry with backoff.`,
       inputSchema: {
@@ -152,44 +141,28 @@ Response shapes:
     async ({ txid }) => {
       try {
         const normalized = normalizeTxid(txid);
-        const progress: string[] = [];
 
         // Pre-flight: confirm the tx is terminal on Stacks before forwarding
-        // to the verifier. Stacks blocks settle in ~30s, so if the first check
-        // shows pending we wait one block and re-check before giving up.
-        let txStatus = await getTransactionStatus(normalized, NETWORK);
-        progress.push(`Checked tx ${normalized}: status=${txStatus.status}`);
-
-        if (txStatus.status === PENDING_TX_STATUS) {
-          progress.push(
-            "Tx is still pending — waiting ~30s for the next Stacks block before re-checking."
-          );
-          await sleep(CONFIRMATION_WAIT_MS);
-          txStatus = await getTransactionStatus(normalized, NETWORK);
-          progress.push(`Re-checked after 30s: status=${txStatus.status}`);
-        }
-
+        // to the verifier. Stacks blocks settle in ~30s, so a "pending" status
+        // means the agent submitted too early — we tell them to wait and
+        // resubmit rather than burning a backend round-trip.
+        const txStatus = await getTransactionStatus(normalized, NETWORK);
         if (txStatus.status === PENDING_TX_STATUS) {
           return createJsonResponse({
             accepted: false,
             txid: normalized,
             tx_status: PENDING_TX_STATUS,
-            progress,
             message:
-              "Transaction is still pending after the 30s confirmation wait. Try again in a minute, or poll with get_transaction_status.",
+              "Transaction is still pending on Stacks. Wait ~30s for confirmation and resubmit. Use get_transaction_status to poll.",
           });
         }
 
-        progress.push(
-          `Tx confirmed (status=${txStatus.status}). Submitting txid to competition verifier now.`
-        );
         const parsed = await competitionFetch("/trades", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ txid: normalized }),
         });
-        progress.push("Verifier accepted the submission.");
-        return createJsonResponse({ progress, result: parsed });
+        return createJsonResponse(parsed);
       } catch (error) {
         return createErrorResponse(error);
       }

--- a/src/tools/competition.tools.ts
+++ b/src/tools/competition.tools.ts
@@ -1,0 +1,202 @@
+/**
+ * AIBTC Trading Competition Tools
+ *
+ * Agents registered on aibtc.com (and indexed via ERC-8004) compete on a
+ * time-bound track scored by P&L from on-chain trades. The competition service
+ * monitors registered addresses passively, but agents can also submit txids
+ * as a fast-path hint to skip indexer lag.
+ *
+ * Tools:
+ * - competition_submit_trade  — Submit a trade txid for verification
+ * - competition_status        — Get current standing for an agent address
+ * - competition_list_trades   — Paginated trade history (submitted + indexed)
+ *
+ * No request signing in v1: txids are self-attesting (the on-chain tx
+ * already carries the agent's signature and sender), and status/list reads
+ * are over public addresses. Rate-limited per IP server-side.
+ *
+ * API spec: see issue in aibtcdev/landing-page describing endpoint contract.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { AIBTC_CAMPAIGN_API_URL } from "../config/competition.js";
+import { NETWORK } from "../config/networks.js";
+import { getWalletManager } from "../services/wallet-manager.js";
+import { createJsonResponse } from "../utils/formatting.js";
+import { createErrorResponse } from "../utils/errors.js";
+
+async function resolveAddress(provided?: string): Promise<string> {
+  if (provided) return provided;
+  const wm = getWalletManager();
+  const activeId = await wm.getActiveWalletId();
+  if (!activeId) {
+    throw new Error(
+      "No address provided and no active wallet found. Pass `address` or activate a wallet."
+    );
+  }
+  const wallets = await wm.listWallets();
+  const meta = wallets.find((w) => w.id === activeId);
+  if (!meta) {
+    throw new Error(`Active wallet ${activeId} not found in wallet index.`);
+  }
+  return meta.address;
+}
+
+function normalizeTxid(txid: string): string {
+  const trimmed = txid.trim();
+  return trimmed.startsWith("0x") ? trimmed : `0x${trimmed}`;
+}
+
+export function registerCompetitionTools(server: McpServer): void {
+  server.registerTool(
+    "competition_submit_trade",
+    {
+      description: `Submit a trade txid to the AIBTC trading competition for verification and P&L scoring.
+
+The competition service fetches the tx from the Stacks chain and validates:
+- sender matches a registered competitor address
+- contract+function is on the campaign allowlist (e.g. Bitflow swap helpers, ALEX, Zest)
+- transaction status is success
+
+Submission is a fast-path hint — the service also indexes registered agent addresses passively, so a missed submission still gets picked up. Submitting the same txid twice is idempotent.
+
+Returns the submission status and (if already verified) the parsed trade details.`,
+      inputSchema: {
+        txid: z
+          .string()
+          .min(1)
+          .describe("Stacks transaction id (with or without 0x prefix)"),
+        network: z
+          .enum(["mainnet", "testnet"])
+          .optional()
+          .describe("Network the tx is on. Defaults to the configured NETWORK."),
+      },
+    },
+    async ({ txid, network }) => {
+      try {
+        const body = {
+          txid: normalizeTxid(txid),
+          network: network ?? NETWORK,
+        };
+        const res = await fetch(`${AIBTC_CAMPAIGN_API_URL}/trades`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const text = await res.text();
+        let parsed: unknown;
+        try {
+          parsed = text ? JSON.parse(text) : null;
+        } catch {
+          parsed = text;
+        }
+        if (!res.ok) {
+          throw new Error(
+            `Competition submit failed (${res.status}): ${
+              typeof parsed === "string" ? parsed : JSON.stringify(parsed)
+            }`
+          );
+        }
+        return createJsonResponse(parsed);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "competition_status",
+    {
+      description: `Get the current AIBTC trading competition standing for an agent.
+
+Returns registration status, trade count, current rank within the active campaign track, and P&L if scoring has run. If no address is provided, uses the active wallet's Stacks address.`,
+      inputSchema: {
+        address: z
+          .string()
+          .optional()
+          .describe(
+            "Stacks address of the agent. Defaults to the active wallet."
+          ),
+      },
+    },
+    async ({ address }) => {
+      try {
+        const target = await resolveAddress(address);
+        const url = `${AIBTC_CAMPAIGN_API_URL}/status?address=${encodeURIComponent(target)}`;
+        const res = await fetch(url);
+        const text = await res.text();
+        let parsed: unknown;
+        try {
+          parsed = text ? JSON.parse(text) : null;
+        } catch {
+          parsed = text;
+        }
+        if (!res.ok) {
+          throw new Error(
+            `Competition status failed (${res.status}): ${
+              typeof parsed === "string" ? parsed : JSON.stringify(parsed)
+            }`
+          );
+        }
+        return createJsonResponse(parsed);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "competition_list_trades",
+    {
+      description: `List submitted and indexed trades for an agent in the current AIBTC trading competition.
+
+Includes both txids the agent submitted directly via competition_submit_trade and txids the competition service discovered via address monitoring. Each entry indicates discovery method, verification status, parsed venue/function, and amounts. If no address is provided, uses the active wallet's Stacks address.`,
+      inputSchema: {
+        address: z
+          .string()
+          .optional()
+          .describe(
+            "Stacks address of the agent. Defaults to the active wallet."
+          ),
+        limit: z
+          .number()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe("Max trades to return (default 50)."),
+        cursor: z
+          .string()
+          .optional()
+          .describe("Opaque pagination cursor from a previous response."),
+      },
+    },
+    async ({ address, limit, cursor }) => {
+      try {
+        const target = await resolveAddress(address);
+        const params = new URLSearchParams({ address: target });
+        if (limit !== undefined) params.set("limit", String(limit));
+        if (cursor) params.set("cursor", cursor);
+        const res = await fetch(
+          `${AIBTC_CAMPAIGN_API_URL}/trades?${params.toString()}`
+        );
+        const text = await res.text();
+        let parsed: unknown;
+        try {
+          parsed = text ? JSON.parse(text) : null;
+        } catch {
+          parsed = text;
+        }
+        if (!res.ok) {
+          throw new Error(
+            `Competition list trades failed (${res.status}): ${
+              typeof parsed === "string" ? parsed : JSON.stringify(parsed)
+            }`
+          );
+        }
+        return createJsonResponse(parsed);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+}

--- a/src/tools/competition.tools.ts
+++ b/src/tools/competition.tools.ts
@@ -20,10 +20,16 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { AIBTC_CAMPAIGN_API_URL } from "../config/competition.js";
-import { NETWORK } from "../config/networks.js";
 import { getWalletManager } from "../services/wallet-manager.js";
 import { createJsonResponse } from "../utils/formatting.js";
 import { createErrorResponse } from "../utils/errors.js";
+
+const stacksAddressSchema = z
+  .string()
+  .regex(
+    /^S[PTM][0-9A-HJKMNP-TV-Z]{38,40}$/,
+    "Expected a Stacks address (SP… mainnet, ST… testnet, SM… contract)"
+  );
 
 async function resolveAddress(provided?: string): Promise<string> {
   if (provided) return provided;
@@ -96,31 +102,30 @@ export function registerCompetitionTools(server: McpServer): void {
     {
       description: `Submit a trade txid to the AIBTC trading competition for verification and P&L scoring.
 
+Prerequisite: the submitting agent must be registered on aibtc.com (call \`identity_register\` first). Mainnet-only in v1.
+
 The competition service fetches the tx from the Stacks chain and validates:
 - sender matches a registered competitor address
 - contract+function is on the campaign allowlist (e.g. Bitflow swap helpers, ALEX, Zest)
 - transaction status is success
 
-Submission is a fast-path hint — the service also indexes registered agent addresses passively, so a missed submission still gets picked up. Submitting the same txid twice is idempotent.
+Submission is a fast-path hint — the service also indexes registered agent addresses passively, so a missed submission still gets picked up. Submitting the same txid twice is idempotent (same response shape, no double-scoring).
 
-Returns the submission status and (if already verified) the parsed trade details.`,
+Response shapes:
+- Accepted: \`{ status: "accepted" | "verified", trade?: {...} }\` — safe to stop.
+- Pending verification: \`{ status: "pending" }\` — the tx is still confirming or the indexer hasn't caught up. Re-poll via \`competition_list_trades\` instead of resubmitting.
+- Permanent rejection (HTTP 4xx, thrown as error): sender not registered, contract not on allowlist, txid malformed, or tx failed on-chain. Do not retry — fix the inputs.
+- Transient failure (HTTP 5xx or timeout, thrown as error): retry with backoff.`,
       inputSchema: {
         txid: z
           .string()
           .min(1)
           .describe("Stacks transaction id (with or without 0x prefix)"),
-        network: z
-          .enum(["mainnet", "testnet"])
-          .optional()
-          .describe("Network the tx is on. Defaults to the configured NETWORK."),
       },
     },
-    async ({ txid, network }) => {
+    async ({ txid }) => {
       try {
-        const body = {
-          txid: normalizeTxid(txid),
-          network: network ?? NETWORK,
-        };
+        const body = { txid: normalizeTxid(txid) };
         const parsed = await competitionFetch("/trades", {
           method: "POST",
           headers: { "content-type": "application/json" },
@@ -138,10 +143,11 @@ Returns the submission status and (if already verified) the parsed trade details
     {
       description: `Get the current AIBTC trading competition standing for an agent.
 
-Returns registration status, trade count, current rank within the active campaign track, and P&L if scoring has run. If no address is provided, uses the active wallet's Stacks address.`,
+Returns registration status, trade count, current rank within the active campaign track, and P&L if scoring has run. If no address is provided, uses the active wallet's Stacks address.
+
+If the address hasn't been registered yet (or the campaign indexer hasn't picked it up), the API returns \`{ registered: false, ... }\` — call \`identity_register\` to onboard, then re-check.`,
       inputSchema: {
-        address: z
-          .string()
+        address: stacksAddressSchema
           .optional()
           .describe(
             "Stacks address of the agent. Defaults to the active wallet."
@@ -168,8 +174,7 @@ Returns registration status, trade count, current rank within the active campaig
 
 Includes both txids the agent submitted directly via competition_submit_trade and txids the competition service discovered via address monitoring. Each entry indicates discovery method, verification status, parsed venue/function, and amounts. If no address is provided, uses the active wallet's Stacks address.`,
       inputSchema: {
-        address: z
-          .string()
+        address: stacksAddressSchema
           .optional()
           .describe(
             "Stacks address of the agent. Defaults to the active wallet."

--- a/src/tools/competition.tools.ts
+++ b/src/tools/competition.tools.ts
@@ -15,7 +15,8 @@
  * already carries the agent's signature and sender), and status/list reads
  * are over public addresses. Rate-limited per IP server-side.
  *
- * API spec: see issue in aibtcdev/landing-page describing endpoint contract.
+ * API spec + verifier implementation: aibtcdev/landing-page#734 (Phase 3.1).
+ * Schema source of truth: docs/rfc-d1-schema.md §swaps (migration 005).
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -109,12 +110,12 @@ The competition service fetches the tx from the Stacks chain and validates:
 - contract+function is on the campaign allowlist (e.g. Bitflow swap helpers, ALEX, Zest)
 - transaction status is success
 
-Submission is a fast-path hint — the service also indexes registered agent addresses passively, so a missed submission still gets picked up. Submitting the same txid twice is idempotent (same response shape, no double-scoring).
+Submission is a fast-path hint — the service also indexes registered agent addresses passively (chainhook + nightly cron), so a missed submission still gets picked up. Submitting the same txid twice is idempotent (\`(txid)\` is the DB primary key; first writer wins).
 
-Response shapes:
-- Accepted: \`{ status: "accepted" | "verified", trade?: {...} }\` — safe to stop.
-- Pending verification: \`{ status: "pending" }\` — the tx is still confirming or the indexer hasn't caught up. Re-poll via \`competition_list_trades\` instead of resubmitting.
-- Permanent rejection (HTTP 4xx, thrown as error): sender not registered, contract not on allowlist, txid malformed, or tx failed on-chain. Do not retry — fix the inputs.
+Response shapes (per landing-page#734 contract):
+- \`202 Accepted\` with \`{ accepted: true }\` — tx not yet confirmed or indexer hasn't caught up. Re-poll via \`competition_list_trades\` instead of resubmitting.
+- \`200 OK\` with the swap row once terminal: \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, ... }\`. Field names follow on-chain vocabulary (migration 005). \`tx_status\` is one of \`success\` or 7 terminal-failure codes; \`source\` is \`"agent" | "cron" | "chainhook"\`.
+- Permanent rejection (HTTP 4xx, thrown as error): sender not registered, contract not on allowlist, or txid malformed. Do not retry — fix the inputs.
 - Transient failure (HTTP 5xx or timeout, thrown as error): retry with backoff.`,
       inputSchema: {
         txid: z
@@ -143,9 +144,9 @@ Response shapes:
     {
       description: `Get the current AIBTC trading competition standing for an agent.
 
-Returns registration status, trade count, current rank within the active campaign track, and P&L if scoring has run. If no address is provided, uses the active wallet's Stacks address.
+Returns \`{ address, agent_id, registered, trade_count, verified_trade_count, first_trade_at, last_trade_at, campaign }\` per landing-page#734. \`agent_id\` is the ERC-8004 id resolved via JOIN over the \`agents\` table (nullable until the agent registers on-chain). \`campaign\` carries rank + P&L once scoring has run.
 
-If the address hasn't been registered yet (or the campaign indexer hasn't picked it up), the API returns \`{ registered: false, ... }\` — call \`identity_register\` to onboard, then re-check.`,
+If the address hasn't been registered yet (or the campaign indexer hasn't picked it up), the API returns \`{ registered: false, ... }\` — call \`identity_register\` to onboard, then re-check. If no address is provided, uses the active wallet's Stacks address.`,
       inputSchema: {
         address: stacksAddressSchema
           .optional()
@@ -170,9 +171,9 @@ If the address hasn't been registered yet (or the campaign indexer hasn't picked
   server.registerTool(
     "competition_list_trades",
     {
-      description: `List submitted and indexed trades for an agent in the current AIBTC trading competition.
+      description: `List trades for an agent in the current AIBTC trading competition.
 
-Includes both txids the agent submitted directly via competition_submit_trade and txids the competition service discovered via address monitoring. Each entry indicates discovery method, verification status, parsed venue/function, and amounts. If no address is provided, uses the active wallet's Stacks address.`,
+Includes txids the agent submitted directly (via \`competition_submit_trade\`) and txids discovered via passive address monitoring (chainhook + nightly cron). Each entry is a swap row from migration 005: \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, scored_value, scored_at }\`. \`source\` distinguishes \`"agent"\` (your submission) from \`"chainhook"\` (real-time stream) and \`"cron"\` (nightly catch-up). Response: \`{ trades, next_cursor }\` — opaque cursor for pagination. If no address is provided, uses the active wallet's Stacks address.`,
       inputSchema: {
         address: stacksAddressSchema
           .optional()

--- a/src/tools/competition.tools.ts
+++ b/src/tools/competition.tools.ts
@@ -37,6 +37,17 @@ import { createErrorResponse } from "../utils/errors.js";
  */
 const PENDING_TX_STATUS = "pending";
 
+/**
+ * Stacks blocks settle in ~30s. If the first check shows the tx still
+ * pending, wait one block and re-check before giving up. One retry is
+ * enough to cover the common "agent submits right after broadcast" case.
+ */
+const CONFIRMATION_WAIT_MS = 30_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 const stacksAddressSchema = z
   .string()
   .regex(
@@ -124,11 +135,11 @@ The competition service fetches the tx from the Stacks chain and validates:
 
 Submission is a fast-path hint — the service also indexes registered agent addresses passively (nightly cron), so a missed submission still gets picked up. Submitting the same txid twice is idempotent (\`(txid)\` is the DB primary key; first writer wins).
 
-**Pre-flight:** This tool checks tx status on Stacks via Hiro before forwarding to the verifier. If the tx is still \`pending\` (in mempool), the call returns \`{ accepted: false, tx_status: "pending", message: "..." }\` without hitting the verifier — wait ~30s for confirmation and retry. Use \`get_transaction_status\` to poll explicitly.
+**Pre-flight + auto-wait:** This tool checks tx status on Stacks via Hiro. If the tx is still \`pending\` (in mempool), it waits one Stacks block (~30s) and re-checks once before either submitting or giving up. The response includes a \`progress\` array of human-readable steps describing what happened — **narrate these to the user verbatim** ("Tx confirmed at block X, submitting now…") so they see the flow in real time. Don't summarize \`progress\`; read it line by line as you process the response.
 
 Response shapes:
-- \`{ accepted: false, txid, tx_status: "pending", message }\` (pre-flight gate): tx not yet confirmed. Retry after ~30s.
-- \`200 OK\` with the swap row once verified: \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, ... }\`. Field names follow on-chain vocabulary (migration 005). \`tx_status\` is one of \`success\` or 7 terminal-failure codes (verifier records terminal failures too); \`source\` is \`"agent" | "cron"\`.
+- Confirmed + submitted (common case): \`{ progress: [...], result: <verifier response> }\` where \`result\` is the swap row \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, ... }\`. Field names follow on-chain vocabulary (migration 005). \`tx_status\` is one of \`success\` or 7 terminal-failure codes (verifier records terminal failures too); \`source\` is \`"agent" | "cron"\`.
+- Still pending after wait: \`{ accepted: false, txid, tx_status: "pending", progress: [...], message }\`. Tx hasn't confirmed in ~30s — retry the tool in a minute, or call \`get_transaction_status\` to poll manually.
 - Permanent rejection (HTTP 4xx, thrown as error): sender not registered, contract not on allowlist, or txid malformed. Do not retry — fix the inputs.
 - Transient failure (HTTP 5xx or timeout, thrown as error): retry with backoff.`,
       inputSchema: {
@@ -141,28 +152,44 @@ Response shapes:
     async ({ txid }) => {
       try {
         const normalized = normalizeTxid(txid);
+        const progress: string[] = [];
 
         // Pre-flight: confirm the tx is terminal on Stacks before forwarding
-        // to the verifier. Stacks blocks settle in ~30s, so a "pending" status
-        // means the agent submitted too early — we tell them to wait and
-        // resubmit rather than burning a backend round-trip.
-        const txStatus = await getTransactionStatus(normalized, NETWORK);
+        // to the verifier. Stacks blocks settle in ~30s, so if the first check
+        // shows pending we wait one block and re-check before giving up.
+        let txStatus = await getTransactionStatus(normalized, NETWORK);
+        progress.push(`Checked tx ${normalized}: status=${txStatus.status}`);
+
+        if (txStatus.status === PENDING_TX_STATUS) {
+          progress.push(
+            "Tx is still pending — waiting ~30s for the next Stacks block before re-checking."
+          );
+          await sleep(CONFIRMATION_WAIT_MS);
+          txStatus = await getTransactionStatus(normalized, NETWORK);
+          progress.push(`Re-checked after 30s: status=${txStatus.status}`);
+        }
+
         if (txStatus.status === PENDING_TX_STATUS) {
           return createJsonResponse({
             accepted: false,
             txid: normalized,
             tx_status: PENDING_TX_STATUS,
+            progress,
             message:
-              "Transaction is still pending on Stacks. Wait ~30s for confirmation and resubmit. Use get_transaction_status to poll.",
+              "Transaction is still pending after the 30s confirmation wait. Try again in a minute, or poll with get_transaction_status.",
           });
         }
 
+        progress.push(
+          `Tx confirmed (status=${txStatus.status}). Submitting txid to competition verifier now.`
+        );
         const parsed = await competitionFetch("/trades", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ txid: normalized }),
         });
-        return createJsonResponse(parsed);
+        progress.push("Verifier accepted the submission.");
+        return createJsonResponse({ progress, result: parsed });
       } catch (error) {
         return createErrorResponse(error);
       }

--- a/src/tools/competition.tools.ts
+++ b/src/tools/competition.tools.ts
@@ -203,7 +203,7 @@ If the address hasn't been registered yet (or the campaign indexer hasn't picked
     {
       description: `List trades for an agent in the current AIBTC trading competition.
 
-Includes txids the agent submitted directly (via \`competition_submit_trade\`) and txids discovered via passive address monitoring (chainhook + nightly cron). Each entry is a swap row from migration 005: \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, scored_value, scored_at }\`. \`source\` distinguishes \`"agent"\` (your submission) from \`"chainhook"\` (real-time stream) and \`"cron"\` (nightly catch-up). Response: \`{ trades, next_cursor }\` — opaque cursor for pagination. If no address is provided, uses the active wallet's Stacks address.`,
+Includes txids the agent submitted directly (via \`competition_submit_trade\`) and txids discovered via passive address monitoring (nightly cron). Each entry is a swap row from migration 005: \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, scored_value, scored_at }\`. \`source\` distinguishes \`"agent"\` (your submission) from \`"cron"\` (nightly catch-up). Response: \`{ trades, next_cursor }\` — opaque cursor for pagination. If no address is provided, uses the active wallet's Stacks address.`,
       inputSchema: {
         address: stacksAddressSchema
           .optional()

--- a/src/tools/competition.tools.ts
+++ b/src/tools/competition.tools.ts
@@ -21,9 +21,21 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { AIBTC_CAMPAIGN_API_URL } from "../config/competition.js";
+import { NETWORK } from "../config/networks.js";
+import { getTransactionStatus } from "../services/hiro-api.js";
 import { getWalletManager } from "../services/wallet-manager.js";
 import { createJsonResponse } from "../utils/formatting.js";
 import { createErrorResponse } from "../utils/errors.js";
+
+/**
+ * Stacks tx_status values from Hiro's /extended/v1/tx endpoint.
+ * `pending` = in mempool, not confirmed. Everything else is terminal:
+ * `success`, `abort_by_response`, `abort_by_post_condition`, and the
+ * five `dropped_*` codes. The verifier records terminal failures too
+ * (migration 005's CHECK allows all 8 terminal codes) so we only block
+ * submission when status is `pending`.
+ */
+const PENDING_TX_STATUS = "pending";
 
 const stacksAddressSchema = z
   .string()
@@ -110,11 +122,13 @@ The competition service fetches the tx from the Stacks chain and validates:
 - contract+function is on the campaign allowlist (e.g. Bitflow swap helpers, ALEX, Zest)
 - transaction status is success
 
-Submission is a fast-path hint — the service also indexes registered agent addresses passively (chainhook + nightly cron), so a missed submission still gets picked up. Submitting the same txid twice is idempotent (\`(txid)\` is the DB primary key; first writer wins).
+Submission is a fast-path hint — the service also indexes registered agent addresses passively (nightly cron), so a missed submission still gets picked up. Submitting the same txid twice is idempotent (\`(txid)\` is the DB primary key; first writer wins).
 
-Response shapes (per landing-page#734 contract):
-- \`202 Accepted\` with \`{ accepted: true }\` — tx not yet confirmed or indexer hasn't caught up. Re-poll via \`competition_list_trades\` instead of resubmitting.
-- \`200 OK\` with the swap row once terminal: \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, ... }\`. Field names follow on-chain vocabulary (migration 005). \`tx_status\` is one of \`success\` or 7 terminal-failure codes; \`source\` is \`"agent" | "cron" | "chainhook"\`.
+**Pre-flight:** This tool checks tx status on Stacks via Hiro before forwarding to the verifier. If the tx is still \`pending\` (in mempool), the call returns \`{ accepted: false, tx_status: "pending", message: "..." }\` without hitting the verifier — wait ~30s for confirmation and retry. Use \`get_transaction_status\` to poll explicitly.
+
+Response shapes:
+- \`{ accepted: false, txid, tx_status: "pending", message }\` (pre-flight gate): tx not yet confirmed. Retry after ~30s.
+- \`200 OK\` with the swap row once verified: \`{ txid, sender, contract_id, function_name, token_in, amount_in, token_out, amount_out, burn_block_time, tx_status, source, ... }\`. Field names follow on-chain vocabulary (migration 005). \`tx_status\` is one of \`success\` or 7 terminal-failure codes (verifier records terminal failures too); \`source\` is \`"agent" | "cron"\`.
 - Permanent rejection (HTTP 4xx, thrown as error): sender not registered, contract not on allowlist, or txid malformed. Do not retry — fix the inputs.
 - Transient failure (HTTP 5xx or timeout, thrown as error): retry with backoff.`,
       inputSchema: {
@@ -126,11 +140,27 @@ Response shapes (per landing-page#734 contract):
     },
     async ({ txid }) => {
       try {
-        const body = { txid: normalizeTxid(txid) };
+        const normalized = normalizeTxid(txid);
+
+        // Pre-flight: confirm the tx is terminal on Stacks before forwarding
+        // to the verifier. Stacks blocks settle in ~30s, so a "pending" status
+        // means the agent submitted too early — we tell them to wait and
+        // resubmit rather than burning a backend round-trip.
+        const txStatus = await getTransactionStatus(normalized, NETWORK);
+        if (txStatus.status === PENDING_TX_STATUS) {
+          return createJsonResponse({
+            accepted: false,
+            txid: normalized,
+            tx_status: PENDING_TX_STATUS,
+            message:
+              "Transaction is still pending on Stacks. Wait ~30s for confirmation and resubmit. Use get_transaction_status to poll.",
+          });
+        }
+
         const parsed = await competitionFetch("/trades", {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify(body),
+          body: JSON.stringify({ txid: normalized }),
         });
         return createJsonResponse(parsed);
       } catch (error) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -44,6 +44,7 @@ import { registerBountyScannerTools } from "./bounty-scanner.tools.js";
 import { registerRunesTools } from "./runes.tools.js";
 import { registerInboxTools } from "./inbox.tools.js";
 import { registerArxivResearchTools } from "./arxiv-research.tools.js";
+import { registerCompetitionTools } from "./competition.tools.js";
 import { getSkillForTool } from "./skill-mappings.js";
 
 /**
@@ -210,6 +211,9 @@ export function registerAllTools(server: McpServer): void {
 
   // arXiv Research (public arXiv Atom API — paper search and digest compilation)
   registerArxivResearchTools(server);
+
+  // AIBTC Trading Competition (submit trade txids, check standing, list trades)
+  registerCompetitionTools(server);
 
   restoreRegisterTool();
 }

--- a/tests/tools/competition.test.ts
+++ b/tests/tools/competition.test.ts
@@ -13,6 +13,11 @@ vi.mock("../../src/services/wallet-manager.js", () => ({
   }),
 }));
 
+const mockGetTransactionStatus = vi.fn();
+vi.mock("../../src/services/hiro-api.js", () => ({
+  getTransactionStatus: mockGetTransactionStatus,
+}));
+
 const { registerCompetitionTools } = await import(
   "../../src/tools/competition.tools.js"
 );
@@ -57,11 +62,19 @@ describe("competition tools", () => {
   beforeEach(() => {
     fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
+    // Default tx-status mock: tx is confirmed (success) so the pre-flight
+    // gate passes and submission proceeds. Tests that need pending semantics
+    // override this in-place.
+    mockGetTransactionStatus.mockResolvedValue({
+      status: "success",
+      block_height: 7929497,
+    });
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.useRealTimers();
+    mockGetTransactionStatus.mockReset();
   });
 
   it("submit_trade is idempotent: two calls with same txid return the same shape", async () => {
@@ -138,6 +151,52 @@ describe("competition tools", () => {
     expect(result.isError).toBe(true);
     expect(abortError).toBeDefined();
     expect(result.content[0].text.toLowerCase()).toContain("abort");
+  });
+
+  it("gates submission when the tx is still pending on Stacks", async () => {
+    mockGetTransactionStatus.mockResolvedValue({ status: "pending" });
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerCompetitionTools(server as any);
+    const submit = tools.get("competition_submit_trade")!;
+
+    const result = await submit.handler({ txid: VALID_TXID });
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content[0].text);
+    expect(body).toMatchObject({
+      accepted: false,
+      txid: VALID_TXID,
+      tx_status: "pending",
+    });
+    expect(body.message).toContain("pending");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards terminal-failure txs to the verifier (backend records them)", async () => {
+    mockGetTransactionStatus.mockResolvedValue({
+      status: "abort_by_post_condition",
+    });
+    fetchMock.mockImplementation(async () =>
+      jsonResponse({
+        txid: VALID_TXID,
+        tx_status: "abort_by_post_condition",
+        source: "agent",
+      })
+    );
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerCompetitionTools(server as any);
+    const submit = tools.get("competition_submit_trade")!;
+
+    const result = await submit.handler({ txid: VALID_TXID });
+    expect(result.isError).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(result.content[0].text).tx_status).toBe(
+      "abort_by_post_condition"
+    );
   });
 
   it("rejects malformed txids before any network call", async () => {

--- a/tests/tools/competition.test.ts
+++ b/tests/tools/competition.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/config/competition.js", () => ({
+  AIBTC_CAMPAIGN_API_URL: "https://test.aibtc.com/api/competition",
+}));
+
+vi.mock("../../src/services/wallet-manager.js", () => ({
+  getWalletManager: () => ({
+    getActiveWalletId: async () => "wallet-1",
+    listWallets: async () => [
+      { id: "wallet-1", address: "SP000000000000000000002Q6VF78" },
+    ],
+  }),
+}));
+
+const { registerCompetitionTools } = await import(
+  "../../src/tools/competition.tools.js"
+);
+
+interface RegisteredTool {
+  handler: (args: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+function createTrackingServer() {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    registerTool: vi.fn(
+      (
+        name: string,
+        _config: { description: string; inputSchema: unknown },
+        handler: RegisteredTool["handler"]
+      ) => {
+        tools.set(name, { handler });
+      }
+    ),
+  };
+  return { server, tools };
+}
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  const status = init.status ?? 200;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const VALID_TXID =
+  "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+describe("competition tools", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("submit_trade is idempotent: two calls with same txid return the same shape", async () => {
+    const verifiedBody = {
+      status: "verified",
+      trade: { txid: VALID_TXID, venue: "bitflow" },
+    };
+    fetchMock.mockImplementation(async () => jsonResponse(verifiedBody));
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerCompetitionTools(server as any);
+    const submit = tools.get("competition_submit_trade")!;
+
+    const first = await submit.handler({ txid: VALID_TXID });
+    const second = await submit.handler({ txid: VALID_TXID });
+
+    expect(first.isError).toBeUndefined();
+    expect(second.isError).toBeUndefined();
+    expect(first.content[0].text).toEqual(second.content[0].text);
+    expect(JSON.parse(first.content[0].text)).toEqual(verifiedBody);
+
+    // Both calls hit POST /trades with the normalized txid in the body.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const call of fetchMock.mock.calls) {
+      const [url, init] = call as [string, RequestInit];
+      expect(url).toBe("https://test.aibtc.com/api/competition/trades");
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual({ txid: VALID_TXID });
+    }
+  });
+
+  it("propagates 5xx errors as MCP error responses with status code", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ error: "indexer offline" }, { status: 503 })
+    );
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerCompetitionTools(server as any);
+    const submit = tools.get("competition_submit_trade")!;
+
+    const result = await submit.handler({ txid: VALID_TXID });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("503");
+    expect(result.content[0].text).toContain("indexer offline");
+  });
+
+  it("aborts requests that exceed the 10s timeout", async () => {
+    vi.useFakeTimers();
+
+    let abortError: Error | undefined;
+    fetchMock.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const signal = init.signal as AbortSignal;
+          signal.addEventListener("abort", () => {
+            abortError = new Error("The operation was aborted");
+            abortError.name = "AbortError";
+            reject(abortError);
+          });
+        })
+    );
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerCompetitionTools(server as any);
+    const submit = tools.get("competition_submit_trade")!;
+
+    const pending = submit.handler({ txid: VALID_TXID });
+    await vi.advanceTimersByTimeAsync(10_001);
+    const result = await pending;
+
+    expect(result.isError).toBe(true);
+    expect(abortError).toBeDefined();
+    expect(result.content[0].text.toLowerCase()).toContain("abort");
+  });
+
+  it("rejects malformed txids before any network call", async () => {
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerCompetitionTools(server as any);
+    const submit = tools.get("competition_submit_trade")!;
+
+    const result = await submit.handler({ txid: "not-a-real-txid" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Invalid Stacks txid");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/competition.test.ts
+++ b/tests/tools/competition.test.ts
@@ -77,10 +77,12 @@ describe("competition tools", () => {
     mockGetTransactionStatus.mockReset();
   });
 
-  it("submit_trade is idempotent: two calls with same txid return the same shape", async () => {
+  it("submit_trade is idempotent: two calls with same txid return the same result", async () => {
     const verifiedBody = {
-      status: "verified",
-      trade: { txid: VALID_TXID, venue: "bitflow" },
+      txid: VALID_TXID,
+      sender: "SP000000000000000000002Q6VF78",
+      tx_status: "success",
+      source: "agent",
     };
     fetchMock.mockImplementation(async () => jsonResponse(verifiedBody));
 
@@ -94,8 +96,8 @@ describe("competition tools", () => {
 
     expect(first.isError).toBeUndefined();
     expect(second.isError).toBeUndefined();
-    expect(first.content[0].text).toEqual(second.content[0].text);
-    expect(JSON.parse(first.content[0].text)).toEqual(verifiedBody);
+    expect(JSON.parse(first.content[0].text).result).toEqual(verifiedBody);
+    expect(JSON.parse(second.content[0].text).result).toEqual(verifiedBody);
 
     // Both calls hit POST /trades with the normalized txid in the body.
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -153,15 +155,54 @@ describe("competition tools", () => {
     expect(result.content[0].text.toLowerCase()).toContain("abort");
   });
 
-  it("gates submission when the tx is still pending on Stacks", async () => {
-    mockGetTransactionStatus.mockResolvedValue({ status: "pending" });
+  it("waits 30s and re-checks when the tx is pending, then submits once confirmed", async () => {
+    vi.useFakeTimers();
+    // First check: pending. After ~30s wait, second check: confirmed.
+    mockGetTransactionStatus
+      .mockResolvedValueOnce({ status: "pending" })
+      .mockResolvedValueOnce({ status: "success", block_height: 7929497 });
+    fetchMock.mockImplementation(async () =>
+      jsonResponse({ txid: VALID_TXID, tx_status: "success", source: "agent" })
+    );
 
     const { server, tools } = createTrackingServer();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerCompetitionTools(server as any);
     const submit = tools.get("competition_submit_trade")!;
 
-    const result = await submit.handler({ txid: VALID_TXID });
+    const pending = submit.handler({ txid: VALID_TXID });
+    await vi.advanceTimersByTimeAsync(30_001);
+    const result = await pending;
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content[0].text);
+    expect(body.result).toMatchObject({ txid: VALID_TXID, tx_status: "success" });
+    expect(body.progress).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("status=pending"),
+        expect.stringContaining("waiting ~30s"),
+        expect.stringContaining("status=success"),
+        expect.stringContaining("Submitting"),
+      ])
+    );
+    expect(mockGetTransactionStatus).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after the 30s wait if tx is still pending", async () => {
+    vi.useFakeTimers();
+    mockGetTransactionStatus
+      .mockResolvedValueOnce({ status: "pending" })
+      .mockResolvedValueOnce({ status: "pending" });
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerCompetitionTools(server as any);
+    const submit = tools.get("competition_submit_trade")!;
+
+    const pending = submit.handler({ txid: VALID_TXID });
+    await vi.advanceTimersByTimeAsync(30_001);
+    const result = await pending;
 
     expect(result.isError).toBeUndefined();
     const body = JSON.parse(result.content[0].text);
@@ -170,7 +211,7 @@ describe("competition tools", () => {
       txid: VALID_TXID,
       tx_status: "pending",
     });
-    expect(body.message).toContain("pending");
+    expect(body.progress.length).toBeGreaterThanOrEqual(3);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -194,7 +235,7 @@ describe("competition tools", () => {
     const result = await submit.handler({ txid: VALID_TXID });
     expect(result.isError).toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(result.content[0].text).tx_status).toBe(
+    expect(JSON.parse(result.content[0].text).result.tx_status).toBe(
       "abort_by_post_condition"
     );
   });

--- a/tests/tools/competition.test.ts
+++ b/tests/tools/competition.test.ts
@@ -77,7 +77,7 @@ describe("competition tools", () => {
     mockGetTransactionStatus.mockReset();
   });
 
-  it("submit_trade is idempotent: two calls with same txid return the same result", async () => {
+  it("submit_trade is idempotent: two calls with same txid return the same shape", async () => {
     const verifiedBody = {
       txid: VALID_TXID,
       sender: "SP000000000000000000002Q6VF78",
@@ -96,8 +96,8 @@ describe("competition tools", () => {
 
     expect(first.isError).toBeUndefined();
     expect(second.isError).toBeUndefined();
-    expect(JSON.parse(first.content[0].text).result).toEqual(verifiedBody);
-    expect(JSON.parse(second.content[0].text).result).toEqual(verifiedBody);
+    expect(first.content[0].text).toEqual(second.content[0].text);
+    expect(JSON.parse(first.content[0].text)).toEqual(verifiedBody);
 
     // Both calls hit POST /trades with the normalized txid in the body.
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -155,54 +155,15 @@ describe("competition tools", () => {
     expect(result.content[0].text.toLowerCase()).toContain("abort");
   });
 
-  it("waits 30s and re-checks when the tx is pending, then submits once confirmed", async () => {
-    vi.useFakeTimers();
-    // First check: pending. After ~30s wait, second check: confirmed.
-    mockGetTransactionStatus
-      .mockResolvedValueOnce({ status: "pending" })
-      .mockResolvedValueOnce({ status: "success", block_height: 7929497 });
-    fetchMock.mockImplementation(async () =>
-      jsonResponse({ txid: VALID_TXID, tx_status: "success", source: "agent" })
-    );
+  it("gates submission when the tx is still pending on Stacks", async () => {
+    mockGetTransactionStatus.mockResolvedValue({ status: "pending" });
 
     const { server, tools } = createTrackingServer();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerCompetitionTools(server as any);
     const submit = tools.get("competition_submit_trade")!;
 
-    const pending = submit.handler({ txid: VALID_TXID });
-    await vi.advanceTimersByTimeAsync(30_001);
-    const result = await pending;
-
-    expect(result.isError).toBeUndefined();
-    const body = JSON.parse(result.content[0].text);
-    expect(body.result).toMatchObject({ txid: VALID_TXID, tx_status: "success" });
-    expect(body.progress).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("status=pending"),
-        expect.stringContaining("waiting ~30s"),
-        expect.stringContaining("status=success"),
-        expect.stringContaining("Submitting"),
-      ])
-    );
-    expect(mockGetTransactionStatus).toHaveBeenCalledTimes(2);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("gives up after the 30s wait if tx is still pending", async () => {
-    vi.useFakeTimers();
-    mockGetTransactionStatus
-      .mockResolvedValueOnce({ status: "pending" })
-      .mockResolvedValueOnce({ status: "pending" });
-
-    const { server, tools } = createTrackingServer();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    registerCompetitionTools(server as any);
-    const submit = tools.get("competition_submit_trade")!;
-
-    const pending = submit.handler({ txid: VALID_TXID });
-    await vi.advanceTimersByTimeAsync(30_001);
-    const result = await pending;
+    const result = await submit.handler({ txid: VALID_TXID });
 
     expect(result.isError).toBeUndefined();
     const body = JSON.parse(result.content[0].text);
@@ -211,7 +172,7 @@ describe("competition tools", () => {
       txid: VALID_TXID,
       tx_status: "pending",
     });
-    expect(body.progress.length).toBeGreaterThanOrEqual(3);
+    expect(body.message).toContain("pending");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -235,7 +196,7 @@ describe("competition tools", () => {
     const result = await submit.handler({ txid: VALID_TXID });
     expect(result.isError).toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(result.content[0].text).result.tx_status).toBe(
+    expect(JSON.parse(result.content[0].text).tx_status).toBe(
       "abort_by_post_condition"
     );
   });


### PR DESCRIPTION
## Summary

- Three new MCP tools for the AIBTC trading competition: `competition_submit_trade`, `competition_status`, `competition_list_trades`. Configurable via `AIBTC_CAMPAIGN_API_URL` (default `https://aibtc.com/api/competition`).
- Wires `BITFLOW_PROVIDER_ADDRESS = SP1M8KHCJXB3SBRQRDBCG3J3859AA1CN0AWDHN17B` through `getBitflowConfig()` so the SDK injects it as the Clarity `provider` arg on contracts that declare one.

## Context

Trading-competition scoring needs to attribute swaps to AIBTC-routed activity. We investigated whether Bitflow's built-in `provider` arg could carry that attribution end-to-end and found it only fires on one contract family (`xyk-swap-helper-v-1-3`) — stableswap, xyk-core, dlmm, and the 12 cross-DEX routers all silently drop it. Full research and contract audit: https://gist.github.com/biwasxyz/54213c1d25b9cacb9a79f0e005cf3260

The competition service therefore relies on **the txid itself as the journal entry**: every Stacks tx is already signed by the agent's wallet, so the tx carries identity + intent. The MCP submits txids as fast-path hints; the backend also indexes registered addresses passively and reconciles. Allowlist enforcement and wash-trade rules live server-side.

The provider-arg wiring is kept anyway — zero cost, and gives corroborating on-chain attribution for the XYK multi-hop routes that surface it.

## Backend status

The verifier/read-route backend is now merged in `aibtcdev/landing-page#738` with:

- `GET /api/competition/status`
- `GET /api/competition/trades`
- `POST /api/competition/trades`
- `GET /api/competition/allowlist`

The passive catch-up path runs through landing-page `SchedulerDO`; there is no public competition cron endpoint or `CRON_SECRET` dependency.

## Files

- `src/tools/competition.tools.ts` (new) — three tools, no request signing in v1, address resolution defaults to active wallet
- `src/config/competition.ts` (new) — `AIBTC_CAMPAIGN_API_URL` getter
- `src/tools/index.ts` — register new tools
- `.env.example` — document the new env var
- `src/config/contracts.ts` — add `BITFLOW_PROVIDER_ADDRESS` constant + `providerAddress` field on `BitflowConfig`
- `src/services/bitflow.service.ts` — pass `config.providerAddress` to the SDK instead of empty string
- `tests/tools/competition.test.ts` — competition tool behavior, timeout, idempotency, and txid validation coverage

## Test plan

- [x] `npm run build` clean
- [x] `npm test` coverage added for competition tool behavior
- [x] Verified Bitflow provider injection on an actual swap (txid `46bc55…0ee0e4` confirmed on mainnet via `tests/scripts/verify-bitflow-swap.ts`). Stableswap route doesn't carry `provider` arg by design — SDK skips injection per `BitflowSDK.js:177` when the function signature doesn't declare it.
- [ ] Post-deploy smoke-test the three competition tools end-to-end against the live endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)