### PR TITLE
feat: relay-free x402 payments (non-sponsored) with spend cap + post-condition

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -114,6 +114,12 @@ Embedded, self-custodial Lightning wallet backed by the [Spark SDK](https://www.
 ### x402 API Endpoints
 - `execute_x402_endpoint` - Execute ANY x402 endpoint URL with automatic payment handling. Can use full URL or path+apiUrl.
 
+**Configuration:**
+- `X402_MAX_USTX_PER_PAYMENT` (optional, default `1000000` = 1 STX): hard cap on the uSTX amount the x402 interceptor will auto-pay per request. Bounds the blast radius if a malicious endpoint demands an arbitrary amount.
+- `X402_MAX_SATS_PER_PAYMENT` (optional, default `10000`): same cap for sBTC payments, in sats.
+
+Invalid (NaN, non-finite, ≤ 0) values fall back to the default with a warning logged to stderr, same as `L402_MAX_SATS_PER_INVOICE`.
+
 ### x402 Endpoint Scaffolding
 - `scaffold_x402_endpoint` - Generate a complete Cloudflare Worker project with x402 payment integration
 

--- a/src/services/x402.service.ts
+++ b/src/services/x402.service.ts
@@ -5,6 +5,7 @@ import {
   uintCV,
   principalCV,
   noneCV,
+  Pc,
   PostConditionMode,
 } from "@stacks/transactions";
 import {
@@ -25,6 +26,7 @@ import { getHiroApi } from "./hiro-api.js";
 import { createHash } from "crypto";
 import { InsufficientBalanceError } from "../utils/errors.js";
 import { getContracts, parseContractId } from "../config/contracts.js";
+import { resolveDefaultFee } from "../utils/fee.js";
 import {
   classifyCanonicalPaymentStatus,
   formatCanonicalPaymentStatus,
@@ -74,6 +76,22 @@ function parseSatsCap(envName: string, fallback: number): number {
 const L402_MAX_SATS_PER_INVOICE = parseSatsCap(
   "L402_MAX_SATS_PER_INVOICE",
   DEFAULT_L402_MAX_SATS
+);
+
+/**
+ * Per-payment caps for the Stacks x402 interceptor, mirroring the L402 cap
+ * above: a malicious endpoint can demand an arbitrary amount in its 402
+ * response and an autoApprove'd call would pay it, bounded only by wallet
+ * balance. Known registry endpoints cost at most 0.02 STX / 100 sats, so the
+ * defaults leave generous headroom. Overridable via env vars.
+ */
+const X402_MAX_USTX_PER_PAYMENT = parseSatsCap(
+  "X402_MAX_USTX_PER_PAYMENT",
+  1_000_000 // 1 STX
+);
+const X402_MAX_SATS_PER_PAYMENT = parseSatsCap(
+  "X402_MAX_SATS_PER_PAYMENT",
+  10_000
 );
 
 // Track payment attempts per client instance (auto-cleanup via WeakMap)
@@ -648,6 +666,21 @@ export async function createApiClient(baseUrl?: string, options?: CreateApiClien
           );
         }
 
+        const tokenType = detectTokenType(selectedOption.asset);
+        const amount = BigInt(selectedOption.amount);
+        const isSbtc = tokenType === "sBTC";
+        const cap = isSbtc ? X402_MAX_SATS_PER_PAYMENT : X402_MAX_USTX_PER_PAYMENT;
+        const unit = isSbtc ? "sats" : "uSTX";
+        if (amount > BigInt(Math.floor(cap))) {
+          return Promise.reject(
+            new Error(
+              `x402 payment of ${amount} ${unit} exceeds the per-payment cap of ${cap} ${unit}. ` +
+              `If this cost is expected, raise the cap via the ` +
+              `${isSbtc ? "X402_MAX_SATS_PER_PAYMENT" : "X402_MAX_USTX_PER_PAYMENT"} env var.`
+            )
+          );
+        }
+
         // Lazy-load account on first 402 — free endpoints never reach here
         const acct = await ensureAccount();
 
@@ -674,9 +707,11 @@ export async function createApiClient(baseUrl?: string, options?: CreateApiClien
           });
         }
 
-        // Build a sponsored signed transaction (relay pays gas; fee: 0n)
-        const tokenType = detectTokenType(selectedOption.asset);
-        const amount = BigInt(selectedOption.amount);
+        // Build a non-sponsored signed transaction: the sender pays its own
+        // STX gas (fee + nonce auto-estimated by @stacks), and the x402
+        // facilitator simply verifies and broadcasts it. No relay sponsorship
+        // — this is the same tx shape the x402-stacks lib produces, and the
+        // balance check in onBeforePayment already accounts for the gas.
         const networkName = getStacksNetwork(acct.network);
 
         let transaction;
@@ -698,9 +733,18 @@ export async function createApiClient(baseUrl?: string, options?: CreateApiClien
             ],
             senderKey: acct.privateKey,
             network: networkName,
-            postConditionMode: PostConditionMode.Allow,
-            sponsored: true,
-            fee: 0n,
+            // The payment amount is known at build time, so pin it: a
+            // compromised token contract must not be able to pull more.
+            postConditionMode: PostConditionMode.Deny,
+            postConditions: [
+              Pc.principal(acct.address)
+                .willSendEq(amount)
+                .ft(contracts.SBTC_TOKEN as `${string}.${string}`, "sbtc-token"),
+            ],
+            // Clamped medium fee — do NOT let @stacks auto-estimate, since
+            // Hiro's contract_call high_priority tier is polluted by outliers
+            // (observed >2000 STX). resolveDefaultFee caps it at 0.05 STX.
+            fee: await resolveDefaultFee(acct.network, "contract_call"),
           });
         } else {
           transaction = await makeSTXTokenTransfer({
@@ -709,8 +753,7 @@ export async function createApiClient(baseUrl?: string, options?: CreateApiClien
             senderKey: acct.privateKey,
             network: networkName,
             memo: "",
-            sponsored: true,
-            fee: 0n,
+            fee: await resolveDefaultFee(acct.network, "token_transfer"),
           });
         }
 
@@ -1009,8 +1052,9 @@ export async function checkSufficientBalance(
       const hiroApiForSbtc = getHiroApi(account.network);
       const stxInfoForSbtc = await hiroApiForSbtc.getStxBalance(account.address);
       const stxBalanceForSbtc = BigInt(stxInfoForSbtc.balance);
-      const sbtcFees = await hiroApiForSbtc.getMempoolFees();
-      const estimatedSbtcFee = BigInt(sbtcFees.contract_call.high_priority);
+      // Same clamped fee the interceptor actually sets on the sBTC contract
+      // call — so this check is exact, not a high-priority over-estimate.
+      const estimatedSbtcFee = await resolveDefaultFee(account.network, "contract_call");
 
       if (stxBalanceForSbtc < estimatedSbtcFee) {
         const stxShortfall = estimatedSbtcFee - stxBalanceForSbtc;
@@ -1036,8 +1080,8 @@ export async function checkSufficientBalance(
 
   let totalRequired = requiredAmount;
   if (!sponsored) {
-    const mempoolFees = await hiroApi.getMempoolFees();
-    const estimatedFee = BigInt(mempoolFees.contract_call.high_priority);
+    // Same clamped fee the interceptor sets on the STX transfer.
+    const estimatedFee = await resolveDefaultFee(account.network, "token_transfer");
     totalRequired = requiredAmount + estimatedFee;
   }
 

--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -338,7 +338,9 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
         const api = await createApiClient(parsed.baseUrl, {
           toolName: "execute_x402_endpoint",
           onBeforePayment: async (requirements) => {
-            await checkSufficientBalance(requirements.account, requirements.amount, requirements.asset, true);
+            // Non-sponsored: sender pays its own gas, so validate STX for the
+            // fee too (sponsored=false is the default, passed explicitly here).
+            await checkSufficientBalance(requirements.account, requirements.amount, requirements.asset, false);
           },
         });
         const response = await api.request({ method, url: parsed.requestPath, params, data });

--- a/tests/services/x402-prevalidation.test.ts
+++ b/tests/services/x402-prevalidation.test.ts
@@ -217,16 +217,16 @@ describe("checkSufficientBalance", () => {
         const error = err as InstanceType<typeof InsufficientBalanceError>;
         expect(error.tokenType).toBe("STX");
         expect(error.balance).toBe("500000");
-        // required = payment (1_000_000) + high_priority fee (15_000)
-        expect(error.required).toBe("1015000");
+        // required = payment (1_000_000) + clamped token_transfer fee (2_500)
+        expect(error.required).toBe("1002500");
         // shortfall = required - balance
-        expect(error.shortfall).toBe("515000");
+        expect(error.shortfall).toBe("502500");
       }
     });
 
     it("passes when balance exactly equals payment + fee", async () => {
-      // Exactly 1_000_000 + 15_000 = 1_015_000
-      mockGetStxBalance.mockResolvedValue({ balance: "1015000" });
+      // Exactly 1_000_000 + clamped token_transfer fee 2_500 = 1_002_500
+      mockGetStxBalance.mockResolvedValue({ balance: "1002500" });
 
       await expect(
         checkSufficientBalance(MOCK_ACCOUNT, "1000000", "STX")
@@ -565,5 +565,60 @@ describe("payment attempt guard", () => {
     ]));
     expect(logEvents.find((entry) => entry.event === "payment.fallback_used")).toBeUndefined();
     consoleSpy.mockRestore();
+  });
+});
+
+describe("x402 per-payment spend cap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    mockGetActiveAccount.mockReturnValue(MOCK_ACCOUNT);
+  });
+
+  /** Adapter that always 402s with a properly encoded payment-required header */
+  function make402Adapter(asset: string, amount: string) {
+    return async (config: unknown) => {
+      const paymentRequired = {
+        x402Version: 2,
+        resource: { url: "https://x402.test.com/test" },
+        accepts: [
+          { network: "stacks:1", asset, amount, payTo: MOCK_ACCOUNT.address },
+        ],
+      };
+      throw {
+        response: {
+          status: 402,
+          data: paymentRequired,
+          headers: {
+            "payment-required": Buffer.from(JSON.stringify(paymentRequired)).toString("base64"),
+          },
+          config,
+        },
+        config,
+      };
+    };
+  }
+
+  it("rejects STX payments above the uSTX cap", async () => {
+    const client = await createApiClient("https://x402.test.com");
+    client.defaults.adapter = make402Adapter("STX", "2000000"); // 2 STX > 1 STX default cap
+    await expect(client.get("/test")).rejects.toThrow("exceeds the per-payment cap");
+  });
+
+  it("rejects sBTC payments above the sats cap", async () => {
+    const client = await createApiClient("https://x402.test.com");
+    client.defaults.adapter = make402Adapter("sbtc", "20000"); // > 10k sats default cap
+    await expect(client.get("/test")).rejects.toThrow("exceeds the per-payment cap");
+  });
+
+  it("does not block payments at the cap", async () => {
+    const client = await createApiClient("https://x402.test.com");
+    client.defaults.adapter = make402Adapter("STX", "1000000"); // exactly 1 STX
+    try {
+      await client.get("/test");
+      expect.fail("Should have thrown (mock account cannot sign)");
+    } catch (error) {
+      expect((error as Error).message).not.toContain("exceeds the per-payment cap");
+    }
   });
 });


### PR DESCRIPTION
Makes `execute_x402_endpoint` pay without the deprecated aibtc sponsor relay, and adds the safety guardrails around it. **Supersedes #567 and the post-condition commit of #568** (verified live on mainnet — see below).

### Why
The payment interceptor built sponsored txs (`sponsored: true, fee: 0n`) that required the aibtc relay to co-sign, pay gas, and broadcast. That relay is deprecated and was leaving payments stuck `queued` / returning 500s. The fix is the non-sponsored model the x402-stacks lib and `send_inbox_message_direct` already use: the sender signs a complete, self-paid tx and the facilitator just verifies and broadcasts it.

### Changes (3 commits)
1. **Spend cap** — `X402_MAX_USTX_PER_PAYMENT` (1 STX) / `X402_MAX_SATS_PER_PAYMENT` (10k sats), enforced before signing, mirroring `L402_MAX_SATS_PER_INVOICE`.
2. **sBTC post-condition** — `PostConditionMode.Deny` + `willSendEq(amount)` pins the transfer so a compromised token contract can't pull more.
3. **Non-sponsored migration** — drop `sponsored:true/fee:0n`; set a clamped fee via `resolveDefaultFee` (Hiro's `contract_call` high-priority tier is polluted — observed >2000 STX); `checkSufficientBalance` validates STX-for-gas with that same clamped fee.

Keeps L402 + dedup (the reason we kept our interceptor rather than adopting the lib wholesale).

### Verified live on mainnet
- **sBTC** (inbox, 100 sats): confirmed `success`, `sponsored=false`, `fee=3000 uSTX`, `result=(ok true)` — post-condition passed a real transfer.
- **STX** (hashing, 0.0005 STX): `200 OK`, `sponsored=false`, `type=token_transfer`, `fee=2823 uSTX`.
- Both settled with no relay involvement. The live test also caught the 2101-STX fee bug (fixed via the clamp), which offline tests missed.

505 tests pass; build clean.