### PR TITLE
Add native aibtc bounty tools

### DIFF
--- a/src/tools/bounty-scanner.tools.ts
+++ b/src/tools/bounty-scanner.tools.ts
@@ -38,6 +38,7 @@ import { createJsonResponse, createErrorResponse } from "../utils/index.js";
 import { bip322Sign } from "../utils/bip322.js";
 
 const BOUNTY_BASE = "https://bounty.drx4.xyz/api";
+const NATIVE_BOUNTY_BASE = "https://aibtc.com/api/bounties";
 
 // ============================================================================
 // Auth header builder for authenticated endpoints
@@ -87,6 +88,61 @@ function buildBountyAuthHeaders(
   return headers;
 }
 
+
+// ============================================================================
+// Native aibtc.com bounty helpers
+// ============================================================================
+
+function buildNativeBountyAuthHeaders(message: string, account: AccountForAuth): Record<string, string> {
+  const btcNetwork = NETWORK === "testnet" ? BTC_TESTNET : BTC_MAINNET;
+  const scriptPubKey = p2wpkh(account.btcPublicKey, btcNetwork).script;
+  const signature = bip322Sign(message, account.btcPrivateKey, scriptPubKey);
+
+  const headers: Record<string, string> = {
+    "X-BTC-Address": account.btcAddress,
+    "X-Signature": signature,
+    "Content-Type": "application/json",
+  };
+
+  if (account.address) {
+    headers["X-STX-Address"] = account.address;
+  }
+
+  return headers;
+}
+
+async function readNativeBountyResponse(res: Response): Promise<unknown> {
+  const responseText = await res.text();
+  try {
+    return responseText ? JSON.parse(responseText) : {};
+  } catch {
+    return { raw: responseText };
+  }
+}
+
+async function postNativeBounty(path: string, payload: Record<string, unknown>, message: string, account: AccountForAuth): Promise<unknown> {
+  const res = await fetch(`${NATIVE_BOUNTY_BASE}${path}`, {
+    method: "POST",
+    headers: buildNativeBountyAuthHeaders(message, account),
+    body: JSON.stringify(payload),
+  });
+
+  const data = await readNativeBountyResponse(res);
+  if (!res.ok) {
+    throw new Error(`Native bounty request failed (${res.status}): ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+async function getCurrentBtcAddress(btcAddress?: string): Promise<string> {
+  if (btcAddress) return btcAddress;
+  const account = await getAccount();
+  if (!account.btcAddress) {
+    throw new Error("No BTC address found. Provide btc_address or unlock a wallet with BTC key derivation.");
+  }
+  return account.btcAddress;
+}
+
 // ============================================================================
 // Tool Registration
 // ============================================================================
@@ -98,7 +154,7 @@ export function registerBountyScannerTools(server: McpServer): void {
   server.registerTool(
     "bounty_list",
     {
-      description: `List bounties on the bounty.drx4.xyz sBTC bounty board.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_list_native for aibtc.com] List bounties on the bounty.drx4.xyz sBTC bounty board.
 
 Returns bounties matching the given filters in reverse chronological order.
 
@@ -180,7 +236,7 @@ No authentication required.`,
   server.registerTool(
     "bounty_get",
     {
-      description: `Get full details for a single bounty on bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_get_native for aibtc.com] Get full details for a single bounty on bounty.drx4.xyz.
 
 Returns the bounty description, reward amount, tags, status, all claims,
 submissions, payments, and available actions for the current agent.
@@ -272,13 +328,246 @@ No authentication required.`,
     }
   );
 
+
+
+  // --------------------------------------------------------------------------
+  // Native aibtc.com bounty tools
+  // --------------------------------------------------------------------------
+  server.registerTool(
+    "bounty_list_native",
+    {
+      description: `List native bounties from aibtc.com/api/bounties. Filters: status, poster, submitter, tag, limit, offset. Omit status to let the server return active non-terminal bounties.`,
+      inputSchema: {
+        status: z.string().optional().describe("Derived status filter, e.g. open, judging, winner-announced, paid, abandoned, cancelled"),
+        poster: z.string().optional().describe("Poster BTC address"),
+        submitter: z.string().optional().describe("Submitter BTC address"),
+        tag: z.string().optional().describe("Tag filter"),
+        limit: z.number().min(1).max(100).optional().describe("Max results"),
+        offset: z.number().min(0).optional().describe("Pagination offset"),
+      },
+    },
+    async ({ status, poster, submitter, tag, limit, offset }) => {
+      try {
+        const params = new URLSearchParams();
+        if (status) params.set("status", status);
+        if (poster) params.set("poster", poster);
+        if (submitter) params.set("submitter", submitter);
+        if (tag) params.set("tag", tag);
+        if (limit !== undefined) params.set("limit", String(limit));
+        if (offset !== undefined) params.set("offset", String(offset));
+        const res = await fetch(`${NATIVE_BOUNTY_BASE}${params.toString() ? `?${params}` : ""}`);
+        const data = await readNativeBountyResponse(res);
+        if (!res.ok) throw new Error(`Failed to list native bounties (${res.status}): ${JSON.stringify(data)}`);
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_get_native",
+    {
+      description: `Get a native aibtc.com bounty detail by bounty_id, including derived status, winner block, and payment hint when available.`,
+      inputSchema: { bounty_id: z.string().describe("Native bounty ID") },
+    },
+    async ({ bounty_id }) => {
+      try {
+        const res = await fetch(`${NATIVE_BOUNTY_BASE}/${encodeURIComponent(bounty_id)}`);
+        const data = await readNativeBountyResponse(res);
+        if (!res.ok) throw new Error(`Failed to fetch native bounty ${bounty_id} (${res.status}): ${JSON.stringify(data)}`);
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_submissions_native",
+    {
+      description: `List paginated submissions for a native aibtc.com bounty.`,
+      inputSchema: {
+        bounty_id: z.string().describe("Native bounty ID"),
+        limit: z.number().min(1).max(100).optional().describe("Max results"),
+        offset: z.number().min(0).optional().describe("Pagination offset"),
+      },
+    },
+    async ({ bounty_id, limit, offset }) => {
+      try {
+        const params = new URLSearchParams();
+        if (limit !== undefined) params.set("limit", String(limit));
+        if (offset !== undefined) params.set("offset", String(offset));
+        const res = await fetch(`${NATIVE_BOUNTY_BASE}/${encodeURIComponent(bounty_id)}/submissions${params.toString() ? `?${params}` : ""}`);
+        const data = await readNativeBountyResponse(res);
+        if (!res.ok) throw new Error(`Failed to fetch native bounty submissions (${res.status}): ${JSON.stringify(data)}`);
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_create_native",
+    {
+      description: `Create a native aibtc.com bounty. Requires unlocked wallet and Genesis L2+ on aibtc.com. Signs: AIBTC Bounty Create | {posterBtc} | {title} | {description} | {rewardSats} | {expiresAt} | {tagsCommaJoined} | {signedAt}`,
+      inputSchema: {
+        title: z.string().min(1).describe("Bounty title"),
+        description: z.string().min(1).describe("Bounty description"),
+        reward_sats: z.number().int().positive().describe("Reward amount in satoshis"),
+        expires_at: z.string().describe("ISO 8601 expiration time"),
+        tags: z.array(z.string()).optional().describe("Tags"),
+      },
+    },
+    async ({ title, description, reward_sats, expires_at, tags }) => {
+      try {
+        const account = await getAccount();
+        if (!account.btcAddress || !account.btcPrivateKey || !account.btcPublicKey) throw new Error("Bitcoin keys not available. Unlock a wallet with BTC key derivation.");
+        const signedAt = new Date().toISOString();
+        const tagsCommaJoined = (tags ?? []).join(",");
+        const message = `AIBTC Bounty Create | ${account.btcAddress} | ${title} | ${description} | ${reward_sats} | ${expires_at} | ${tagsCommaJoined} | ${signedAt}`;
+        const payload = { title, description, rewardSats: reward_sats, expiresAt: expires_at, tags: tags ?? [], signedAt };
+        const data = await postNativeBounty("", payload, message, account as AccountForAuth);
+        return createJsonResponse({ success: true, bounty: data, created_by: account.btcAddress });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_submit_native",
+    {
+      description: `Submit work to a native aibtc.com bounty. Requires unlocked wallet and Registered L1+ on aibtc.com. Signs: AIBTC Bounty Submit | {bountyId} | {submitterBtc} | {message} | {contentUrl} | {signedAt}`,
+      inputSchema: {
+        bounty_id: z.string().describe("Native bounty ID"),
+        message: z.string().min(1).describe("Submission message"),
+        content_url: z.string().optional().describe("Optional content URL / PR URL / artifact URL"),
+      },
+    },
+    async ({ bounty_id, message, content_url }) => {
+      try {
+        const account = await getAccount();
+        if (!account.btcAddress || !account.btcPrivateKey || !account.btcPublicKey) throw new Error("Bitcoin keys not available. Unlock a wallet with BTC key derivation.");
+        const signedAt = new Date().toISOString();
+        const url = content_url ?? "";
+        const signedMessage = `AIBTC Bounty Submit | ${bounty_id} | ${account.btcAddress} | ${message} | ${url} | ${signedAt}`;
+        const payload: Record<string, unknown> = { message, signedAt };
+        if (content_url) payload.contentUrl = content_url;
+        const data = await postNativeBounty(`/${encodeURIComponent(bounty_id)}/submit`, payload, signedMessage, account as AccountForAuth);
+        return createJsonResponse({ success: true, submission: data, submitted_by: account.btcAddress, bounty_id });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_accept_native",
+    {
+      description: `Accept a native bounty submission as winner. Poster only. Signs: AIBTC Bounty Accept | {bountyId} | {submissionId} | {signedAt}`,
+      inputSchema: { bounty_id: z.string(), submission_id: z.string() },
+    },
+    async ({ bounty_id, submission_id }) => {
+      try {
+        const account = await getAccount();
+        if (!account.btcAddress || !account.btcPrivateKey || !account.btcPublicKey) throw new Error("Bitcoin keys not available. Unlock a wallet with BTC key derivation.");
+        const signedAt = new Date().toISOString();
+        const message = `AIBTC Bounty Accept | ${bounty_id} | ${submission_id} | ${signedAt}`;
+        const data = await postNativeBounty(`/${encodeURIComponent(bounty_id)}/accept`, { submissionId: submission_id, signedAt }, message, account as AccountForAuth);
+        return createJsonResponse({ success: true, result: data, bounty_id, submission_id });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_paid_native",
+    {
+      description: `Prove native bounty payment with confirmed sBTC txid. Poster only. Signs: AIBTC Bounty Paid | {bountyId} | {txid} | {signedAt}`,
+      inputSchema: { bounty_id: z.string(), txid: z.string() },
+    },
+    async ({ bounty_id, txid }) => {
+      try {
+        const account = await getAccount();
+        if (!account.btcAddress || !account.btcPrivateKey || !account.btcPublicKey) throw new Error("Bitcoin keys not available. Unlock a wallet with BTC key derivation.");
+        const signedAt = new Date().toISOString();
+        const message = `AIBTC Bounty Paid | ${bounty_id} | ${txid} | ${signedAt}`;
+        const data = await postNativeBounty(`/${encodeURIComponent(bounty_id)}/paid`, { txid, signedAt }, message, account as AccountForAuth);
+        return createJsonResponse({ success: true, result: data, bounty_id, txid });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_cancel_native",
+    {
+      description: `Cancel a native bounty while open or judging. Poster only. Signs: AIBTC Bounty Cancel | {bountyId} | {signedAt}`,
+      inputSchema: { bounty_id: z.string() },
+    },
+    async ({ bounty_id }) => {
+      try {
+        const account = await getAccount();
+        if (!account.btcAddress || !account.btcPrivateKey || !account.btcPublicKey) throw new Error("Bitcoin keys not available. Unlock a wallet with BTC key derivation.");
+        const signedAt = new Date().toISOString();
+        const message = `AIBTC Bounty Cancel | ${bounty_id} | ${signedAt}`;
+        const data = await postNativeBounty(`/${encodeURIComponent(bounty_id)}/cancel`, { signedAt }, message, account as AccountForAuth);
+        return createJsonResponse({ success: true, result: data, bounty_id });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_my_posted",
+    {
+      description: `One-call view of native aibtc.com bounties posted by a BTC address. Defaults to current wallet BTC address.`,
+      inputSchema: { btc_address: z.string().optional().describe("BTC address; omit to use current wallet" ) },
+    },
+    async ({ btc_address }) => {
+      try {
+        const address = await getCurrentBtcAddress(btc_address);
+        const res = await fetch(`${NATIVE_BOUNTY_BASE}?poster=${encodeURIComponent(address)}&limit=50`);
+        const data = await readNativeBountyResponse(res);
+        if (!res.ok) throw new Error(`Failed to fetch posted native bounties (${res.status}): ${JSON.stringify(data)}`);
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "bounty_my_submissions",
+    {
+      description: `One-call view of native aibtc.com bounties submitted to by a BTC address. Defaults to current wallet BTC address.`,
+      inputSchema: { btc_address: z.string().optional().describe("BTC address; omit to use current wallet" ) },
+    },
+    async ({ btc_address }) => {
+      try {
+        const address = await getCurrentBtcAddress(btc_address);
+        const res = await fetch(`${NATIVE_BOUNTY_BASE}?submitter=${encodeURIComponent(address)}&limit=50`);
+        const data = await readNativeBountyResponse(res);
+        if (!res.ok) throw new Error(`Failed to fetch submitted native bounties (${res.status}): ${JSON.stringify(data)}`);
+        return createJsonResponse(data);
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
   // --------------------------------------------------------------------------
   // bounty_create — Create a new bounty (requires bc1q wallet, BIP-322 auth)
   // --------------------------------------------------------------------------
   server.registerTool(
     "bounty_create",
     {
-      description: `Create a new bounty on bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_create_native for aibtc.com] Create a new bounty on bounty.drx4.xyz.
 
 Posts a new bounty to the sBTC bounty board. Requires an unlocked wallet with
 BTC keys and AIBTC level >= 1. The request is authenticated via BIP-322 signing.
@@ -377,7 +666,7 @@ Fields:
   server.registerTool(
     "bounty_claim",
     {
-      description: `Claim a bounty on bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, native bounties use bounty_submit_native instead] Claim a bounty on bounty.drx4.xyz.
 
 Submits a claim for an open bounty. Requires an unlocked wallet with BTC keys.
 The request is authenticated via BIP-322 signing.
@@ -458,7 +747,7 @@ Fields:
   server.registerTool(
     "bounty_status",
     {
-      description: `Check the current status of a bounty on bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz, use bounty_get_native for aibtc.com] Check the current status of a bounty on bounty.drx4.xyz.
 
 Returns the bounty's current status in the workflow, along with any claims
 and submission details. The status flow is:
@@ -555,7 +844,7 @@ No authentication required.`,
   server.registerTool(
     "bounty_stats",
     {
-      description: `Get aggregate platform statistics from bounty.drx4.xyz.
+      description: `[DEPRECATED — targets bounty.drx4.xyz] Get aggregate platform statistics from bounty.drx4.xyz.
 
 Returns totals for bounties, agents, claims, submissions, and sBTC paid out.
 


### PR DESCRIPTION
Implements native aibtc.com bounty read/write tools alongside deprecated drx4 tools.\n\nAdded:\n- bounty_list_native\n- bounty_get_native\n- bounty_submissions_native\n- bounty_create_native\n- bounty_submit_native\n- bounty_accept_native\n- bounty_paid_native\n- bounty_cancel_native\n- bounty_my_posted\n- bounty_my_submissions\n\nAlso marks old drx4 descriptions as deprecated.\n\nVerification: npm install --no-audit --no-fund && npm run build\n\nCloses #524