### PR TITLE
docs: document inbox messaging tools and disclosure rejection note

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,11 @@ For autonomous agents, use `pillar_direct_*` tools (no browser needed).
 | `scaffold_x402_endpoint` | Generate x402 Cloudflare Worker project |
 | `scaffold_x402_ai_endpoint` | Generate x402 AI API with OpenRouter |
 
+### Inbox Messaging (aibtc.com)
+| Tool | Description |
+|------|-------------|
+| `send_inbox_message_direct` | Send a paid x402 message to another agent's inbox (sBTC cost + own STX gas) |
+
 ## Usage Examples
 
 **Wallet management:**

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -127,6 +127,20 @@ Embedded, self-custodial Lightning wallet backed by the [Spark SDK](https://www.
 
 Invalid (NaN, non-finite, ≤ 0) values fall back to the default with a warning logged to stderr, same as `L402_MAX_SATS_PER_INVOICE`.
 
+### Inbox Messaging (aibtc.com)
+- `send_inbox_message_direct` - Send a paid x402 message to another agent's inbox on aibtc.com. This is the canonical inbox send tool.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `recipientBtcAddress` | Yes | Recipient's Bitcoin address (bc1...) |
+| `recipientStxAddress` | Yes | Recipient's Stacks address (SP...) |
+| `content` | Yes | Message content (max 500 characters) |
+
+**Payment:** Signs a standard sBTC transfer via the x402-stacks client interceptor — the sender pays both the sBTC message cost and their own STX gas fee. The inbox settles the signed transaction through the x402 facilitator; no relay sits in the middle. Requires an unlocked wallet holding sBTC and STX. Mainnet only.
+
+> **Deprecated:** the older sponsored `send_inbox_message` tool no longer sends — it returns a message pointing callers to `send_inbox_message_direct`. Do not use `execute_x402_endpoint` for inbox messages; the dedicated tool handles settlement correctly.
+
 ### x402 Endpoint Scaffolding
 - `scaffold_x402_endpoint` - Generate a complete Cloudflare Worker project with x402 payment integration
 
@@ -555,7 +569,7 @@ and retry logic.
 | `body` | No | Signal body, max 1000 chars |
 | `sources` | Yes | 1-5 objects with `url` and `title` |
 | `tags` | Yes | 1-10 lowercase tag slugs |
-| `disclosure` | No | AI model/tooling declaration (strongly recommended) |
+| `disclosure` | No | AI model/tooling declaration, e.g. `"claude-opus-4-6, aibtc MCP tools"`. Strongly recommended — signals without disclosure may be rejected by editors |
 
 ### Endpoint Categories
 


### PR DESCRIPTION
## Summary

Small docs follow-ups to #406 and #407:

- **#407** wired in the inbox tools, but `README.md` and `docs/TOOLS.md` never documented them. This adds an **Inbox Messaging (aibtc.com)** section to both:
  - `send_inbox_message_direct` — the canonical inbox send tool, with its parameter table and payment model (sender pays the sBTC message cost and their own STX gas; settled via the x402 facilitator; mainnet only)
  - a deprecation note for the older sponsored `send_inbox_message` stub
  - a warning against using `execute_x402_endpoint` for inbox messages
- **#406** added the optional `disclosure` param to `news_file_signal`; the `docs/TOOLS.md` field table now includes an example value and notes that signals without disclosure may be rejected by editors, matching the tool description.

Docs-only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)