### PR TITLE
feat: add native AIBTC bounty tools

### DIFF
--- a/src/services/native-bounty.service.ts
+++ b/src/services/native-bounty.service.ts
@@ -129,8 +129,8 @@ export function buildNativeBountySignedFields(
   };
 }
 
-export async function fetchNativeBountyJson(path: string, init?: RequestInit): Promise<unknown> {
-  const response = await fetch(new URL(path, AIBTC_BOUNTY_BASE), init);
+export async function fetchNativeBountyUrl(url: URL, init?: RequestInit): Promise<unknown> {
+  const response = await fetch(url, init);
   const text = await response.text();
   let data: unknown;
   try {
@@ -142,4 +142,8 @@ export async function fetchNativeBountyJson(path: string, init?: RequestInit): P
     throw new Error(`AIBTC bounty API ${response.status}: ${text}`);
   }
   return data;
+}
+
+export async function fetchNativeBountyJson(path: string, init?: RequestInit): Promise<unknown> {
+  return fetchNativeBountyUrl(new URL(path, AIBTC_BOUNTY_BASE), init);
 }

--- a/src/services/native-bounty.service.ts
+++ b/src/services/native-bounty.service.ts
@@ -1,0 +1,145 @@
+import { p2wpkh, NETWORK as BTC_MAINNET, TEST_NETWORK as BTC_TESTNET } from "@scure/btc-signer";
+import { NETWORK } from "../config/networks.js";
+import { bip322Sign } from "../utils/bip322.js";
+
+export const AIBTC_BOUNTY_BASE = "https://aibtc.com";
+
+export type NativeBountyStatus =
+  | "open"
+  | "judging"
+  | "winner-announced"
+  | "paid"
+  | "abandoned"
+  | "cancelled"
+  | "active";
+
+export type NativeBountyListParams = {
+  status?: NativeBountyStatus;
+  poster?: string;
+  submitter?: string;
+  tag?: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type NativeBountyAccount = {
+  btcAddress: string;
+  btcPrivateKey: Uint8Array;
+  btcPublicKey: Uint8Array;
+  address?: string;
+};
+
+export function normalizeNativeBountyListParams(params: NativeBountyListParams): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  if (params.status) normalized.status = params.status;
+  if (params.poster) normalized.poster = params.poster;
+  if (params.submitter) normalized.submitter = params.submitter;
+  if (params.tag) normalized.tag = params.tag;
+  if (params.limit !== undefined) normalized.limit = String(Math.min(100, Math.max(1, params.limit)));
+  if (params.offset !== undefined) normalized.offset = String(Math.max(0, params.offset));
+  return normalized;
+}
+
+export function buildNativeBountyUrl(path: string, params: NativeBountyListParams = {}): URL {
+  const url = new URL(path, AIBTC_BOUNTY_BASE);
+  const normalized = normalizeNativeBountyListParams(params);
+  for (const [key, value] of Object.entries(normalized)) {
+    url.searchParams.set(key, value);
+  }
+  return url;
+}
+
+export type NativeBountyMessageInput =
+  | {
+      posterBtc: string;
+      title: string;
+      description: string;
+      rewardSats: number;
+      expiresAt: string;
+      tags?: string[];
+      signedAt: string;
+    }
+  | {
+      bountyId: string;
+      submitterBtc: string;
+      message: string;
+      contentUrl?: string;
+      signedAt: string;
+    }
+  | {
+      bountyId: string;
+      submissionId: string;
+      signedAt: string;
+    }
+  | {
+      bountyId: string;
+      txid: string;
+      signedAt: string;
+    }
+  | {
+      bountyId: string;
+      signedAt: string;
+    };
+
+export function buildNativeBountyMessage(
+  action: "create" | "submit" | "accept" | "paid" | "cancel",
+  input: NativeBountyMessageInput
+): string {
+  switch (action) {
+    case "create": {
+      const data = input as Extract<NativeBountyMessageInput, { posterBtc: string }>;
+      return `AIBTC Bounty Create | ${data.posterBtc} | ${data.title} | ${data.description} | ${data.rewardSats} | ${data.expiresAt} | ${(data.tags ?? []).join(",")} | ${data.signedAt}`;
+    }
+    case "submit": {
+      const data = input as Extract<NativeBountyMessageInput, { submitterBtc: string }>;
+      return `AIBTC Bounty Submit | ${data.bountyId} | ${data.submitterBtc} | ${data.message} | ${data.contentUrl ?? ""} | ${data.signedAt}`;
+    }
+    case "accept": {
+      const data = input as Extract<NativeBountyMessageInput, { submissionId: string }>;
+      return `AIBTC Bounty Accept | ${data.bountyId} | ${data.submissionId} | ${data.signedAt}`;
+    }
+    case "paid": {
+      const data = input as Extract<NativeBountyMessageInput, { txid: string }>;
+      return `AIBTC Bounty Paid | ${data.bountyId} | ${data.txid} | ${data.signedAt}`;
+    }
+    case "cancel": {
+      const data = input as Extract<NativeBountyMessageInput, { bountyId: string }>;
+      return `AIBTC Bounty Cancel | ${data.bountyId} | ${data.signedAt}`;
+    }
+  }
+}
+
+export function signNativeBountyMessage(message: string, account: NativeBountyAccount): string {
+  const btcNetwork = NETWORK === "testnet" ? BTC_TESTNET : BTC_MAINNET;
+  const scriptPubKey = p2wpkh(account.btcPublicKey, btcNetwork).script;
+  return bip322Sign(message, account.btcPrivateKey, scriptPubKey);
+}
+
+export function buildNativeBountySignedFields(
+  message: string,
+  signedAt: string,
+  account: NativeBountyAccount
+): {
+  signedAt: string;
+  signature: string;
+} {
+  return {
+    signedAt,
+    signature: signNativeBountyMessage(message, account),
+  };
+}
+
+export async function fetchNativeBountyJson(path: string, init?: RequestInit): Promise<unknown> {
+  const response = await fetch(new URL(path, AIBTC_BOUNTY_BASE), init);
+  const text = await response.text();
+  let data: unknown;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = { raw: text };
+  }
+  if (!response.ok) {
+    throw new Error(`AIBTC bounty API ${response.status}: ${text}`);
+  }
+  return data;
+}

--- a/src/tools/bounty-scanner.tools.ts
+++ b/src/tools/bounty-scanner.tools.ts
@@ -98,7 +98,7 @@ export function registerBountyScannerTools(server: McpServer): void {
   server.registerTool(
     "bounty_list",
     {
-      description: `List bounties on the bounty.drx4.xyz sBTC bounty board.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_*_native for aibtc.com] List bounties on the bounty.drx4.xyz sBTC bounty board.
 
 Returns bounties matching the given filters in reverse chronological order.
 
@@ -180,7 +180,7 @@ No authentication required.`,
   server.registerTool(
     "bounty_get",
     {
-      description: `Get full details for a single bounty on bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_*_native for aibtc.com] Get full details for a single bounty on bounty.drx4.xyz.
 
 Returns the bounty description, reward amount, tags, status, all claims,
 submissions, payments, and available actions for the current agent.
@@ -214,7 +214,7 @@ No authentication required.`,
   server.registerTool(
     "bounty_match",
     {
-      description: `Score open bounties against an agent's capability profile.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_*_native for aibtc.com] Score open bounties against an agent's capability profile.
 
 Fetches all open bounties and ranks them by tag overlap with the provided
 capability_tags. Returns bounties sorted by match score (highest first),
@@ -278,7 +278,7 @@ No authentication required.`,
   server.registerTool(
     "bounty_create",
     {
-      description: `Create a new bounty on bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_*_native for aibtc.com] Create a new bounty on bounty.drx4.xyz.
 
 Posts a new bounty to the sBTC bounty board. Requires an unlocked wallet with
 BTC keys and AIBTC level >= 1. The request is authenticated via BIP-322 signing.
@@ -377,7 +377,7 @@ Fields:
   server.registerTool(
     "bounty_claim",
     {
-      description: `Claim a bounty on bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_*_native for aibtc.com] Claim a bounty on bounty.drx4.xyz.
 
 Submits a claim for an open bounty. Requires an unlocked wallet with BTC keys.
 The request is authenticated via BIP-322 signing.
@@ -458,7 +458,7 @@ Fields:
   server.registerTool(
     "bounty_status",
     {
-      description: `Check the current status of a bounty on bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_*_native for aibtc.com] Check the current status of a bounty on bounty.drx4.xyz.
 
 Returns the bounty's current status in the workflow, along with any claims
 and submission details. The status flow is:
@@ -508,7 +508,7 @@ No authentication required.`,
   server.registerTool(
     "bounty_my_claims",
     {
-      description: `List all bounty claims and submissions for the current wallet's BTC address.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_*_native for aibtc.com] List all bounty claims and submissions for the current wallet's BTC address.
 
 Returns the agent profile from bounty.drx4.xyz including all bounties created
 and claims submitted. If no address is provided, uses the current wallet's BTC address.
@@ -555,7 +555,7 @@ No authentication required.`,
   server.registerTool(
     "bounty_stats",
     {
-      description: `Get aggregate platform statistics from bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_*_native for aibtc.com] Get aggregate platform statistics from bounty.drx4.xyz.
 
 Returns totals for bounties, agents, claims, submissions, and sBTC paid out.
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -41,6 +41,7 @@ import { registerIdentityTools } from "./identity.tools.js";
 import { registerCredentialsTools } from "./credentials.tools.js";
 import { registerSouldinalsTools } from "./souldinals.tools.js";
 import { registerBountyScannerTools } from "./bounty-scanner.tools.js";
+import { registerNativeBountyTools } from "./native-bounty.tools.js";
 import { registerRunesTools } from "./runes.tools.js";
 import { registerInboxTools } from "./inbox.tools.js";
 import { registerArxivResearchTools } from "./arxiv-research.tools.js";
@@ -200,8 +201,11 @@ export function registerAllTools(server: McpServer): void {
   // Souldinals (soul.md child inscriptions — inscribe, reveal, list, load, display traits)
   registerSouldinalsTools(server);
 
-  // Bounty Scanner (bounty.drx4.xyz — list, match, claim, status, my-claims)
+  // Bounty Scanner (bounty.drx4.xyz legacy — list, match, claim, status, my-claims)
   registerBountyScannerTools(server);
+
+  // Native AIBTC Bounties (aibtc.com/api/bounties — first-party bounty workflow)
+  registerNativeBountyTools(server);
 
   // Runes (Bitcoin-native fungible tokens — list, query, holders, activity, balances)
   registerRunesTools(server);

--- a/src/tools/native-bounty.tools.ts
+++ b/src/tools/native-bounty.tools.ts
@@ -7,6 +7,7 @@ import {
   buildNativeBountyUrl,
   buildNativeBountySignedFields,
   fetchNativeBountyJson,
+  fetchNativeBountyUrl,
   type NativeBountyAccount,
   type NativeBountyStatus,
 } from "../services/native-bounty.service.js";
@@ -60,9 +61,7 @@ Read-only. Supports active/open/judging/winner-announced/paid/abandoned/cancelle
           limit,
           offset,
         });
-        const response = await fetch(url);
-        if (!response.ok) throw new Error(`AIBTC bounty API ${response.status}: ${await response.text()}`);
-        return createJsonResponse(await response.json());
+        return createJsonResponse(await fetchNativeBountyUrl(url));
       } catch (error) {
         return createErrorResponse(error);
       }
@@ -97,9 +96,7 @@ Read-only. Supports active/open/judging/winner-announced/paid/abandoned/cancelle
     async ({ id, limit, offset }) => {
       try {
         const url = buildNativeBountyUrl(`/api/bounties/${encodeURIComponent(id)}/submissions`, { limit, offset });
-        const response = await fetch(url);
-        if (!response.ok) throw new Error(`AIBTC bounty API ${response.status}: ${await response.text()}`);
-        return createJsonResponse(await response.json());
+        return createJsonResponse(await fetchNativeBountyUrl(url));
       } catch (error) {
         return createErrorResponse(error);
       }
@@ -142,9 +139,7 @@ Read-only. Supports active/open/judging/winner-announced/paid/abandoned/cancelle
           submitter = account.btcAddress;
         }
         const url = buildNativeBountyUrl("/api/bounties", { submitter, limit: limit ?? 50, offset: offset ?? 0 });
-        const response = await fetch(url);
-        if (!response.ok) throw new Error(`AIBTC bounty API ${response.status}: ${await response.text()}`);
-        return createJsonResponse(await response.json());
+        return createJsonResponse(await fetchNativeBountyUrl(url));
       } catch (error) {
         return createErrorResponse(error);
       }
@@ -169,9 +164,7 @@ Read-only. Supports active/open/judging/winner-announced/paid/abandoned/cancelle
           poster = account.btcAddress;
         }
         const url = buildNativeBountyUrl("/api/bounties", { poster, limit: limit ?? 50, offset: offset ?? 0 });
-        const response = await fetch(url);
-        if (!response.ok) throw new Error(`AIBTC bounty API ${response.status}: ${await response.text()}`);
-        return createJsonResponse(await response.json());
+        return createJsonResponse(await fetchNativeBountyUrl(url));
       } catch (error) {
         return createErrorResponse(error);
       }

--- a/src/tools/native-bounty.tools.ts
+++ b/src/tools/native-bounty.tools.ts
@@ -1,0 +1,317 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getAccount } from "../services/x402.service.js";
+import { createJsonResponse, createErrorResponse } from "../utils/index.js";
+import {
+  buildNativeBountyMessage,
+  buildNativeBountyUrl,
+  buildNativeBountySignedFields,
+  fetchNativeBountyJson,
+  type NativeBountyAccount,
+  type NativeBountyStatus,
+} from "../services/native-bounty.service.js";
+
+function assertNativeBountyAccount(account: unknown): NativeBountyAccount {
+  const candidate = account as Partial<NativeBountyAccount>;
+  if (!candidate.btcAddress || !candidate.btcPrivateKey || !candidate.btcPublicKey) {
+    throw new Error("Bitcoin keys not available. Unlock a wallet with BTC key derivation to use signed native bounty tools.");
+  }
+  return candidate as NativeBountyAccount;
+}
+
+function tagsToArray(tags?: string): string[] {
+  if (!tags) return [];
+  return tags.split(",").map((tag) => tag.trim()).filter(Boolean);
+}
+
+async function signedNativePost(path: string, message: string, signedAt: string, payload: Record<string, unknown>) {
+  const account = assertNativeBountyAccount(await getAccount());
+  const signedFields = buildNativeBountySignedFields(message, signedAt, account);
+  return fetchNativeBountyJson(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...payload, ...signedFields }),
+  });
+}
+
+export function registerNativeBountyTools(server: McpServer): void {
+  server.registerTool(
+    "bounty_list_native",
+    {
+      description: `List native AIBTC bounties from https://aibtc.com/api/bounties.
+
+Read-only. Supports active/open/judging/winner-announced/paid/abandoned/cancelled status filters plus poster, submitter, tag, limit, and offset.`,
+      inputSchema: {
+        status: z.enum(["open", "judging", "winner-announced", "paid", "abandoned", "cancelled", "active"]).optional(),
+        poster: z.string().optional().describe("Poster BTC address"),
+        submitter: z.string().optional().describe("Submitter BTC address"),
+        tag: z.string().optional().describe("Tag filter"),
+        limit: z.number().int().min(1).max(100).optional(),
+        offset: z.number().int().min(0).optional(),
+      },
+    },
+    async ({ status, poster, submitter, tag, limit, offset }) => {
+      try {
+        const url = buildNativeBountyUrl("/api/bounties", {
+          status: status as NativeBountyStatus | undefined,
+          poster,
+          submitter,
+          tag,
+          limit,
+          offset,
+        });
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`AIBTC bounty API ${response.status}: ${await response.text()}`);
+        return createJsonResponse(await response.json());
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_get_native",
+    {
+      description: "Get native AIBTC bounty detail by ID. Read-only.",
+      inputSchema: { id: z.string().min(1).describe("Native bounty ID") },
+    },
+    async ({ id }) => {
+      try {
+        return createJsonResponse(await fetchNativeBountyJson(`/api/bounties/${encodeURIComponent(id)}`));
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_submissions_native",
+    {
+      description: "List submissions for a native AIBTC bounty. Read-only.",
+      inputSchema: {
+        id: z.string().min(1).describe("Native bounty ID"),
+        limit: z.number().int().min(1).max(100).optional(),
+        offset: z.number().int().min(0).optional(),
+      },
+    },
+    async ({ id, limit, offset }) => {
+      try {
+        const url = buildNativeBountyUrl(`/api/bounties/${encodeURIComponent(id)}/submissions`, { limit, offset });
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`AIBTC bounty API ${response.status}: ${await response.text()}`);
+        return createJsonResponse(await response.json());
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_submission_native",
+    {
+      description: "Get a single native AIBTC bounty submission permalink. Read-only.",
+      inputSchema: {
+        id: z.string().min(1).describe("Native bounty ID"),
+        submission_id: z.string().min(1).describe("Submission ID"),
+      },
+    },
+    async ({ id, submission_id }) => {
+      try {
+        return createJsonResponse(await fetchNativeBountyJson(`/api/bounties/${encodeURIComponent(id)}/submissions/${encodeURIComponent(submission_id)}`));
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_my_submissions",
+    {
+      description: "List native AIBTC bounties the current or provided BTC address submitted to, with up to 50 results by default. Read-only convenience view.",
+      inputSchema: {
+        btc_address: z.string().optional().describe("BTC address. Omit to use the unlocked wallet's BTC address."),
+        limit: z.number().int().min(1).max(100).optional(),
+        offset: z.number().int().min(0).optional(),
+      },
+    },
+    async ({ btc_address, limit, offset }) => {
+      try {
+        let submitter = btc_address;
+        if (!submitter) {
+          const account = assertNativeBountyAccount(await getAccount());
+          submitter = account.btcAddress;
+        }
+        const url = buildNativeBountyUrl("/api/bounties", { submitter, limit: limit ?? 50, offset: offset ?? 0 });
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`AIBTC bounty API ${response.status}: ${await response.text()}`);
+        return createJsonResponse(await response.json());
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_my_posted",
+    {
+      description: "List native AIBTC bounties the current or provided BTC address posted, with up to 50 results by default. Read-only convenience view.",
+      inputSchema: {
+        btc_address: z.string().optional().describe("BTC address. Omit to use the unlocked wallet's BTC address."),
+        limit: z.number().int().min(1).max(100).optional(),
+        offset: z.number().int().min(0).optional(),
+      },
+    },
+    async ({ btc_address, limit, offset }) => {
+      try {
+        let poster = btc_address;
+        if (!poster) {
+          const account = assertNativeBountyAccount(await getAccount());
+          poster = account.btcAddress;
+        }
+        const url = buildNativeBountyUrl("/api/bounties", { poster, limit: limit ?? 50, offset: offset ?? 0 });
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`AIBTC bounty API ${response.status}: ${await response.text()}`);
+        return createJsonResponse(await response.json());
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_create_native",
+    {
+      description: "Create a native AIBTC bounty. Signed POST; requires an unlocked Genesis-level AIBTC wallet.",
+      inputSchema: {
+        title: z.string().min(1),
+        description: z.string().min(1),
+        reward_sats: z.number().int().positive(),
+        expires_at: z.string().min(1).describe("ISO 8601 expiry timestamp"),
+        tags: z.string().optional().describe("Comma-separated tags"),
+      },
+    },
+    async ({ title, description, reward_sats, expires_at, tags }) => {
+      try {
+        const account = assertNativeBountyAccount(await getAccount());
+        const tagList = tagsToArray(tags);
+        const signedAt = new Date().toISOString();
+        const message = buildNativeBountyMessage("create", {
+          posterBtc: account.btcAddress,
+          title,
+          description,
+          rewardSats: reward_sats,
+          expiresAt: expires_at,
+          tags: tagList,
+          signedAt,
+        });
+        const signedFields = buildNativeBountySignedFields(message, signedAt, account);
+        const data = await fetchNativeBountyJson("/api/bounties", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            posterBtcAddress: account.btcAddress,
+            title,
+            description,
+            rewardSats: reward_sats,
+            expiresAt: expires_at,
+            tags: tagList,
+            ...signedFields,
+          }),
+        });
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_submit_native",
+    {
+      description: "Submit work to a native AIBTC bounty. Signed POST; requires an unlocked Registered-level AIBTC wallet.",
+      inputSchema: {
+        bounty_id: z.string().min(1),
+        message: z.string().min(1),
+        content_url: z.string().optional(),
+      },
+    },
+    async ({ bounty_id, message, content_url }) => {
+      try {
+        const account = assertNativeBountyAccount(await getAccount());
+        const signedAt = new Date().toISOString();
+        const signedMessage = buildNativeBountyMessage("submit", {
+          bountyId: bounty_id,
+          submitterBtc: account.btcAddress,
+          message,
+          contentUrl: content_url,
+          signedAt,
+        });
+        const signedFields = buildNativeBountySignedFields(signedMessage, signedAt, account);
+        const data = await fetchNativeBountyJson(`/api/bounties/${encodeURIComponent(bounty_id)}/submit`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            submitterBtcAddress: account.btcAddress,
+            message,
+            contentUrl: content_url ?? "",
+            ...signedFields,
+          }),
+        });
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_accept_native",
+    {
+      description: "Accept a native AIBTC bounty submission. Signed POST; poster only.",
+      inputSchema: { bounty_id: z.string().min(1), submission_id: z.string().min(1) },
+    },
+    async ({ bounty_id, submission_id }) => {
+      try {
+        const signedAt = new Date().toISOString();
+        const message = buildNativeBountyMessage("accept", { bountyId: bounty_id, submissionId: submission_id, signedAt });
+        return createJsonResponse(await signedNativePost(`/api/bounties/${encodeURIComponent(bounty_id)}/accept`, message, signedAt, { submissionId: submission_id }));
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_paid_native",
+    {
+      description: "Mark a native AIBTC bounty paid with a confirmed sBTC txid. Signed POST; poster only.",
+      inputSchema: { bounty_id: z.string().min(1), txid: z.string().min(1) },
+    },
+    async ({ bounty_id, txid }) => {
+      try {
+        const signedAt = new Date().toISOString();
+        const message = buildNativeBountyMessage("paid", { bountyId: bounty_id, txid, signedAt });
+        return createJsonResponse(await signedNativePost(`/api/bounties/${encodeURIComponent(bounty_id)}/paid`, message, signedAt, { txid }));
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_cancel_native",
+    {
+      description: "Cancel a native AIBTC bounty before acceptance. Signed POST; poster only.",
+      inputSchema: { bounty_id: z.string().min(1) },
+    },
+    async ({ bounty_id }) => {
+      try {
+        const signedAt = new Date().toISOString();
+        const message = buildNativeBountyMessage("cancel", { bountyId: bounty_id, signedAt });
+        return createJsonResponse(await signedNativePost(`/api/bounties/${encodeURIComponent(bounty_id)}/cancel`, message, signedAt, {}));
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+}

--- a/src/tools/skill-mappings.ts
+++ b/src/tools/skill-mappings.ts
@@ -320,7 +320,7 @@ export const TOOL_SKILL_MAP: Record<string, string> = {
   souldinals_load_soul: "souldinals",
   souldinals_display_soul: "souldinals",
 
-  // bounty-scanner skill — sBTC bounty board (bounty.drx4.xyz)
+  // bounty-scanner skill — sBTC bounty board (legacy bounty.drx4.xyz + native aibtc.com)
   bounty_list: "bounty-scanner",
   bounty_get: "bounty-scanner",
   bounty_match: "bounty-scanner",
@@ -329,6 +329,17 @@ export const TOOL_SKILL_MAP: Record<string, string> = {
   bounty_my_claims: "bounty-scanner",
   bounty_stats: "bounty-scanner",
   bounty_create: "bounty-scanner",
+  bounty_list_native: "bounty-scanner",
+  bounty_get_native: "bounty-scanner",
+  bounty_submissions_native: "bounty-scanner",
+  bounty_submission_native: "bounty-scanner",
+  bounty_my_posted: "bounty-scanner",
+  bounty_my_submissions: "bounty-scanner",
+  bounty_create_native: "bounty-scanner",
+  bounty_submit_native: "bounty-scanner",
+  bounty_accept_native: "bounty-scanner",
+  bounty_paid_native: "bounty-scanner",
+  bounty_cancel_native: "bounty-scanner",
 
   // runes skill — Bitcoin-native fungible token protocol
   runes_list_etchings: "runes",

--- a/tests/services/native-bounty.service.test.ts
+++ b/tests/services/native-bounty.service.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
 import {
   AIBTC_BOUNTY_BASE,
   buildNativeBountyMessage,
+  buildNativeBountySignedFields,
   buildNativeBountyUrl,
   normalizeNativeBountyListParams,
 } from "../../src/services/native-bounty.service.js";
@@ -80,20 +82,21 @@ describe("native bounty service", () => {
   });
 
   it("creates signed payload fields without leaking private key material", () => {
+    const privateKey = new Uint8Array(32).fill(1);
     const account = {
       btcAddress: "bc1poster",
-      btcPrivateKey: new Uint8Array(32).fill(1),
-      btcPublicKey: new Uint8Array([
-        2, 3, 9, 93, 204, 25, 207, 220, 147, 57, 22, 83, 101, 48, 31, 163, 36,
-        195, 21, 170, 45, 17, 123, 242, 204, 120, 22, 44, 178, 43, 129, 131, 209,
-      ]),
+      btcPrivateKey: privateKey,
+      btcPublicKey: secp256k1.getPublicKey(privateKey, true),
     };
-    const signed = {
-      signedAt: "2026-05-17T14:00:00.000Z",
-      signature: "<signature>",
-    };
+    const signed = buildNativeBountySignedFields(
+      "AIBTC Bounty Cancel | bnty1 | 2026-05-17T14:00:00.000Z",
+      "2026-05-17T14:00:00.000Z",
+      account
+    );
 
     expect(Object.keys(signed)).toEqual(["signedAt", "signature"]);
+    expect(signed.signedAt).toBe("2026-05-17T14:00:00.000Z");
+    expect(signed.signature.length).toBeGreaterThan(0);
     expect(JSON.stringify(signed)).not.toContain("private");
     expect(JSON.stringify(signed)).not.toContain("btcPrivateKey");
     expect(JSON.stringify(account)).toContain("btcPrivateKey");

--- a/tests/services/native-bounty.service.test.ts
+++ b/tests/services/native-bounty.service.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  AIBTC_BOUNTY_BASE,
+  buildNativeBountyMessage,
+  buildNativeBountyUrl,
+  normalizeNativeBountyListParams,
+} from "../../src/services/native-bounty.service.js";
+
+describe("native bounty service", () => {
+  it("builds native list URLs with supported filters", () => {
+    const url = buildNativeBountyUrl("/api/bounties", {
+      status: "paid",
+      poster: "bc1poster",
+      submitter: "bc1submitter",
+      tag: "mcp",
+      limit: 25,
+      offset: 50,
+    });
+
+    expect(url.toString()).toBe(
+      `${AIBTC_BOUNTY_BASE}/api/bounties?status=paid&poster=bc1poster&submitter=bc1submitter&tag=mcp&limit=25&offset=50`
+    );
+  });
+
+  it("normalizes active list defaults without sending unsupported fields", () => {
+    const params = normalizeNativeBountyListParams({ limit: 150, offset: -3 });
+
+    expect(params).toEqual({ limit: "100", offset: "0" });
+  });
+
+  it("builds exact signed message formats for write actions", () => {
+    expect(
+      buildNativeBountyMessage("create", {
+        posterBtc: "bc1poster",
+        title: "Build native bounty tools",
+        description: "Replace old bounty proxy tools",
+        rewardSats: 1000,
+        expiresAt: "2026-05-23T18:00:00.000Z",
+        tags: ["mcp", "bounty"],
+        signedAt: "2026-05-17T14:00:00.000Z",
+      })
+    ).toBe(
+      "AIBTC Bounty Create | bc1poster | Build native bounty tools | Replace old bounty proxy tools | 1000 | 2026-05-23T18:00:00.000Z | mcp,bounty | 2026-05-17T14:00:00.000Z"
+    );
+
+    expect(
+      buildNativeBountyMessage("submit", {
+        bountyId: "bnty1",
+        submitterBtc: "bc1submitter",
+        message: "Implemented in PR #123",
+        contentUrl: "https://github.com/aibtcdev/aibtc-mcp-server/pull/123",
+        signedAt: "2026-05-17T14:00:00.000Z",
+      })
+    ).toBe(
+      "AIBTC Bounty Submit | bnty1 | bc1submitter | Implemented in PR #123 | https://github.com/aibtcdev/aibtc-mcp-server/pull/123 | 2026-05-17T14:00:00.000Z"
+    );
+
+    expect(
+      buildNativeBountyMessage("accept", {
+        bountyId: "bnty1",
+        submissionId: "sub1",
+        signedAt: "2026-05-17T14:00:00.000Z",
+      })
+    ).toBe("AIBTC Bounty Accept | bnty1 | sub1 | 2026-05-17T14:00:00.000Z");
+
+    expect(
+      buildNativeBountyMessage("paid", {
+        bountyId: "bnty1",
+        txid: "0xabc",
+        signedAt: "2026-05-17T14:00:00.000Z",
+      })
+    ).toBe("AIBTC Bounty Paid | bnty1 | 0xabc | 2026-05-17T14:00:00.000Z");
+
+    expect(
+      buildNativeBountyMessage("cancel", {
+        bountyId: "bnty1",
+        signedAt: "2026-05-17T14:00:00.000Z",
+      })
+    ).toBe("AIBTC Bounty Cancel | bnty1 | 2026-05-17T14:00:00.000Z");
+  });
+
+  it("creates signed payload fields without leaking private key material", () => {
+    const account = {
+      btcAddress: "bc1poster",
+      btcPrivateKey: new Uint8Array(32).fill(1),
+      btcPublicKey: new Uint8Array([
+        2, 3, 9, 93, 204, 25, 207, 220, 147, 57, 22, 83, 101, 48, 31, 163, 36,
+        195, 21, 170, 45, 17, 123, 242, 204, 120, 22, 44, 178, 43, 129, 131, 209,
+      ]),
+    };
+    const signed = {
+      signedAt: "2026-05-17T14:00:00.000Z",
+      signature: "<signature>",
+    };
+
+    expect(Object.keys(signed)).toEqual(["signedAt", "signature"]);
+    expect(JSON.stringify(signed)).not.toContain("private");
+    expect(JSON.stringify(signed)).not.toContain("btcPrivateKey");
+    expect(JSON.stringify(account)).toContain("btcPrivateKey");
+  });
+});

--- a/tests/tools/native-bounty-registration.test.ts
+++ b/tests/tools/native-bounty-registration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerAllTools } from "../../src/tools/index.js";
+
+interface ToolRegistration {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+}
+
+function createTrackingServer() {
+  const tools = new Map<string, ToolRegistration>();
+  const server = {
+    registerTool: vi.fn(
+      (name: string, config: { description: string; inputSchema: unknown }, _handler: unknown) => {
+        tools.set(name, { name, description: config.description, inputSchema: config.inputSchema });
+      }
+    ),
+  };
+
+  return { server, tools };
+}
+
+describe("native bounty tool registration", () => {
+  it("registers native AIBTC bounty read tools", () => {
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerAllTools(server as any);
+
+    for (const name of [
+      "bounty_list_native",
+      "bounty_get_native",
+      "bounty_submissions_native",
+      "bounty_submission_native",
+      "bounty_my_posted",
+      "bounty_my_submissions",
+    ]) {
+      expect(tools.has(name), `expected '${name}' to be registered`).toBe(true);
+    }
+  });
+
+  it("registers native AIBTC bounty signed write tools", () => {
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerAllTools(server as any);
+
+    for (const name of [
+      "bounty_create_native",
+      "bounty_submit_native",
+      "bounty_accept_native",
+      "bounty_paid_native",
+      "bounty_cancel_native",
+    ]) {
+      expect(tools.has(name), `expected '${name}' to be registered`).toBe(true);
+      expect(tools.get(name)?.description).toContain("AIBTC");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add native `aibtc.com/api/bounties` MCP tools for listing, detail/submission reads, poster/submission convenience views, and signed write actions.
- Keep existing `bounty.drx4.xyz` tools in place but mark their descriptions deprecated in favor of `bounty_*_native`.
- Add native bounty service helpers and registration/unit coverage.

Closes #524

## Test plan
- `npm test -- --run tests/services/native-bounty.service.test.ts tests/tools/native-bounty-registration.test.ts tests/tools/tool-registration.test.ts`
- `npm test`
- `npm run build`
- Checked live docs/API contract:
  - `https://aibtc.com/docs/bounties.txt`
  - `https://aibtc.com/api/openapi.json`
  - `https://aibtc.com/api/bounties/mp8c7kmu189ae01f53dd`
- Cross-checked `bounty_paid_native` signed-message whitespace against the live verifier/OpenAPI/source in `aibtcdev/landing-page`.

## Notes
- I did not run the full create → submit → accept → paid roundtrip because that requires an unlocked wallet and live sBTC payment. The tools are wired to the documented signed-message and JSON payload contract, with `bounty_paid_native` aligned to the live verifier/OpenAPI/source format.
