### PR TITLE
docs(inbox): recommend non-sponsored tool; flag sponsored as unstable

### DIFF
--- a/src/tools/inbox-x402.tools.ts
+++ b/src/tools/inbox-x402.tools.ts
@@ -107,7 +107,8 @@ export function registerInboxX402Tools(server: McpServer): void {
     "send_inbox_message_direct",
     {
       description:
-        "Send a paid x402 message to another agent's inbox on aibtc.com using a DIRECT (non-sponsored) payment.\n\n" +
+        "Send a paid x402 message to another agent's inbox on aibtc.com using a DIRECT (non-sponsored) payment. " +
+        "Recommended over send_inbox_message — sponsored (relay) transactions are currently unstable.\n\n" +
         "Unlike send_inbox_message (which uses a sponsored relay so you pay no STX gas), this tool signs a standard sBTC " +
         "transfer with the x402-stacks client interceptor — you pay BOTH the sBTC message cost AND your own STX gas fee. " +
         "No relay sits in the middle of the payment; the inbox settles the signed transaction via the x402 facilitator.\n\n" +

--- a/src/tools/inbox.tools.ts
+++ b/src/tools/inbox.tools.ts
@@ -278,6 +278,10 @@ export function registerInboxTools(server: McpServer): void {
     {
       description:
         "Send a paid x402 message to another agent's inbox on aibtc.com.\n\n" +
+        "⚠️ Sponsored (relay) transactions are currently unstable — prefer send_inbox_message_direct " +
+        "(non-sponsored x402), which signs a standard sBTC transfer and pays its own STX gas with no relay " +
+        "in the middle. This sponsored tool still works (sBTC-only cost, no STX gas) and remains available " +
+        "if you have no STX or specifically want relay-sponsored gas.\n\n" +
         "Uses sponsored transactions so the sender only pays the sBTC message cost — no STX gas fees.\n\n" +
         "This tool handles the full 5-step x402 payment flow:\n" +
         "1. POST to inbox → receive 402 payment challenge\n" +


### PR DESCRIPTION
Adds guidance to the inbox tool descriptions:

- `send_inbox_message` (sponsored): warning that relay/sponsored txs are currently unstable; recommends `send_inbox_message_direct`. Still usable for sBTC-only / no-STX cases.
- `send_inbox_message_direct` (non-sponsored): marked as recommended.

Description text only — no behavior change. Both tools remain functional.
