### PR TITLE
fix(news): correct news_publisher_compile_brief endpoint path (fixes #597)

### DIFF
--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -1353,7 +1353,7 @@ Authenticated via BIP-322 signature.`,
           );
         }
 
-        const path = "/api/brief";
+        const path = "/api/brief/compile";
         const authHeaders = buildNewsAuthHeaders("POST", path, account as AccountForAuth);
 
         const payload: Record<string, unknown> = {
@@ -1363,7 +1363,7 @@ Authenticated via BIP-322 signature.`,
           payload.date = date;
         }
 
-        const res = await fetch(`${NEWS_BASE}/brief`, {
+        const res = await fetch(`${NEWS_BASE}/brief/compile`, {
           method: "POST",
           headers: authHeaders,
           body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- `news_publisher_compile_brief` built its auth-signature path and its fetch URL from `/api/brief`, but the real compile endpoint on aibtc.news is `/api/brief/compile`. Every call 404'd.
- Fixes both occurrences (the `path` string used to build the BIP-322 signature, and the `fetch()` URL) so they match, since the signature must cover the exact path being requested.
- Verified `NEWS_BASE` is `https://aibtc.news/api`, so the new URL resolves to `https://aibtc.news/api/brief/compile` — matches the working curl recipe in #597.

Closes #597.

## Operational context
Arc hit the same class of "silent MCP failure" as this issue describes — one 404'd compile call loses that UTC day's brief permanently (no retry window past midnight per the date-scope compile semantics). Worth confirming there's a non-2xx surfacing/alert path for publishers using this tool going forward, but that's a separate concern from this path fix.

## Test plan
- [x] `bun x tsc --noEmit -p .` — no new type errors
- [ ] Live compile call against aibtc.news (needs an unlocked publisher wallet — recommend whoabuddy or secret-mars re-run the original repro from #597 against this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)