### PR TITLE
fix: surface errors instead of returning defaults

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,24 @@ function getClaudeDesktopConfigPath(): string {
 }
 
 async function readJsonConfig(filePath: string): Promise<Record<string, unknown>> {
+  let content: string;
   try {
-    const content = await fs.readFile(filePath, "utf8");
+    content = await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {}; // No config yet - fresh install
+    }
+    throw error;
+  }
+  try {
     return JSON.parse(content);
   } catch {
-    // File doesn't exist or isn't valid JSON, start fresh
-    return {};
+    // Never silently replace an unparseable config: it may hold the user's
+    // other MCP servers, and "merging" into {} would discard them on write.
+    throw new Error(
+      `Existing config at ${filePath} is not valid JSON. ` +
+        `Fix or remove it, then re-run the install.`
+    );
   }
 }
 
@@ -107,8 +119,10 @@ async function writeCodexToml(configPath: string, network: string): Promise<void
   let existing = "";
   try {
     existing = await fs.readFile(configPath, "utf8");
-  } catch {
-    existing = "";
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error; // Unreadable existing config must not be clobbered
+    }
   }
   const preserved = stripCodexSection(existing).replace(/\s+$/, "");
   const block = [

--- a/src/services/defi.service.ts
+++ b/src/services/defi.service.ts
@@ -13,7 +13,7 @@ import {
   bufferCV,
 } from "@stacks/transactions";
 import { AlexSDK, Currency, type TokenInfo } from "alex-sdk";
-import { HiroApiService, getHiroApi } from "./hiro-api.js";
+import { HiroApiService, getHiroApi, isNotFoundError } from "./hiro-api.js";
 import {
   getAlexContracts,
   getZestContracts,
@@ -255,8 +255,9 @@ export class AlexDexService {
       }
 
       return null;
-    } catch {
-      return null;
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
     }
   }
 
@@ -544,8 +545,9 @@ export class ZestProtocolService {
         borrowed,
         healthFactor: position["health-factor"]?.value,
       };
-    } catch {
-      return null;
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
     }
   }
 
@@ -569,8 +571,9 @@ export class ZestProtocolService {
       }
 
       return cvToJSON(hexToCV(result.result));
-    } catch {
-      return null;
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
     }
   }
 
@@ -621,8 +624,11 @@ export class ZestProtocolService {
           return BigInt(value);
         }
       }
-    } catch {
-      // Fall back to shares as lower bound estimate
+    } catch (error) {
+      // Only fall back to the shares lower-bound estimate when the vault
+      // function is missing — network/server failures must surface, or the
+      // post-conditions built from this value would be silently wrong.
+      if (!isNotFoundError(error)) throw error;
     }
     return shares;
   }
@@ -650,8 +656,9 @@ export class ZestProtocolService {
           return BigInt(value);
         }
       }
-    } catch {
-      // Fall back to amount as upper bound
+    } catch (error) {
+      // Same rationale as getUnderlyingFromShares: estimate only on 404.
+      if (!isNotFoundError(error)) throw error;
     }
     return amount;
   }

--- a/src/services/hiro-api.ts
+++ b/src/services/hiro-api.ts
@@ -20,6 +20,25 @@ export class HiroApiRateLimitError extends Error {
   }
 }
 
+/**
+ * HTTP error from the Hiro / BNS V2 APIs, carrying the status code so
+ * callers can treat 404 as "not found" without swallowing other failures.
+ */
+export class HiroApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = "HiroApiError";
+  }
+}
+
+/** True when the error is an expected "resource does not exist" response. */
+export function isNotFoundError(error: unknown): boolean {
+  return error instanceof HiroApiError && error.status === 404;
+}
+
 export interface AccountInfo {
   balance: string;
   locked: string;
@@ -362,7 +381,10 @@ export class HiroApiService {
       }
 
       const errorText = await response.text();
-      throw new Error(`Hiro API error (${response.status}): ${errorText}`);
+      throw new HiroApiError(
+        `Hiro API error (${response.status}): ${errorText}`,
+        response.status
+      );
     }
 
     return response.json();
@@ -450,8 +472,9 @@ export class HiroApiService {
   async getTokenMetadata(contractId: string): Promise<TokenMetadata | null> {
     try {
       return await this.fetch<TokenMetadata>(`/metadata/v1/ft/${contractId}`);
-    } catch {
-      return null;
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
     }
   }
 
@@ -710,8 +733,9 @@ export class HiroApiService {
     try {
       const info = await this.getBnsNameInfo(name);
       return info.address;
-    } catch {
-      return null;
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
     }
   }
 
@@ -809,7 +833,10 @@ export class BnsV2ApiService {
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`BNS V2 API error (${response.status}): ${errorText}`);
+      throw new HiroApiError(
+        `BNS V2 API error (${response.status}): ${errorText}`,
+        response.status
+      );
     }
 
     return response.json();
@@ -858,8 +885,9 @@ export class BnsV2ApiService {
         return info.data.owner;
       }
       return null;
-    } catch {
-      return null;
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
     }
   }
 }

--- a/src/services/nft.service.ts
+++ b/src/services/nft.service.ts
@@ -1,5 +1,5 @@
 import { ClarityValue, uintCV, principalCV } from "@stacks/transactions";
-import { HiroApiService, getHiroApi, NftHolding, NftEvent } from "./hiro-api.js";
+import { HiroApiService, getHiroApi, HiroApiError, NftHolding, NftEvent } from "./hiro-api.js";
 import { parseContractId, type Network } from "../config/index.js";
 import { callContract, type Account, type TransferResult } from "../transactions/builder.js";
 import { createNftSendPostCondition } from "../transactions/post-conditions.js";
@@ -95,8 +95,13 @@ export class NftService {
         }
       }
       return null;
-    } catch {
-      return null;
+    } catch (error) {
+      // 4xx means the contract doesn't implement get-owner (or rejects the
+      // call) — that is "no owner". Network/server failures must surface.
+      if (error instanceof HiroApiError && error.status < 500) {
+        return null;
+      }
+      throw error;
     }
   }
 
@@ -126,8 +131,12 @@ export class NftService {
           totalSupply = parseInt(match[1], 10);
         }
       }
-    } catch {
-      // Function may not exist or may fail
+    } catch (error) {
+      // 4xx means the contract doesn't implement get-last-token-id —
+      // supply is simply unknown. Network/server failures must surface.
+      if (!(error instanceof HiroApiError && error.status < 500)) {
+        throw error;
+      }
     }
 
     return {

--- a/src/services/pillar-api.service.ts
+++ b/src/services/pillar-api.service.ts
@@ -1,5 +1,19 @@
 import { PILLAR_API_URL, PILLAR_API_KEY } from "../config/pillar.js";
 
+/**
+ * HTTP error from the Pillar API, carrying the status code so callers can
+ * treat 4xx ("no such wallet / no position") differently from infra failures.
+ */
+export class PillarApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = "PillarApiError";
+  }
+}
+
 class PillarApiService {
   private baseUrl: string;
   private apiKey: string;
@@ -43,7 +57,10 @@ class PillarApiService {
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`Pillar API error (${response.status}): ${errorText}`);
+      throw new PillarApiError(
+        `Pillar API error (${response.status}): ${errorText}`,
+        response.status
+      );
     }
 
     return response.json();

--- a/src/tools/inbox.tools.ts
+++ b/src/tools/inbox.tools.ts
@@ -73,19 +73,17 @@ async function getNextNonce(address: string): Promise<number> {
   const accountInfo = await hiroApi.getAccountInfo(address);
   const confirmedNonce = accountInfo.nonce;
 
+  // The mempool scan is what makes the nonce safe against pending txs —
+  // silently skipping it on failure risks a nonce collision, so let it fail.
   let highestMempoolNonce = -1;
-  try {
-    const mempool = await hiroApi.getMempoolTransactions({
-      sender_address: address,
-      limit: 50,
-    });
-    for (const tx of mempool.results) {
-      if (tx.nonce > highestMempoolNonce) {
-        highestMempoolNonce = tx.nonce;
-      }
+  const mempool = await hiroApi.getMempoolTransactions({
+    sender_address: address,
+    limit: 50,
+  });
+  for (const tx of mempool.results) {
+    if (tx.nonce > highestMempoolNonce) {
+      highestMempoolNonce = tx.nonce;
     }
-  } catch {
-    // Non-fatal: fall back to confirmed nonce only
   }
 
   const chainNext = Math.max(confirmedNonce, highestMempoolNonce + 1);

--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -82,19 +82,17 @@ async function getNextNonce(address: string): Promise<number> {
   const accountInfo = await hiroApi.getAccountInfo(address);
   const confirmedNonce = accountInfo.nonce;
 
+  // The mempool scan is what makes the nonce safe against pending txs —
+  // silently skipping it on failure risks a nonce collision, so let it fail.
   let highestMempoolNonce = -1;
-  try {
-    const mempool = await hiroApi.getMempoolTransactions({
-      sender_address: address,
-      limit: 50,
-    });
-    for (const tx of mempool.results) {
-      if (tx.nonce > highestMempoolNonce) {
-        highestMempoolNonce = tx.nonce;
-      }
+  const mempool = await hiroApi.getMempoolTransactions({
+    sender_address: address,
+    limit: 50,
+  });
+  for (const tx of mempool.results) {
+    if (tx.nonce > highestMempoolNonce) {
+      highestMempoolNonce = tx.nonce;
     }
-  } catch {
-    // Non-fatal
   }
 
   const chainNext = Math.max(confirmedNonce, highestMempoolNonce + 1);

--- a/src/tools/pillar-direct.tools.ts
+++ b/src/tools/pillar-direct.tools.ts
@@ -17,7 +17,7 @@ import {
   generateAuthId,
   type SigAuth,
 } from "../services/signing-key.service.js";
-import { getPillarApi } from "../services/pillar-api.service.js";
+import { getPillarApi, PillarApiError } from "../services/pillar-api.service.js";
 import { getHiroApi } from "../services/hiro-api.js";
 import { NETWORK } from "../config/networks.js";
 import { PILLAR_API_KEY } from "../config/pillar.js";
@@ -635,8 +635,12 @@ export function registerPillarDirectTools(server: McpServer): void {
             data: { status: string; contractAddress: string } | null;
           }>(`/api/smart-wallet/${walletName}`);
           walletStatus = walletInfo.data?.status || null;
-        } catch {
-          // Wallet not found in backend
+        } catch (error) {
+          // 404 = wallet not registered in backend. Anything else (network,
+          // 5xx) must surface, or an initialized wallet gets misreported.
+          if (!(error instanceof PillarApiError && error.status === 404)) {
+            throw error;
+          }
         }
 
         if (!walletStatus || walletStatus === "pending_init") {
@@ -715,8 +719,11 @@ export function registerPillarDirectTools(server: McpServer): void {
           });
 
           position = unwindQuote.data as Record<string, unknown>;
-        } catch {
-          // unwind-quote may fail for fresh wallets with no position
+        } catch (error) {
+          // 4xx = fresh wallet with no position. Infra failures must surface.
+          if (!(error instanceof PillarApiError && error.status < 500)) {
+            throw error;
+          }
         }
 
         return createJsonResponse({
@@ -1572,27 +1579,16 @@ export function registerPillarDirectTools(server: McpServer): void {
           return `${whole}.${frac} STX`;
         };
 
-        // Fetch PoX cycle info
-        let poxInfo: {
-          currentCycleId: number;
-          nextCycleId: number;
-          blocksUntilNextCycle: number;
-          minAmountUstx: number;
-          isPoxActive: boolean;
-        } | null = null;
-
-        try {
-          const pox = await hiro.getPoxInfo();
-          poxInfo = {
-            currentCycleId: pox.current_cycle.id,
-            nextCycleId: pox.next_cycle.id,
-            blocksUntilNextCycle: pox.next_cycle.blocks_until_reward_phase,
-            minAmountUstx: pox.min_amount_ustx,
-            isPoxActive: pox.current_cycle.is_pox_active,
-          };
-        } catch {
-          // PoX info fetch failed, continue without it
-        }
+        // Fetch PoX cycle info — a global endpoint with no "not found" case,
+        // so any failure is infrastructure and should surface.
+        const pox = await hiro.getPoxInfo();
+        const poxInfo = {
+          currentCycleId: pox.current_cycle.id,
+          nextCycleId: pox.next_cycle.id,
+          blocksUntilNextCycle: pox.next_cycle.blocks_until_reward_phase,
+          minAmountUstx: pox.min_amount_ustx,
+          isPoxActive: pox.current_cycle.is_pox_active,
+        };
 
         // Check enrollment status via backend
         const api = getPillarApi();
@@ -1619,8 +1615,13 @@ export function registerPillarDirectTools(server: McpServer): void {
               dualStackingTxId: walletInfo.data.dualStackingTxId || null,
             };
           }
-        } catch {
-          // Backend lookup failed, continue without enrollment info
+        } catch (error) {
+          // 404 = wallet not registered, so not enrolled. Other failures
+          // must surface — defaulting to enrolled:false on a backend outage
+          // misreports an enrolled wallet and could prompt re-enrollment.
+          if (!(error instanceof PillarApiError && error.status === 404)) {
+            throw error;
+          }
         }
 
         const isStacking = lockedMicro > BigInt(0);

--- a/src/tools/sbtc.tools.ts
+++ b/src/tools/sbtc.tools.ts
@@ -367,15 +367,9 @@ Signers later process the request and send BTC on L1.`,
     },
     async () => {
       try {
-        // Try to get wallet account (don't throw if not unlocked)
+        // getActiveAccount returns null when locked - generic instructions then
         const walletManager = getWalletManager();
-        let account;
-        try {
-          account = walletManager.getActiveAccount();
-        } catch {
-          // Wallet not unlocked - return generic instructions
-          account = null;
-        }
+        const account = walletManager.getActiveAccount();
 
         // If wallet is unlocked and has Taproot keys, generate real deposit address
         if (account?.taprootPublicKey) {

--- a/src/tools/scaffold.tools.ts
+++ b/src/tools/scaffold.tools.ts
@@ -15,21 +15,17 @@ import { getWalletAddress } from "../services/x402.service.js";
  * Check if a directory contains an existing x402 project
  */
 async function isExistingX402Project(dir: string): Promise<boolean> {
-  try {
-    const indexPath = path.join(dir, "src", "index.ts");
-    const middlewarePath = path.join(dir, "src", "x402-middleware.ts");
-    const packagePath = path.join(dir, "package.json");
+  const indexPath = path.join(dir, "src", "index.ts");
+  const middlewarePath = path.join(dir, "src", "x402-middleware.ts");
+  const packagePath = path.join(dir, "package.json");
 
-    const [hasIndex, hasMiddleware, hasPackage] = await Promise.all([
-      fs.access(indexPath).then(() => true).catch(() => false),
-      fs.access(middlewarePath).then(() => true).catch(() => false),
-      fs.access(packagePath).then(() => true).catch(() => false),
-    ]);
+  const [hasIndex, hasMiddleware, hasPackage] = await Promise.all([
+    fs.access(indexPath).then(() => true).catch(() => false),
+    fs.access(middlewarePath).then(() => true).catch(() => false),
+    fs.access(packagePath).then(() => true).catch(() => false),
+  ]);
 
-    return hasIndex && hasMiddleware && hasPackage;
-  } catch {
-    return false;
-  }
+  return hasIndex && hasMiddleware && hasPackage;
 }
 
 /**

--- a/src/tools/stacking-lottery.tools.ts
+++ b/src/tools/stacking-lottery.tools.ts
@@ -9,7 +9,7 @@ import {
   cvToJSON,
 } from "@stacks/transactions";
 import { getAccount, NETWORK } from "../services/x402.service.js";
-import { getHiroApi } from "../services/hiro-api.js";
+import { getHiroApi, isNotFoundError } from "../services/hiro-api.js";
 import { callContract } from "../transactions/builder.js";
 import { getExplorerTxUrl } from "../config/networks.js";
 import { createJsonResponse, createErrorResponse } from "../utils/index.js";
@@ -147,13 +147,14 @@ Note: Stackspot is only available on mainnet.`,
                 "get-pot-value",
                 []
               );
-            } catch {
-              // pot may not be deployed or reachable — skip gracefully
+            } catch (error) {
+              // 404 = pot contract not deployed; other failures surface
+              if (!isNotFoundError(error)) throw error;
             }
             try {
               isLocked = await callPotReadOnly(pot.contractName, "is-locked", []);
-            } catch {
-              // same
+            } catch (error) {
+              if (!isNotFoundError(error)) throw error;
             }
             return {
               name: pot.name,

--- a/src/tools/yield-dashboard.tools.ts
+++ b/src/tools/yield-dashboard.tools.ts
@@ -323,26 +323,26 @@ async function readStackingPosition(walletAddress: string): Promise<ProtocolPosi
 async function getWalletBalances(
   walletAddress: string
 ): Promise<{ stxMicroStx: number; sbtcSats: number }> {
-  try {
-    const res = await fetch(
-      `${MAINNET_HIRO_API}/extended/v1/address/${walletAddress}/balances`
+  const res = await fetch(
+    `${MAINNET_HIRO_API}/extended/v1/address/${walletAddress}/balances`
+  );
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch wallet balances for ${walletAddress}: HTTP ${res.status}`
     );
-    if (!res.ok) return { stxMicroStx: 0, sbtcSats: 0 };
-    const data = (await res.json()) as {
-      stx?: { balance?: string };
-      fungible_tokens?: Record<string, { balance?: string }>;
-    };
-    const stxMicroStx = parseInt(data.stx?.balance ?? "0", 10);
-    const sbtcKey = Object.keys(data.fungible_tokens ?? {}).find((k) =>
-      k.toLowerCase().includes("sbtc")
-    );
-    const sbtcSats = sbtcKey
-      ? parseInt(data.fungible_tokens?.[sbtcKey]?.balance ?? "0", 10)
-      : 0;
-    return { stxMicroStx, sbtcSats };
-  } catch {
-    return { stxMicroStx: 0, sbtcSats: 0 };
   }
+  const data = (await res.json()) as {
+    stx?: { balance?: string };
+    fungible_tokens?: Record<string, { balance?: string }>;
+  };
+  const stxMicroStx = parseInt(data.stx?.balance ?? "0", 10);
+  const sbtcKey = Object.keys(data.fungible_tokens ?? {}).find((k) =>
+    k.toLowerCase().includes("sbtc")
+  );
+  const sbtcSats = sbtcKey
+    ? parseInt(data.fungible_tokens?.[sbtcKey]?.balance ?? "0", 10)
+    : 0;
+  return { stxMicroStx, sbtcSats };
 }
 
 async function checkZestV2(): Promise<boolean> {


### PR DESCRIPTION
Sweep of the swallowed-catch sites from the audit (CLAUDE.md principles 2 and 5). The recurring fix: catches now distinguish expected "not found" responses from real failures, via new typed HiroApiError / PillarApiError classes carrying the HTTP status. Four commits:

1. **hiro-api / nft.service / yield-dashboard / inbox** — typed HiroApiError; getTokenMetadata and BNS resolvers return null only on 404; NFT probes treat contract-level 4xx as "not supported"; yield-dashboard balance fetch errors instead of reporting fake zero balances; inbox mempool nonce scan failure surfaces instead of risking a nonce collision.
2. **defi.service** — pool/position/supplies reads return null only on 404; share-conversion estimate fallbacks apply only when the vault function is missing, since post-conditions are built from those values.
3. **--install config reads** — an unparseable existing client config now errors instead of being treated as empty and rewritten (which would have discarded the user's other MCP servers); only ENOENT means "fresh install". Also removes two dead catches (getActiveAccount returns null, never throws; fs.access probes already catch).
4. **pillar-direct / stacking-lottery / news** — typed PillarApiError; wallet status, unwind-quote, and enrollment lookups swallow only 404/4xx so a backend outage can't misreport wallet state (e.g. enrolled:false prompting re-enrollment); pot reads skip only undeployed contracts; news nonce scan matches the inbox fix.

Left as-is, deliberately: competition token pricing (failures already surfaced via unpriced_trade_count/unpriced_tokens in the response), bitflow price-impact (aborts explicitly on any failed hop), news/inbox JSON-parse-to-{raw} (passes the raw body through rather than masking), and the clamped fallback fee in fee.ts (bounded, logged, and keeps txs flowing during fee-API outages).

Build clean, 502 tests pass.