### PR TITLE
feat: cap x402 auto-payment amounts

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -114,6 +114,12 @@ Embedded, self-custodial Lightning wallet backed by the [Spark SDK](https://www.
 ### x402 API Endpoints
 - `execute_x402_endpoint` - Execute ANY x402 endpoint URL with automatic payment handling. Can use full URL or path+apiUrl.
 
+**Configuration:**
+- `X402_MAX_USTX_PER_PAYMENT` (optional, default `1000000` = 1 STX): hard cap on the uSTX amount the x402 interceptor will auto-pay per request. Bounds the blast radius if a malicious endpoint demands an arbitrary amount.
+- `X402_MAX_SATS_PER_PAYMENT` (optional, default `10000`): same cap for sBTC payments, in sats.
+
+Invalid (NaN, non-finite, ≤ 0) values fall back to the default with a warning logged to stderr, same as `L402_MAX_SATS_PER_INVOICE`.
+
 ### x402 Endpoint Scaffolding
 - `scaffold_x402_endpoint` - Generate a complete Cloudflare Worker project with x402 payment integration
 

--- a/src/services/x402.service.ts
+++ b/src/services/x402.service.ts
@@ -76,6 +76,22 @@ const L402_MAX_SATS_PER_INVOICE = parseSatsCap(
   DEFAULT_L402_MAX_SATS
 );
 
+/**
+ * Per-payment caps for the Stacks x402 interceptor, mirroring the L402 cap
+ * above: a malicious endpoint can demand an arbitrary amount in its 402
+ * response and an autoApprove'd call would pay it, bounded only by wallet
+ * balance. Known registry endpoints cost at most 0.02 STX / 100 sats, so the
+ * defaults leave generous headroom. Overridable via env vars.
+ */
+const X402_MAX_USTX_PER_PAYMENT = parseSatsCap(
+  "X402_MAX_USTX_PER_PAYMENT",
+  1_000_000 // 1 STX
+);
+const X402_MAX_SATS_PER_PAYMENT = parseSatsCap(
+  "X402_MAX_SATS_PER_PAYMENT",
+  10_000
+);
+
 // Track payment attempts per client instance (auto-cleanup via WeakMap)
 const paymentAttempts: WeakMap<AxiosInstance, number> = new WeakMap();
 
@@ -648,6 +664,21 @@ export async function createApiClient(baseUrl?: string, options?: CreateApiClien
           );
         }
 
+        const tokenType = detectTokenType(selectedOption.asset);
+        const amount = BigInt(selectedOption.amount);
+        const isSbtc = tokenType === "sBTC";
+        const cap = isSbtc ? X402_MAX_SATS_PER_PAYMENT : X402_MAX_USTX_PER_PAYMENT;
+        const unit = isSbtc ? "sats" : "uSTX";
+        if (amount > BigInt(Math.floor(cap))) {
+          return Promise.reject(
+            new Error(
+              `x402 payment of ${amount} ${unit} exceeds the per-payment cap of ${cap} ${unit}. ` +
+              `If this cost is expected, raise the cap via the ` +
+              `${isSbtc ? "X402_MAX_SATS_PER_PAYMENT" : "X402_MAX_USTX_PER_PAYMENT"} env var.`
+            )
+          );
+        }
+
         // Lazy-load account on first 402 — free endpoints never reach here
         const acct = await ensureAccount();
 
@@ -675,8 +706,6 @@ export async function createApiClient(baseUrl?: string, options?: CreateApiClien
         }
 
         // Build a sponsored signed transaction (relay pays gas; fee: 0n)
-        const tokenType = detectTokenType(selectedOption.asset);
-        const amount = BigInt(selectedOption.amount);
         const networkName = getStacksNetwork(acct.network);
 
         let transaction;

--- a/tests/services/x402-prevalidation.test.ts
+++ b/tests/services/x402-prevalidation.test.ts
@@ -567,3 +567,58 @@ describe("payment attempt guard", () => {
     consoleSpy.mockRestore();
   });
 });
+
+describe("x402 per-payment spend cap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    mockGetActiveAccount.mockReturnValue(MOCK_ACCOUNT);
+  });
+
+  /** Adapter that always 402s with a properly encoded payment-required header */
+  function make402Adapter(asset: string, amount: string) {
+    return async (config: unknown) => {
+      const paymentRequired = {
+        x402Version: 2,
+        resource: { url: "https://x402.test.com/test" },
+        accepts: [
+          { network: "stacks:1", asset, amount, payTo: MOCK_ACCOUNT.address },
+        ],
+      };
+      throw {
+        response: {
+          status: 402,
+          data: paymentRequired,
+          headers: {
+            "payment-required": Buffer.from(JSON.stringify(paymentRequired)).toString("base64"),
+          },
+          config,
+        },
+        config,
+      };
+    };
+  }
+
+  it("rejects STX payments above the uSTX cap", async () => {
+    const client = await createApiClient("https://x402.test.com");
+    client.defaults.adapter = make402Adapter("STX", "2000000"); // 2 STX > 1 STX default cap
+    await expect(client.get("/test")).rejects.toThrow("exceeds the per-payment cap");
+  });
+
+  it("rejects sBTC payments above the sats cap", async () => {
+    const client = await createApiClient("https://x402.test.com");
+    client.defaults.adapter = make402Adapter("sbtc", "20000"); // > 10k sats default cap
+    await expect(client.get("/test")).rejects.toThrow("exceeds the per-payment cap");
+  });
+
+  it("does not block payments at the cap", async () => {
+    const client = await createApiClient("https://x402.test.com");
+    client.defaults.adapter = make402Adapter("STX", "1000000"); // exactly 1 STX
+    try {
+      await client.get("/test");
+      expect.fail("Should have thrown (mock account cannot sign)");
+    } catch (error) {
+      expect((error as Error).message).not.toContain("exceeds the per-payment cap");
+    }
+  });
+});


### PR DESCRIPTION
Adds per-payment spend caps to the Stacks x402 payment interceptor. Previously an autoApprove'd call would pay whatever amount a 402 response demanded, bounded only by wallet balance — a malicious endpoint could drain the wallet in one call under prompt injection.

The cap is enforced in the interceptor right after the payment option is selected, before the wallet is touched, mirroring the existing L402_MAX_SATS_PER_INVOICE pattern:

- `X402_MAX_USTX_PER_PAYMENT` (default 1,000,000 uSTX = 1 STX)
- `X402_MAX_SATS_PER_PAYMENT` (default 10,000 sats)

Known registry endpoints cost at most 0.02 STX / 100 sats, so the defaults leave ~50x headroom. Over-cap payments reject with an error naming the env var to raise.

Includes 3 interceptor tests (STX over cap, sBTC over cap, at-cap not blocked) and a docs/TOOLS.md entry. 505 tests pass.