### PR TITLE
feat: add --install flags for Cursor, Windsurf, Gemini, Codex, VS Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,21 +140,23 @@ Managed wallets are stored encrypted in `~/.aibtc/`:
         └── keystore.json  # Encrypted mnemonic (AES-256-GCM)
 ```
 
-## Adding to Claude Code or Claude Desktop
+## Adding to an MCP Client
 
-**Claude Code (terminal):**
+This is a standard stdio MCP server, so it works with any MCP-compatible client. The `--install` helper writes the right config for a target; Claude Code is the default, others are selected with a flag. The install registry lives in `src/index.ts` (`INSTALL_TARGETS`).
+
 ```bash
-npx @aibtc/mcp-server@latest --install
+npx @aibtc/mcp-server@latest --install              # Claude Code (default)
+npx @aibtc/mcp-server@latest --install --desktop    # Claude Desktop (OS-detected path)
+npx @aibtc/mcp-server@latest --install --cursor     # Cursor
+npx @aibtc/mcp-server@latest --install --windsurf   # Windsurf
+npx @aibtc/mcp-server@latest --install --gemini     # Gemini CLI
+npx @aibtc/mcp-server@latest --install --codex      # OpenAI Codex CLI (TOML)
+npx @aibtc/mcp-server@latest --install --vscode     # VS Code (./.vscode/mcp.json)
 ```
 
-**Claude Desktop (app):**
-```bash
-npx @aibtc/mcp-server@latest --install --desktop
-```
+Each installer merges into the existing config rather than overwriting it. Zed and Cline are manual-config only (their schemas/paths vary by version) — see README for snippets. The `@latest` tag ensures users always get the newest features.
 
-The `--desktop` flag auto-detects your OS and writes to the correct Claude Desktop config path. The `@latest` tag ensures users always get the newest features.
-
-**For testnet:** Add `--testnet` to either command, e.g. `npx @aibtc/mcp-server@latest --install --desktop --testnet`
+**For testnet:** Add `--testnet` to any install command, e.g. `npx @aibtc/mcp-server@latest --install --cursor --testnet`
 
 **Note:** `CLIENT_MNEMONIC` is optional. Users can either:
 1. **Managed wallets (recommended)**: Use `wallet_create` or `wallet_import` to generate/import wallets with password protection

--- a/README.md
+++ b/README.md
@@ -45,41 +45,46 @@ This detects your OS and writes to the correct Claude Desktop config file:
 
 Restart Claude Desktop after installing.
 
-### Testnet Mode
+### Other MCP Clients
 
-Add `--testnet` to either command:
+This is a standard stdio MCP server, so it works with **any** MCP-compatible client. Claude Code is the default `--install` target; select another client with a flag:
 
 ```bash
-# Claude Code on testnet
-npx @aibtc/mcp-server@latest --install --testnet
+npx @aibtc/mcp-server@latest --install --cursor     # Cursor
+npx @aibtc/mcp-server@latest --install --windsurf   # Windsurf
+npx @aibtc/mcp-server@latest --install --gemini     # Gemini CLI
+npx @aibtc/mcp-server@latest --install --codex      # OpenAI Codex CLI
+npx @aibtc/mcp-server@latest --install --vscode     # VS Code (writes ./.vscode/mcp.json)
+```
 
-# Claude Desktop on testnet
-npx @aibtc/mcp-server@latest --install --desktop --testnet
+| Flag | Client | Config written |
+|------|--------|----------------|
+| _(none)_ | Claude Code | `~/.claude.json` |
+| `--desktop` | Claude Desktop | `claude_desktop_config.json` (see path table above) |
+| `--cursor` | Cursor | `~/.cursor/mcp.json` |
+| `--windsurf` | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
+| `--gemini` | Gemini CLI | `~/.gemini/settings.json` |
+| `--codex` | OpenAI Codex CLI | `~/.codex/config.toml` |
+| `--vscode` | VS Code (Copilot agent) | `./.vscode/mcp.json` (project-scoped) |
+
+Each installer merges into the existing config — it won't clobber other servers or settings. Restart the client afterward.
+
+### Testnet Mode
+
+Add `--testnet` to any install command:
+
+```bash
+npx @aibtc/mcp-server@latest --install --testnet            # Claude Code, testnet
+npx @aibtc/mcp-server@latest --install --cursor --testnet   # Cursor, testnet
 ```
 
 > **Why npx?** Using `npx @aibtc/mcp-server@latest` ensures you always get the newest version automatically. Global installs (`npm install -g`) won't auto-update.
 
 ### Manual Configuration
 
-If you prefer to configure manually, add the following to your config file.
+If you prefer to configure manually, add the following to your client's config file. The `-y` flag stops npx from prompting for confirmation.
 
-**Claude Code** (`~/.claude.json`):
-
-```json
-{
-  "mcpServers": {
-    "aibtc": {
-      "command": "npx",
-      "args": ["@aibtc/mcp-server@latest"],
-      "env": {
-        "NETWORK": "mainnet"
-      }
-    }
-  }
-}
-```
-
-**Claude Desktop** (`claude_desktop_config.json` -- see path table above):
+**Claude Code / Claude Desktop / Cursor / Windsurf / Gemini CLI** — `mcpServers` JSON:
 
 ```json
 {
@@ -95,7 +100,50 @@ If you prefer to configure manually, add the following to your config file.
 }
 ```
 
-> **Note:** Claude Desktop requires the `-y` flag in args so npx doesn't prompt for confirmation.
+**VS Code** (`.vscode/mcp.json`) — uses a `servers` key and a typed entry:
+
+```json
+{
+  "servers": {
+    "aibtc": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@aibtc/mcp-server@latest"],
+      "env": { "NETWORK": "mainnet" }
+    }
+  }
+}
+```
+
+**OpenAI Codex CLI** (`~/.codex/config.toml`) — TOML, not JSON:
+
+```toml
+[mcp_servers.aibtc]
+command = "npx"
+args = ["-y", "@aibtc/mcp-server@latest"]
+
+[mcp_servers.aibtc.env]
+NETWORK = "mainnet"
+```
+
+**Zed** (`settings.json`) — uses a `context_servers` key:
+
+```json
+{
+  "context_servers": {
+    "aibtc": {
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "@aibtc/mcp-server@latest"],
+      "env": { "NETWORK": "mainnet" }
+    }
+  }
+}
+```
+
+**Cline / Roo Code** (VS Code extension) — add the same `mcpServers` JSON block above via the extension's MCP settings panel (the exact `cline_mcp_settings.json` path varies by OS and VS Code build).
+
+> Any other MCP client works too — point it at `npx -y @aibtc/mcp-server@latest` over stdio with `NETWORK` in the env.
 
 ## Giving Claude a Wallet
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -15,13 +15,24 @@ A skill for managing Bitcoin L1 wallets with optional Pillar smart wallet and St
 
 ## Install
 
-One-command installation:
+One-command installation (Claude Code is the default):
 
 ```bash
 npx @aibtc/mcp-server@latest --install
 ```
 
-For testnet:
+Other MCP clients are selected with a flag:
+
+```bash
+npx @aibtc/mcp-server@latest --install --cursor     # Cursor
+npx @aibtc/mcp-server@latest --install --codex      # OpenAI Codex CLI
+npx @aibtc/mcp-server@latest --install --gemini     # Gemini CLI
+npx @aibtc/mcp-server@latest --install --windsurf   # Windsurf
+npx @aibtc/mcp-server@latest --install --vscode     # VS Code
+npx @aibtc/mcp-server@latest --install --desktop    # Claude Desktop
+```
+
+For testnet, add `--testnet` to any command:
 
 ```bash
 npx @aibtc/mcp-server@latest --install --testnet

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,14 @@ const require = createRequire(import.meta.url);
 const packageJson = require("../package.json");
 
 // =============================================================================
-// AUTO-INSTALL FOR CLAUDE CODE AND CLAUDE DESKTOP
+// AUTO-INSTALL FOR MCP CLIENTS
+//
+// The server is a standard stdio MCP server, so it works with any MCP client.
+// `--install` writes the correct config for a target client. Claude Code is the
+// default; other clients are selected with a flag (e.g. --cursor, --codex).
 // =============================================================================
+
+const SERVER_NPM = "@aibtc/mcp-server@latest";
 
 function getClaudeDesktopConfigPath(): string {
   const platform = process.platform;
@@ -51,70 +57,156 @@ async function writeJsonConfig(filePath: string, config: Record<string, unknown>
   await fs.writeFile(filePath, JSON.stringify(config, null, 2));
 }
 
-async function installToClaudeCode(): Promise<void> {
-  const claudeConfigPath = path.join(os.homedir(), ".claude.json");
-  const network = process.argv.includes("--testnet") ? "testnet" : "mainnet";
-
-  console.log("🔧 Installing @aibtc/mcp-server to Claude Code...\n");
-
-  const config = await readJsonConfig(claudeConfigPath) as { mcpServers?: Record<string, unknown> };
-
-  if (!config.mcpServers) {
-    config.mcpServers = {};
-  }
-
-  config.mcpServers["aibtc"] = {
+// Standard MCP server entry shared by every JSON-based client config.
+function serverEntry(network: string): Record<string, unknown> {
+  return {
     command: "npx",
-    args: ["@aibtc/mcp-server@latest"],
-    env: {
-      NETWORK: network,
-    },
+    args: ["-y", SERVER_NPM],
+    env: { NETWORK: network },
   };
-
-  await writeJsonConfig(claudeConfigPath, config);
-
-  console.log("✅ Successfully installed!\n");
-  console.log(`   Config: ${claudeConfigPath}`);
-  console.log(`   Network: ${network}`);
-  console.log("\n📋 Next steps:");
-  console.log("   1. Restart Claude Code (close and reopen terminal)");
-  console.log("   2. Ask Claude: \"What's your wallet address?\"");
-  console.log("   3. Claude will guide you through wallet setup\n");
-
-  if (network === "testnet") {
-    console.log("💡 Tip: Get testnet STX at https://explorer.hiro.so/sandbox/faucet?chain=testnet\n");
-  }
 }
 
-async function installToClaudeDesktop(): Promise<void> {
-  const configPath = getClaudeDesktopConfigPath();
-  const network = process.argv.includes("--testnet") ? "testnet" : "mainnet";
-
-  console.log("🔧 Installing @aibtc/mcp-server to Claude Desktop...\n");
-
-  const config = await readJsonConfig(configPath) as { mcpServers?: Record<string, unknown> };
-
-  if (!config.mcpServers) {
-    config.mcpServers = {};
-  }
-
-  config.mcpServers["aibtc"] = {
-    command: "npx",
-    args: ["-y", "@aibtc/mcp-server@latest"],
-    env: {
-      NETWORK: network,
-    },
-  };
-
+// Most clients (Claude Code, Claude Desktop, Cursor, Windsurf, Gemini CLI) use
+// the same `{ "mcpServers": { "aibtc": {...} } }` JSON shape.
+async function writeMcpServersJson(configPath: string, network: string): Promise<void> {
+  const config = await readJsonConfig(configPath);
+  const servers = (config.mcpServers ??= {}) as Record<string, unknown>;
+  servers["aibtc"] = serverEntry(network);
   await writeJsonConfig(configPath, config);
+}
+
+// VS Code (.vscode/mcp.json) uses a `servers` key and a typed stdio entry.
+async function writeVsCodeJson(configPath: string, network: string): Promise<void> {
+  const config = await readJsonConfig(configPath);
+  const servers = (config.servers ??= {}) as Record<string, unknown>;
+  servers["aibtc"] = {
+    type: "stdio",
+    command: "npx",
+    args: ["-y", SERVER_NPM],
+    env: { NETWORK: network },
+  };
+  await writeJsonConfig(configPath, config);
+}
+
+// Codex uses TOML, not JSON. Rewrite only the `[mcp_servers.aibtc]` section so
+// the rest of the user's config.toml (including comments) is preserved.
+function stripCodexSection(content: string): string {
+  const out: string[] = [];
+  let skipping = false;
+  for (const line of content.split("\n")) {
+    const header = line.trim();
+    if (header.startsWith("[")) {
+      skipping = header === "[mcp_servers.aibtc]" || header.startsWith("[mcp_servers.aibtc.");
+    }
+    if (!skipping) out.push(line);
+  }
+  return out.join("\n");
+}
+
+async function writeCodexToml(configPath: string, network: string): Promise<void> {
+  let existing = "";
+  try {
+    existing = await fs.readFile(configPath, "utf8");
+  } catch {
+    existing = "";
+  }
+  const preserved = stripCodexSection(existing).replace(/\s+$/, "");
+  const block = [
+    "[mcp_servers.aibtc]",
+    'command = "npx"',
+    `args = ["-y", "${SERVER_NPM}"]`,
+    "",
+    "[mcp_servers.aibtc.env]",
+    `NETWORK = "${network}"`,
+  ].join("\n");
+  const content = (preserved ? `${preserved}\n\n` : "") + block + "\n";
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, content);
+}
+
+interface InstallTarget {
+  flag: string | null; // null = default target (Claude Code)
+  label: string;
+  configPath: () => string;
+  write: (configPath: string, network: string) => Promise<void>;
+  restart: string;
+}
+
+const INSTALL_TARGETS: InstallTarget[] = [
+  {
+    flag: "--desktop",
+    label: "Claude Desktop",
+    configPath: getClaudeDesktopConfigPath,
+    write: writeMcpServersJson,
+    restart: "Restart Claude Desktop (quit and reopen the app)",
+  },
+  {
+    flag: "--cursor",
+    label: "Cursor",
+    configPath: () => path.join(os.homedir(), ".cursor", "mcp.json"),
+    write: writeMcpServersJson,
+    restart: "Restart Cursor",
+  },
+  {
+    flag: "--windsurf",
+    label: "Windsurf",
+    configPath: () => path.join(os.homedir(), ".codeium", "windsurf", "mcp_config.json"),
+    write: writeMcpServersJson,
+    restart: "Restart Windsurf",
+  },
+  {
+    flag: "--gemini",
+    label: "Gemini CLI",
+    configPath: () => path.join(os.homedir(), ".gemini", "settings.json"),
+    write: writeMcpServersJson,
+    restart: "Restart the Gemini CLI",
+  },
+  {
+    flag: "--vscode",
+    label: "VS Code",
+    configPath: () => path.join(process.cwd(), ".vscode", "mcp.json"),
+    write: writeVsCodeJson,
+    restart: "Reload VS Code, then start the MCP server from the .vscode/mcp.json gutter",
+  },
+  {
+    flag: "--codex",
+    label: "Codex CLI",
+    configPath: () => path.join(os.homedir(), ".codex", "config.toml"),
+    write: writeCodexToml,
+    restart: "Restart the Codex CLI",
+  },
+  {
+    flag: null,
+    label: "Claude Code",
+    configPath: () => path.join(os.homedir(), ".claude.json"),
+    write: writeMcpServersJson,
+    restart: "Restart Claude Code (close and reopen terminal)",
+  },
+];
+
+function resolveInstallTarget(): InstallTarget {
+  const flagged = INSTALL_TARGETS.find((t) => t.flag && process.argv.includes(t.flag));
+  // Default to Claude Code when no client flag is present.
+  return flagged ?? INSTALL_TARGETS[INSTALL_TARGETS.length - 1];
+}
+
+async function runInstall(): Promise<void> {
+  const network = process.argv.includes("--testnet") ? "testnet" : "mainnet";
+  const target = resolveInstallTarget();
+  const configPath = target.configPath();
+
+  console.log(`🔧 Installing @aibtc/mcp-server to ${target.label}...\n`);
+
+  await target.write(configPath, network);
 
   console.log("✅ Successfully installed!\n");
-  console.log(`   Config: ${configPath}`);
+  console.log(`   Client:  ${target.label}`);
+  console.log(`   Config:  ${configPath}`);
   console.log(`   Network: ${network}`);
   console.log("\n📋 Next steps:");
-  console.log("   1. Restart Claude Desktop (quit and reopen the app)");
-  console.log("   2. Ask Claude: \"What's your wallet address?\"");
-  console.log("   3. Claude will guide you through wallet setup\n");
+  console.log(`   1. ${target.restart}`);
+  console.log("   2. Ask the agent: \"What's your wallet address?\"");
+  console.log("   3. The agent will guide you through wallet setup\n");
 
   if (network === "testnet") {
     console.log("💡 Tip: Get testnet STX at https://explorer.hiro.so/sandbox/faucet?chain=testnet\n");
@@ -150,9 +242,7 @@ if (process.argv[2] === "yield-hunter") {
 }
 // Check for --install flag
 else if (process.argv.includes("--install") || process.argv.includes("install")) {
-  const isDesktop = process.argv.includes("--desktop");
-  const installFn = isDesktop ? installToClaudeDesktop : installToClaudeCode;
-  installFn()
+  runInstall()
     .then(() => process.exit(0))
     .catch((error) => {
       console.error("❌ Installation failed:", redactSensitive(error.message));

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,9 +185,14 @@ const INSTALL_TARGETS: InstallTarget[] = [
 ];
 
 function resolveInstallTarget(): InstallTarget {
-  const flagged = INSTALL_TARGETS.find((t) => t.flag && process.argv.includes(t.flag));
-  // Default to Claude Code when no client flag is present.
-  return flagged ?? INSTALL_TARGETS[INSTALL_TARGETS.length - 1];
+  const matched = INSTALL_TARGETS.filter((t) => t.flag && process.argv.includes(t.flag));
+  if (matched.length > 1) {
+    console.warn(
+      `⚠️  Multiple client flags passed (${matched.map((t) => t.flag).join(", ")}); using ${matched[0].label}.`,
+    );
+  }
+  // Default to the entry explicitly marked as default (flag === null) — Claude Code.
+  return matched[0] ?? INSTALL_TARGETS.find((t) => t.flag === null)!;
 }
 
 async function runInstall(): Promise<void> {

--- a/src/tools/settings.tools.ts
+++ b/src/tools/settings.tools.ts
@@ -252,7 +252,7 @@ Example: http://localhost:3999`,
     {
       description: `Check the currently running MCP server version and compare with the latest published version on npm.
 Use this to detect if you're running a stale cached version (common with npx).
-If your version is outdated, clear the npx cache and reinstall: npx clear-npx-cache && npx @aibtc/mcp-server@latest --install`,
+If your version is outdated, clear the npx cache and restart your MCP client: npx clear-npx-cache (the client config already points at @latest, so the next launch pulls the newest version).`,
       inputSchema: {},
     },
     async () => {
@@ -295,7 +295,7 @@ If your version is outdated, clear the npx cache and reinstall: npx clear-npx-ca
           updateAvailable,
           package: "@aibtc/mcp-server",
           hint: updateAvailable
-            ? "⚠️  Update available! Clear npx cache and reinstall: npx clear-npx-cache && npx @aibtc/mcp-server@latest --install"
+            ? "⚠️  Update available! Clear the npx cache and restart your MCP client: npx clear-npx-cache (config already points at @latest, so the next launch pulls the newest version)."
             : fetched
               ? "✅ Running the latest version"
               : "Unable to verify latest version (network error)",


### PR DESCRIPTION
## What

The server is a standard stdio MCP server and already works with any MCP client — only the `--install` config writer was Claude-specific. This refactors it into a client registry so other popular agentic tools can be auto-configured.

Claude Code stays the **default** target (no flag). Other clients are selected with a flag:

| Flag | Client | Config written |
|------|--------|----------------|
| _(none)_ | Claude Code | `~/.claude.json` |
| `--desktop` | Claude Desktop | OS-specific `claude_desktop_config.json` |
| `--cursor` | Cursor | `~/.cursor/mcp.json` |
| `--windsurf` | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
| `--gemini` | Gemini CLI | `~/.gemini/settings.json` |
| `--codex` | OpenAI Codex CLI | `~/.codex/config.toml` |
| `--vscode` | VS Code (Copilot agent) | `./.vscode/mcp.json` |

`--testnet` composes with all of them.

## Notes

- **Three config formats** handled: `mcpServers` JSON (Claude/Cursor/Windsurf/Gemini), `servers` JSON with typed stdio entry (VS Code), and TOML (Codex).
- **Codex** is a section-preserving TOML merge (no new dependency) — it rewrites only the `[mcp_servers.aibtc]` section, leaving comments and other servers intact.
- All installers **merge** into existing config rather than overwriting.
- **Zed** and **Cline** are manual-config only (docs), since their schemas/paths shift between versions and weren't worth shipping an unverified writer for.

## Verification

Smoke-tested every installer against a throwaway `HOME`:
- Merge-not-clobber: installing into a config with other servers + top-level keys preserves all of them.
- Codex idempotency: running `--codex` twice over a `config.toml` with comments + a `model` setting + a stale `aibtc` block replaces only the `aibtc` section, no duplicates.

`npm run build` passes.

## Docs

README (flags table + manual snippets for every client incl. Zed/Cline), CLAUDE.md, and skill/SKILL.md all updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)