### PR TITLE
fix(send_inbox_message): truthful response copy when payment is staged (#540 fix 1/4)

### DIFF
--- a/src/tools/inbox.tools.ts
+++ b/src/tools/inbox.tools.ts
@@ -558,9 +558,12 @@ export function registerInboxTools(server: McpServer): void {
               canonicalHints.checkStatusUrl ??
               (resolvedPaymentId ? getInboxPaymentStatusUrl(resolvedPaymentId) : undefined);
 
+            // Only say "delivered" when we have a chain txid — otherwise the payment is staged at the relay (#540).
             return createJsonResponse({
               success: true,
-              message: "Message delivered",
+              message: txid
+                ? "Message delivered"
+                : "Payment queued — delivery pending broadcast. Poll checkStatusUrl until status='confirmed' to verify delivery.",
               recipient: {
                 btcAddress: recipientBtcAddress,
                 stxAddress: recipientStxAddress,


### PR DESCRIPTION
## Summary

Smallest of the 4 fixes proposed in #540 — the misleading **\"Message delivered\"** copy.

**Before:** every successful x402 send returned \`message: \"Message delivered\"\` regardless of whether the underlying sBTC transfer had reached the chain. With a paymentId but no \`txid\`, the message is queued at the relay pending broadcast — but the caller-facing copy claimed delivery.

**Symptom (from my session today, captured in #540):** a 4-send burst all returned \`success: true\` + \`\"Message delivered\"\` to the agent, but none reached recipients (all 4 paymentIds remain held in the relay at t+2h+, 400 sats locked). The agent's downstream experiment treated \"0 inbox replies\" as a true signal when in fact the blast never landed.

**After:** the \`message\` field is now conditional on \`txid\`:
- Has \`txid\` → \`\"Message delivered\"\` (truly broadcast)
- No \`txid\` → \`\"Payment queued — delivery pending broadcast. Poll checkStatusUrl until status='confirmed' to verify delivery.\"\`

The \`payment.status\` field on the same response already correctly reports \`queued\` vs \`confirmed\` — this PR just aligns the top-level \`message\` string with that truth.

## Diff size

+4 / -1 lines in \`src/tools/inbox.tools.ts\`. One-line comment cross-references #540 for context.

## Test plan

- [x] No existing tests assert the literal \`\"Message delivered\"\` string (grepped via \`xargs grep -l 'Message delivered' tests/\`).
- [x] The conditional uses the existing \`txid\` variable already in scope (same one used by \`payment.status\` ternary at line 579 / 582 post-patch).
- [ ] CI typecheck / lint / build to confirm (couldn't run locally; deps not installed in my work env).

## Scope

Fix 1 of 4 from #540. Out of scope here:
- Fix 2 (pre-burst nonce guard in MCP server) — happy to draft as separate PR if useful, design needs operator input on whether to warn-or-refuse.
- Fix 3 (relay-side RBF / fill-gap recovery) — relay-domain.
- Fix 4 (hold-expiry honor-or-remove) — relay-domain.

## Why this matters beyond my session

Any agent doing distribution blasts via \`send_inbox_message\` will hit this. The current copy gives them false confidence that a payment-queued response equals a delivered message. The downstream cost of believing that lie is real: missed reply windows, misread experiments, wasted retries against the same recipients.

Closes #540 fix 1 of 4.