### PR TITLE
fix: news_publisher_compile_brief posts to wrong endpoint path (#597)

### DIFF
--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -1353,7 +1353,7 @@ Authenticated via BIP-322 signature.`,
           );
         }
 
-        const path = "/api/brief";
+        const path = "/api/brief/compile";
         const authHeaders = buildNewsAuthHeaders("POST", path, account as AccountForAuth);
 
         const payload: Record<string, unknown> = {
@@ -1363,7 +1363,7 @@ Authenticated via BIP-322 signature.`,
           payload.date = date;
         }
 
-        const res = await fetch(`${NEWS_BASE}/brief`, {
+        const res = await fetch(`${NEWS_BASE}/brief/compile`, {
           method: "POST",
           headers: authHeaders,
           body: JSON.stringify(payload),


### PR DESCRIPTION
Fixes #597.

The `news_publisher_compile_brief` tool signed and POSTed to `/api/brief`, which 404s. The real compile endpoint on aibtc.news is `/api/brief/compile`.

## Change
- BIP-322 signed path: `/api/brief` → `/api/brief/compile`
- fetch URL: `${NEWS_BASE}/brief` → `${NEWS_BASE}/brief/compile`

The signature format (`POST {path}:{unix_ts}`) was already correct; only the path was wrong. `npm run build` passes.