### PR TITLE
feat: register orphaned inscription tools (ordinals + child)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -41,6 +41,7 @@ import { registerNewsTools } from "./news.tools.js";
 import { registerIdentityTools } from "./identity.tools.js";
 import { registerCredentialsTools } from "./credentials.tools.js";
 import { registerSouldinalsTools } from "./souldinals.tools.js";
+import { registerOrdinalsTools } from "./ordinals.tools.js";
 import { registerChildInscriptionTools } from "./child-inscription.tools.js";
 import { registerBountyScannerTools } from "./bounty-scanner.tools.js";
 import { registerRunesTools } from "./runes.tools.js";
@@ -215,6 +216,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Credentials (encrypted credential store — list, get, set, delete, unlock)
   registerCredentialsTools(server);
+
+  // Ordinals (genesis inscriptions — taproot address, estimate fee, inscribe, reveal, lookup)
+  registerOrdinalsTools(server);
 
   // Souldinals (soul.md child inscriptions — inscribe, reveal, list, load, display traits)
   registerSouldinalsTools(server);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -41,6 +41,7 @@ import { registerNewsTools } from "./news.tools.js";
 import { registerIdentityTools } from "./identity.tools.js";
 import { registerCredentialsTools } from "./credentials.tools.js";
 import { registerSouldinalsTools } from "./souldinals.tools.js";
+import { registerChildInscriptionTools } from "./child-inscription.tools.js";
 import { registerBountyScannerTools } from "./bounty-scanner.tools.js";
 import { registerRunesTools } from "./runes.tools.js";
 import { registerInboxTools } from "./inbox.tools.js";
@@ -217,6 +218,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Souldinals (soul.md child inscriptions — inscribe, reveal, list, load, display traits)
   registerSouldinalsTools(server);
+
+  // Child inscriptions (parent-child provenance — estimate fee, commit, reveal)
+  registerChildInscriptionTools(server);
 
   // Bounty board (aibtc.com/api/bounties — list, get, submit, accept, pay, cancel, my-views)
   registerBountyScannerTools(server);


### PR DESCRIPTION
## Summary

Two tool-registration functions were defined but never wired into `registerAllTools`, so their tools were never exposed to any MCP client. This wires both in.

### `registerOrdinalsTools` (ordinals.tools.ts) — genesis inscriptions
- `get_taproot_address`
- `estimate_inscription_fee`
- `inscribe` — create a genesis (parent) inscription from arbitrary content (`image/png`, `text/html`, base64), Step 1 commit
- `inscribe_reveal` — Step 2 reveal
- `get_inscription`

Without these there was **no way to mint a genesis/parent inscription from scratch** via MCP. This also left the child/souldinals flow effectively unusable, since a child inscription requires a parent that already exists.

### `registerChildInscriptionTools` (child-inscription.tools.ts) — parent-child provenance
- `estimate_child_inscription_fee`
- `inscribe_child`
- `inscribe_child_reveal`

Defined in #254 but never registered. `skill-mappings.ts` also referenced `inscribe_child`/`inscribe_child_reveal` as if live.

## Changes

- Import + call `registerOrdinalsTools` and `registerChildInscriptionTools` in `src/tools/index.ts`.

## Verification

- `npm run build` — clean.
- `bridge --list-tools` now shows all 8 tools registered at runtime.

No new dependencies; the tool implementations and builders (`inscription-builder.ts`, `child-inscription-builder.ts`) already existed.