### PR TITLE
fix: security hardening — BTC address network check + credentials perms

### DIFF
--- a/src/services/credentials.ts
+++ b/src/services/credentials.ts
@@ -78,6 +78,7 @@ async function encrypt(data: string, password: string): Promise<EncryptedData> {
   const iv = crypto.randomBytes(12);
   const key = await deriveKey(password, salt);
   const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  key.fill(0); // cipher holds its own copy
   const encrypted = Buffer.concat([cipher.update(data, "utf8"), cipher.final()]);
   const authTag = cipher.getAuthTag();
   return {
@@ -97,6 +98,7 @@ async function decrypt(encrypted: EncryptedData, password: string): Promise<stri
     key,
     Buffer.from(encrypted.iv, "base64")
   );
+  key.fill(0); // decipher holds its own copy
   decipher.setAuthTag(Buffer.from(encrypted.authTag, "base64"));
   const decrypted = Buffer.concat([
     decipher.update(Buffer.from(encrypted.ciphertext, "base64")),
@@ -112,12 +114,15 @@ function emptyStore(): CredentialStore {
 
 async function save(): Promise<void> {
   if (!_store || !_password) throw new Error("Store not unlocked");
-  await fs.mkdir(getStoreDir(), { recursive: true });
+  await fs.mkdir(getStoreDir(), { recursive: true, mode: 0o700 });
   const file: EncryptedFile = {
     version: VERSION,
     encrypted: await encrypt(JSON.stringify(_store), _password),
   };
-  await fs.writeFile(getStoreFile(), JSON.stringify(file, null, 2));
+  // Owner-only perms + atomic rename, same pattern as the wallet keystores
+  const tempFile = getStoreFile() + ".tmp";
+  await fs.writeFile(tempFile, JSON.stringify(file, null, 2), { mode: 0o600 });
+  await fs.rename(tempFile, getStoreFile());
 }
 
 async function load(password: string): Promise<CredentialStore> {

--- a/src/tools/bitcoin.tools.ts
+++ b/src/tools/bitcoin.tools.ts
@@ -48,6 +48,23 @@ async function getBtcAddress(providedAddress?: string): Promise<string> {
 }
 
 /**
+ * Reject recipient addresses that belong to the other Bitcoin network before
+ * any UTXO fetching. The tx builder (@scure/btc-signer) rejects these too, but
+ * late and with a cryptic bech32/version-byte error.
+ */
+function validateRecipientNetwork(address: string): void {
+  const prefixes =
+    NETWORK === "mainnet" ? ["bc1", "1", "3"] : ["tb1", "m", "n", "2"];
+  if (!prefixes.some((p) => address.startsWith(p))) {
+    throw new Error(
+      `Recipient "${address}" is not a ${NETWORK} address. ` +
+        `Expected a prefix of ${prefixes.join(", ")} — check that the address ` +
+        `matches the configured NETWORK.`
+    );
+  }
+}
+
+/**
  * Format satoshis as BTC string
  */
 function formatBtc(satoshis: number): string {
@@ -284,6 +301,8 @@ export function registerBitcoinTools(server: McpServer): void {
     },
     async ({ recipient, amount, feeRate, includeOrdinals }) => {
       try {
+        validateRecipientNetwork(recipient);
+
         // Get wallet account (requires unlocked wallet)
         const walletManager = getWalletManager();
         const account = walletManager.getActiveAccount();

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -68,6 +68,7 @@ export async function encrypt(
 
   // Encrypt with AES-256-GCM
   const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  key.fill(0); // cipher holds its own copy
   const encrypted = Buffer.concat([
     cipher.update(plaintext, "utf8"),
     cipher.final(),
@@ -102,6 +103,7 @@ export async function decrypt(
 
   // Decrypt with AES-256-GCM
   const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+  key.fill(0); // decipher holds its own copy
   decipher.setAuthTag(authTag);
 
   try {


### PR DESCRIPTION
Two independent hardening fixes from the security audit. (The sBTC post-condition originally in this PR moved to #570, the relay-free x402 PR, where it belongs with the payment-path changes.)

1. **transfer_btc** validates the recipient's network prefix up front. @scure/btc-signer already rejects cross-network addresses, but only after UTXO fetching and with a cryptic bech32 error; this fails fast with a clear message.
2. **Credentials store** (~/.aibtc/credentials.enc) now uses 0o700/0o600 permissions and atomic temp-file writes, matching the wallet keystores. Scrypt-derived key buffers are zeroed once the cipher context holds its own copy.

Build clean, 502 tests pass.