### PR TITLE
fix(x402): select payment asset in probe and execute (#613)

### DIFF
--- a/src/services/x402.service.ts
+++ b/src/services/x402.service.ts
@@ -21,7 +21,7 @@ import { getNetworkFromStacksChainId } from "../config/caip.js";
 import type { Account } from "../transactions/builder.js";
 import { getWalletManager } from "./wallet-manager.js";
 import { getSpendLimiter } from "./spend-limiter.js";
-import { formatStx, formatSbtc } from "../utils/formatting.js";
+import { formatStx, formatSbtc, formatTokenAmount } from "../utils/formatting.js";
 import { getSbtcService } from "./sbtc.service.js";
 import { getHiroApi } from "./hiro-api.js";
 import { createHash } from "crypto";
@@ -316,6 +316,8 @@ export interface CreateApiClientOptions {
    * callback aborts the payment (e.g. insufficient balance check).
    */
   onBeforePayment?: (requirements: PaymentRequirements) => Promise<void>;
+  /** Select a specific advertised payment asset by contract ID, symbol, or name. */
+  asset?: string;
   toolName?: string;
 }
 
@@ -667,15 +669,36 @@ export async function createApiClient(baseUrl?: string, options?: CreateApiClien
           );
         }
 
-        // Select first Stacks-compatible payment option
-        const selectedOption = paymentRequired.accepts.find(
+        const stacksOptions = paymentRequired.accepts.filter(
           (opt) => opt.network?.startsWith("stacks:")
         );
+        // Preserve the existing first-compatible fallback when no selector is
+        // supplied. Balance lookup is currently performed only after selection.
+        const selectedOption = selectPaymentRequirement(stacksOptions, options?.asset);
 
         if (!selectedOption) {
+          if (options?.asset) {
+            const assets = paymentRequired.accepts.map((a) => a.asset).join(", ");
+            return Promise.reject(
+              new Error(`No matching payment asset for selector "${options.asset}". Advertised assets: ${assets}`)
+            );
+          }
           const networks = paymentRequired.accepts.map((a) => a.network).join(", ");
           return Promise.reject(
             new Error(`No compatible Stacks payment option found. Available networks: ${networks}`)
+          );
+        }
+
+        // USDCx is a SIP-010 token, not native STX. The x402 executor only
+        // supports native STX and the dedicated sBTC contract path today, so
+        // fail before loading an account or constructing/signing a transaction.
+        // Falling through to detectTokenType would otherwise build an STX
+        // transfer while advertising the selected USDCx requirement.
+        if (getPaymentAssetSymbol(selectedOption.asset) === "USDCx") {
+          return Promise.reject(
+            new Error(
+              `USDCx x402 payment execution is not supported for asset "${selectedOption.asset}"`
+            )
           );
         }
 
@@ -910,7 +933,33 @@ export function formatPaymentAmount(amount: string, asset: string): string {
   if (tokenType === 'sBTC') {
     return formatSbtc(amount);
   }
-  return formatStx(amount);
+  const symbol = getPaymentAssetSymbol(asset);
+  if (symbol === 'STX') return formatStx(amount);
+  if (symbol === 'USDCx') return formatTokenAmount(amount, 6, symbol);
+  return `${amount} ${symbol}`;
+}
+
+/** Return a stable display/matching symbol from an advertised asset identifier. */
+export function getPaymentAssetSymbol(asset: string): string {
+  const normalized = asset.trim().toLowerCase();
+  const parts = normalized.split(/\.|::/).filter(Boolean);
+  if (normalized === 'stx' || parts.includes('stx')) return 'STX';
+  if (normalized === 'sbtc' || parts.some((part) => part === 'sbtc' || part === 'sbtc-token' || part === 'token-sbtc')) return 'sBTC';
+  if (normalized === 'usdcx' || parts.some((part) => part === 'usdcx' || part === 'usdcx-token' || part === 'token-usdcx')) return 'USDCx';
+  return asset.includes('::') ? asset.split('::').at(-1)! : asset.split('.').at(-1)!;
+}
+
+/** Select an advertised requirement by full contract ID or common symbol/name. */
+export function selectPaymentRequirement<T extends { asset: string }>(
+  accepts: T[],
+  selector?: string
+): T | undefined {
+  if (!selector) return accepts[0];
+  const normalizedSelector = selector.trim().toLowerCase();
+  return accepts.find((entry) =>
+    entry.asset.trim().toLowerCase() === normalizedSelector ||
+    getPaymentAssetSymbol(entry.asset).toLowerCase() === normalizedSelector
+  );
 }
 
 /**
@@ -922,8 +971,9 @@ export async function probeEndpoint(options: {
   url: string;
   params?: Record<string, string>;
   data?: Record<string, unknown>;
+  asset?: string;
 }): Promise<ProbeResult> {
-  const { method, url, params, data } = options;
+  const { method, url, params, data, asset } = options;
   const axiosInstance = createBaseAxiosInstance();
 
   try {
@@ -945,7 +995,13 @@ export async function probeEndpoint(options: {
 
       // If v2 header is successfully parsed, use it
       if (paymentRequired?.accepts?.length) {
-        const acceptedPayment = paymentRequired.accepts[0];
+        // The probe has no safe, side-effect-free multi-token balance snapshot,
+        // so omission intentionally preserves the first-advertised fallback.
+        const acceptedPayment = selectPaymentRequirement(paymentRequired.accepts, asset);
+        if (!acceptedPayment) {
+          const assets = paymentRequired.accepts.map((entry) => entry.asset).join(', ');
+          throw new Error(`No matching payment asset for selector "${asset}". Advertised assets: ${assets}`);
+        }
 
         // Convert CAIP-2 network identifier to human-readable format
         const network = getNetworkFromStacksChainId(acceptedPayment.network) ?? NETWORK;
@@ -978,6 +1034,10 @@ export async function probeEndpoint(options: {
           `Invalid 402 response from ${url}: missing payment fields in both v2 header and v1 body. ` +
           `v2 header: ${headerDebug}; v1 body keys: ${Object.keys(paymentData as object).join(', ') || 'none'}`
         );
+      }
+
+      if (asset && !selectPaymentRequirement([{ asset: paymentData.asset }], asset)) {
+        throw new Error(`No matching payment asset for selector "${asset}". Advertised asset: ${paymentData.asset}`);
       }
 
       return {

--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -85,6 +85,7 @@ function buildCallWith(options: {
   apiUrl?: string;
   params?: Record<string, string>;
   data?: Record<string, unknown>;
+  asset?: string;
 }): Record<string, unknown> {
   const callWith: Record<string, unknown> = { method: options.method, autoApprove: true };
   if (options.url) callWith.url = options.url;
@@ -92,6 +93,7 @@ function buildCallWith(options: {
   if (options.apiUrl) callWith.apiUrl = options.apiUrl;
   if (options.params && Object.keys(options.params).length > 0) callWith.params = options.params;
   if (options.data && Object.keys(options.data).length > 0) callWith.data = options.data;
+  if (options.asset) callWith.asset = options.asset;
   return callWith;
 }
 
@@ -301,6 +303,10 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
           .record(z.string(), z.unknown())
           .optional()
           .describe("Request body for POST/PUT requests"),
+        asset: z
+          .string()
+          .optional()
+          .describe("Payment asset selector (full contract ID or common symbol/name such as sBTC, USDCx, or STX). When omitted, uses the first advertised compatible asset."),
         autoApprove: z
           .boolean()
           .optional()
@@ -308,7 +314,7 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
           .describe("Skip cost probe and execute immediately. When false (default), probes first and returns cost info for paid endpoints. When true, executes atomically like before. Free endpoints always execute transparently."),
       },
     },
-    async ({ method, url, path, apiUrl, params, data, autoApprove }) => {
+    async ({ method, url, path, apiUrl, params, data, asset, autoApprove }) => {
       let fullUrl = "";
 
       try {
@@ -317,8 +323,8 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
         params = parsed.params;
 
         if (!autoApprove) {
-          const probeResult = await probeEndpoint({ method, url: fullUrl, params, data });
-          return formatProbeResponse(probeResult, method, fullUrl, { method, url, path, apiUrl, params, data });
+          const probeResult = await probeEndpoint({ method, url: fullUrl, params, data, asset });
+          return formatProbeResponse(probeResult, method, fullUrl, { method, url, path, apiUrl, params, data, asset });
         }
 
         // autoApprove=true: check dedup cache before any network request, then execute
@@ -337,6 +343,7 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
 
         const api = await createApiClient(parsed.baseUrl, {
           toolName: "execute_x402_endpoint",
+          asset,
           onBeforePayment: async (requirements) => {
             // Non-sponsored: sender pays its own gas, so validate STX for the
             // fee too (sponsored=false is the default, passed explicitly here).
@@ -532,9 +539,13 @@ Supported sources:
           .record(z.string(), z.unknown())
           .optional()
           .describe("Request body for POST/PUT requests"),
+        asset: z
+          .string()
+          .optional()
+          .describe("Payment asset selector (full contract ID or common symbol/name such as sBTC, USDCx, or STX). When omitted, uses the first advertised asset."),
       },
     },
-    async ({ method, url, path, apiUrl, params, data }) => {
+    async ({ method, url, path, apiUrl, params, data, asset }) => {
       let fullUrl = "";
 
       try {
@@ -542,8 +553,8 @@ Supported sources:
         fullUrl = parsed.fullUrl;
         params = parsed.params;
 
-        const result = await probeEndpoint({ method, url: fullUrl, params, data });
-        return formatProbeResponse(result, method, fullUrl, { method, url, path, apiUrl, params, data });
+        const result = await probeEndpoint({ method, url: fullUrl, params, data, asset });
+        return formatProbeResponse(result, method, fullUrl, { method, url, path, apiUrl, params, data, asset });
       } catch (error) {
         return formatEndpointError(error, fullUrl || "unknown");
       }

--- a/tests/services/x402-prevalidation.test.ts
+++ b/tests/services/x402-prevalidation.test.ts
@@ -34,6 +34,7 @@ const {
   recordTransaction,
   detectTokenType,
   formatPaymentAmount,
+  selectPaymentRequirement,
   createApiClient,
   getAccount,
 } = await import("../../src/services/x402.service.js");
@@ -100,6 +101,34 @@ describe("formatPaymentAmount", () => {
   it("formats sBTC amounts from sats", () => {
     expect(formatPaymentAmount("100", "sbtc")).toBe("0.000001 sBTC");
     expect(formatPaymentAmount("100000000", "sbtc")).toBe("1 sBTC");
+  });
+
+  it("never labels USDCx as STX", () => {
+    expect(formatPaymentAmount("1500000", "SP123.usdcx::usdcx")).toBe("1.5 USDCx");
+  });
+});
+
+describe("selectPaymentRequirement", () => {
+  const accepts = [
+    { asset: "STX", amount: "1000" },
+    { asset: "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::token-sbtc", amount: "100" },
+    { asset: "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx", amount: "500000" },
+  ];
+
+  it("selects sBTC from a multi-asset manifest by symbol", () => {
+    expect(selectPaymentRequirement(accepts, "sBTC")).toBe(accepts[1]);
+  });
+
+  it("matches a full contract asset identifier case-insensitively", () => {
+    expect(selectPaymentRequirement(accepts, accepts[2].asset.toLowerCase())).toBe(accepts[2]);
+  });
+
+  it("returns no match for an unadvertised selector", () => {
+    expect(selectPaymentRequirement(accepts, "not-a-token")).toBeUndefined();
+  });
+
+  it("preserves the first-advertised fallback when omitted", () => {
+    expect(selectPaymentRequirement(accepts)).toBe(accepts[0]);
   });
 });
 
@@ -609,6 +638,29 @@ describe("x402 per-payment spend cap", () => {
     const client = await createApiClient("https://x402.test.com");
     client.defaults.adapter = make402Adapter("sbtc", "20000"); // > 10k sats default cap
     await expect(client.get("/test")).rejects.toThrow("exceeds the per-payment cap");
+  });
+
+  it("returns a clear error when the selected asset is not advertised", async () => {
+    const client = await createApiClient("https://x402.test.com", { asset: "sBTC" });
+    client.defaults.adapter = make402Adapter("STX", "1000");
+    await expect(client.get("/test")).rejects.toThrow(
+      'No matching payment asset for selector "sBTC". Advertised assets: STX'
+    );
+  });
+
+  it("fails closed before constructing a payment for an explicit USDCx selection", async () => {
+    const usdcxAsset = "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx::usdcx";
+    const client = await createApiClient("https://x402.test.com", { asset: "USDCx" });
+    client.defaults.adapter = make402Adapter(usdcxAsset, "500000");
+
+    await expect(client.get("/test")).rejects.toThrow(
+      `USDCx x402 payment execution is not supported for asset "${usdcxAsset}"`
+    );
+    // The guard runs before account access and therefore before either the
+    // native STX or contract-call transaction builder can be reached.
+    expect(mockGetActiveAccount).not.toHaveBeenCalled();
+    expect(mockGetStxBalance).not.toHaveBeenCalled();
+    expect(mockGetMempoolFees).not.toHaveBeenCalled();
   });
 
   it("does not block payments at the cap", async () => {

--- a/tests/tools/endpoint-x402-success.test.ts
+++ b/tests/tools/endpoint-x402-success.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockCreateApiClient = vi.fn();
+const mockProbeEndpoint = vi.fn();
 const mockCheckSufficientBalance = vi.fn();
 const mockGenerateDedupKey = vi.fn(() => "dedup-key-success");
 const mockCheckDedupCache = vi.fn(() => null);
@@ -9,7 +10,7 @@ const mockRecordTransaction = vi.fn();
 vi.mock("../../src/services/x402.service.js", () => ({
   createApiClient: mockCreateApiClient,
   API_URL: "https://aibtc.com",
-  probeEndpoint: vi.fn(),
+  probeEndpoint: mockProbeEndpoint,
   formatPaymentAmount: vi.fn((amount: string, asset: string) => `${amount} ${asset}`),
   checkSufficientBalance: mockCheckSufficientBalance,
   generateDedupKey: mockGenerateDedupKey,
@@ -67,6 +68,33 @@ function buildOkResponse(opts: {
 describe("execute_x402_endpoint success-path txid handling (#487 Gap 1)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("carries the selected probe asset into callWith and keeps display/payment consistent", async () => {
+    const contract = "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::token-sbtc";
+    mockProbeEndpoint.mockResolvedValue({
+      type: "payment_required",
+      amount: "100",
+      asset: contract,
+      recipient: "SP000000000000000000002Q6VF78",
+      network: "mainnet",
+      endpoint: "https://example.com/paid",
+    });
+
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerEndpointTools(server as any);
+    const result = (await tools.get("probe_x402_endpoint")!.handler({
+      method: "GET",
+      url: "https://example.com/paid",
+      asset: "sBTC",
+    })) as { content: Array<{ text: string }> };
+    const body = JSON.parse(result.content[0].text);
+
+    expect(mockProbeEndpoint).toHaveBeenCalledWith(expect.objectContaining({ asset: "sBTC" }));
+    expect(body.payment).toMatchObject({ amount: "100", asset: contract });
+    expect(body.message).toContain(`100 ${contract}`);
+    expect(body.callWith.asset).toBe("sBTC");
   });
 
   it("returns the real txid when the upstream response exposes one", async () => {


### PR DESCRIPTION
## Summary

- add an optional `asset` selector to `probe_x402_endpoint` and `execute_x402_endpoint`
- match advertised requirements by full contract ID or the common `STX`, `sBTC`, and `USDCx` symbols
- carry the selector from a probe response into its executable `callWith` parameters
- derive the displayed amount and currency from the same selected requirement returned in `payment`
- return a clear error listing advertised assets when the requested asset is unavailable
- preserve and document the existing first-advertised/first-compatible fallback when no selector is supplied

Explicit USDCx execution now fails closed before wallet access or transaction construction. The existing executor has native STX and dedicated sBTC payment builders but no safely capped generic SIP-010 payment path; previously, USDCx could fall through to a native STX transfer. Probing and display still select and report USDCx correctly.

Fixes #613.

## Verification

Run in a network-isolated transient systemd unit without wallet or home-directory access:

```text
npm run build -- --noEmit
success

npm test
Test Files  33 passed | 1 skipped (34)
Tests       536 passed | 4 skipped (540)
```

Focused selector and endpoint tests:

```text
Test Files  2 passed (2)
Tests       49 passed (49)
```

The regression coverage includes symbol/full-ID matching, omission fallback, unavailable selectors, selected-asset propagation through `callWith`, display consistency, and a guard proving USDCx cannot reach the native STX transaction path.

## Live reproducer

With this branch loaded:

```text
probe_x402_endpoint(
  url="https://arc0btc.com/api/reports/arc-field-guide",
  asset="sBTC"
)
```

returned:

```json
{
  "type": "payment_required",
  "amount": "45385",
  "asset": "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token",
  "recipient": "SP2GHQRCRMYY4S8PMBR49BEKX144VR437YT42SF3B",
  "network": "mainnet",
  "endpoint": "https://arc0btc.com/api/reports/arc-field-guide",
  "formatted": "0.00045385 sBTC"
}
```

The selected machine-readable asset and formatted display now agree, and the sBTC requirement is selected instead of the manifest's first USDCx entry.
