### PR TITLE
fix: use published Spark SDK dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aibtc/tx-schemas": "^0.7.0",
         "@bitflowlabs/core-sdk": "^3.0.0",
-        "@buildonspark/spark-sdk": "^0.7.14",
+        "@buildonspark/spark-sdk": "^0.5.0",
         "@faktoryfun/styx-sdk": "^1.3.5",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@noble/curves": "^2.0.1",
@@ -111,14 +111,14 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@buildonspark/spark-sdk": {
-      "version": "0.7.14",
-      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.7.14.tgz",
-      "integrity": "sha512-R/kJp+MSPQDvV6QfFGEBV9um6hhQNN60vWGA+e5hdh/cMroVL9BAmz7h4cNxXHZM0PhpMW18PeLVg9Qjhh9ipQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.5.0.tgz",
+      "integrity": "sha512-+u39p8Hb9t0VzWPsPvnt5r8P799R/wTyLfycu9PvZdsTQbxOPbSV+vYhMWLxqQdEtT/DeC+zVgt2skda+lG4Gg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.5",
-        "@lightsparkdev/core": "^1.4.9",
-        "@noble/curves": "^1.9.7",
+        "@lightsparkdev/core": "^1.4.4",
+        "@noble/curves": "^1.8.0",
         "@noble/hashes": "^1.7.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.0.0",
@@ -146,7 +146,7 @@
         "nice-grpc-common": "^2.0.2",
         "nice-grpc-opentelemetry": "^0.1.18",
         "nice-grpc-web": "^3.3.7",
-        "ts-proto": "2.8.3",
+        "ts-proto": "^2.6.1",
         "ua-parser-js": "^2.0.6",
         "uuidv7": "^1.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@aibtc/tx-schemas": "^0.7.0",
     "@bitflowlabs/core-sdk": "^3.0.0",
-    "@buildonspark/spark-sdk": "^0.7.14",
+    "@buildonspark/spark-sdk": "^0.5.0",
     "@faktoryfun/styx-sdk": "^1.3.5",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@noble/curves": "^2.0.1",

--- a/src/services/lightning/spark-provider.ts
+++ b/src/services/lightning/spark-provider.ts
@@ -50,6 +50,10 @@ interface SparkCurrencyAmount {
   originalUnit: string;
 }
 
+type SparkWalletBalance =
+  | { balance: bigint | number | string }
+  | { satsBalance: { available: bigint | number | string } };
+
 /**
  * Convert a Spark `CurrencyAmount` to whole satoshis.
  *
@@ -169,9 +173,12 @@ export class SparkLightningProvider implements LightningProvider {
   }
 
   async getBalance(): Promise<{ balanceSats: number }> {
-    const balance = await this.wallet.getBalance();
+    const balance = (await this.wallet.getBalance()) as SparkWalletBalance;
+    const balanceSats =
+      "satsBalance" in balance ? balance.satsBalance.available : balance.balance;
+
     return {
-      balanceSats: Number(balance.satsBalance.available),
+      balanceSats: Number(balanceSats),
     };
   }
 


### PR DESCRIPTION
## Summary
- replace the unavailable @buildonspark/spark-sdk ^0.7.14 dependency with the latest published ^0.5.0 range
- adapt Lightning balance handling to Spark SDK 0.5.0 while keeping compatibility with the previous satsBalance shape
- refresh package-lock.json so npm can install the package from the public registry

## Reproduction
The published package currently cannot be installed because npm cannot resolve the Spark SDK range:

npm exec --yes --package=@aibtc/mcp-server@1.58.0 -- aibtc-mcp-server --version

Actual behavior:

npm error code ETARGET
npm error notarget No matching version found for @buildonspark/spark-sdk@^0.7.14.

The public npm registry currently publishes @buildonspark/spark-sdk up to 0.5.0, so ^0.7.14 is unsatisfiable for users installing @aibtc/mcp-server.

## Verification
- npm install @buildonspark/spark-sdk@^0.5.0
- npm run build
- npm test (30 files, 502 passed, 4 skipped)
- npm pack --dry-run
