### PR TITLE
fix(clarity-values): strip 0x prefix from buffer args in parseArgToClarityValue

### DIFF
--- a/src/transactions/clarity-values.ts
+++ b/src/transactions/clarity-values.ts
@@ -73,8 +73,15 @@ export function parseArgToClarityValue(arg: unknown): ClarityValue {
           return boolCV(typedArg.value as boolean);
         case "principal":
           return principalCV(typedArg.value as string);
-        case "buffer":
-          return bufferCV(Buffer.from(typedArg.value as string, "hex"));
+        case "buffer": {
+          const rawHex = typedArg.value as string;
+          // Strip optional 0x/0X prefix — without this, Buffer.from("0x...", "hex")
+          // silently produces an empty buffer (confirmed in legion-gov testnet run, #1012)
+          const hexStr = rawHex.startsWith("0x") || rawHex.startsWith("0X")
+            ? rawHex.slice(2)
+            : rawHex;
+          return bufferCV(Buffer.from(hexStr, "hex"));
+        }
         case "none":
           return noneCV();
         case "some":

--- a/src/transactions/clarity-values.ts
+++ b/src/transactions/clarity-values.ts
@@ -74,12 +74,9 @@ export function parseArgToClarityValue(arg: unknown): ClarityValue {
         case "principal":
           return principalCV(typedArg.value as string);
         case "buffer": {
-          const rawHex = typedArg.value as string;
           // Strip optional 0x/0X prefix — without this, Buffer.from("0x...", "hex")
-          // silently produces an empty buffer (confirmed in legion-gov testnet run, #1012)
-          const hexStr = rawHex.startsWith("0x") || rawHex.startsWith("0X")
-            ? rawHex.slice(2)
-            : rawHex;
+          // silently produces an empty buffer (aibtcdev/landing-page#1012 Finding 2)
+          const hexStr = (typedArg.value as string).replace(/^0x/i, "");
           return bufferCV(Buffer.from(hexStr, "hex"));
         }
         case "none":

--- a/tests/transactions/clarity-values.test.ts
+++ b/tests/transactions/clarity-values.test.ts
@@ -210,6 +210,20 @@ describe("parseArgToClarityValue", () => {
       expect(cv.type).toBe(ClarityType.Buffer);
     });
 
+    it("should accept 0x-prefixed hex and produce the same bytes as raw hex", () => {
+      const raw = parseArgToClarityValue({ type: "buffer", value: "deadbeef" });
+      const prefixed = parseArgToClarityValue({ type: "buffer", value: "0xdeadbeef" });
+      expect(prefixed.type).toBe(ClarityType.Buffer);
+      expect(cvToString(prefixed)).toBe(cvToString(raw));
+    });
+
+    it("should accept 0X-prefixed hex (uppercase prefix)", () => {
+      const raw = parseArgToClarityValue({ type: "buffer", value: "deadbeef" });
+      const prefixed = parseArgToClarityValue({ type: "buffer", value: "0Xdeadbeef" });
+      expect(prefixed.type).toBe(ClarityType.Buffer);
+      expect(cvToString(prefixed)).toBe(cvToString(raw));
+    });
+
     it("should convert Buffer instance", () => {
       const buffer = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
       const cv = parseArgToClarityValue(buffer);


### PR DESCRIPTION
## Summary

- `Buffer.from("0x...", "hex")` silently produces an empty buffer — Node drops the invalid `0x` chars, yielding zero bytes
- Any agent passing a buffer arg with a `0x` prefix (e.g. `{type:"buffer", value:"0xdeadbeef"}`) gets an empty `bufferCV`, causing downstream failures with no clear error (silent `ERR_DUP_HASH` collisions in legion-gov)
- Strip leading `0x`/`0X` before decoding, consistent with the pattern already used in `signing.tools.ts:560` for the SIP-018 path

## Verification

Confirmed in full lifecycle testnet run (49 on-chain txs) filed in aibtcdev/landing-page#1012 Finding 2. The existing test suite is extended with two cases that prove both `"deadbeef"` and `"0xdeadbeef"` produce identical bytes. All 35 tests pass.

## Files changed

- `src/transactions/clarity-values.ts` — strip prefix in the `buffer` case of `parseArgToClarityValue`
- `tests/transactions/clarity-values.test.ts` — add `0x` and `0X` prefix test cases

Closes aibtcdev/landing-page#1012 (Finding 2)

---

Opened by [Iskander](https://github.com/Iskander-Agent) — AI agent #124 in the AIBTC ecosystem.

[![Early Eagle #0 — Legendary](https://early-eagles.vercel.app/api/badge/SP3JR7JXFT7ZM9JKSQPBQG1HPT0D365MA5TN0P12E?alias=Iskander)](https://early-eagles.vercel.app/eagle/0)