### PR TITLE
docs(news): compile_brief defaults to yesterday, not today

### DIFF
--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -1355,7 +1355,12 @@ Authenticated via BIP-322 signature.`,
       description: `Compile the daily intelligence brief on aibtc.news.
 
 Triggers compilation of the daily brief from approved signals. Only the publisher
-can compile briefs. If no date is provided, defaults to today.
+can compile briefs.
+
+A brief covers a complete UTC day and is compiled once — it is not recompiled, so
+signals filed after the compile cannot reach it. Compile after the day has ended.
+If no date is provided, defaults to yesterday (UTC). Passing today or a future date
+returns 400.
 
 Requires an unlocked wallet with a P2WPKH (bc1q) BTC address.
 
@@ -1364,7 +1369,10 @@ Authenticated via BIP-322 signature.`,
         date: z
           .string()
           .optional()
-          .describe("Date to compile the brief for (YYYY-MM-DD). Defaults to today."),
+          .describe(
+            "Date to compile the brief for (YYYY-MM-DD). Defaults to yesterday (UTC). " +
+              "Must be a UTC day that has already ended — today or a future date returns 400."
+          ),
       },
     },
     async ({ date }) => {


### PR DESCRIPTION
Closes #606.

## What changed

`agent-news` #869 (merged 2026-07-16T05:48Z) changed `POST /api/brief/compile`: the default target moved from today to yesterday, and `date >= today` (UTC) now returns 400.

Both description strings on `news_publisher_compile_brief` still said "defaults to today" — so the tool was telling agents to make the one call the API now rejects. This updates both to the wording proposed in #606:

- the tool description
- the `date` param's `.describe()`

Description-only. The passthrough (`if (date) payload.date = date`) was already correct — omitting `date` lets the API apply its own default, which is now the right one.

## Why the wording carries weight

A brief is compiled once and never recompiled, so compiling `date=today` mid-day permanently orphans every signal filed after it. That's what caused agent-news#815; briefs from 06-24 to 07-14 orphaned 19-93% of each day's filings. The publisher agent wasn't ignoring a rule — it called the tool the way this description told it to. #869 makes the wrong call impossible at the API; this stops advertising it.

## Verification

- `npm run build` clean.
- Confirmed both strings reach the client over a real MCP `tools/list` handshake against `dist/index.js`, rather than only checking the source.

Checked for the same stale wording elsewhere: `docs/TOOLS.md` doesn't document this tool and `skill-mappings.ts` holds only a name→skill map, so these two strings were the only occurrences. (The `arxiv-research.tools.ts` "default: today's date" hit is an unrelated digest-header label.)