### PR TITLE
fix(dual-stacking): decode Clarity tuples from cvToJSON's nested shape (#611)

### DIFF
--- a/src/tools/dual-stacking.tools.ts
+++ b/src/tools/dual-stacking.tools.ts
@@ -24,9 +24,69 @@ const DUAL_STACKING_ADDRESS = "SP1HFCRKEJ8BYW4D0E3FAWHFDX8A25PPAA83HWWZ9";
 const DUAL_STACKING_CONTRACT = "dual-stacking-v2_0_4";
 const DUAL_STACKING_CONTRACT_ID = `${DUAL_STACKING_ADDRESS}.${DUAL_STACKING_CONTRACT}`;
 
+/** APR fields are fixed-point, scaled by 1e6 (500000 => 0.5%). */
+const APR_DIVISOR = 1_000_000;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Unwrap a `cvToJSON` tuple into its field map.
+ *
+ * cvToJSON renders a tuple as `{ type: "(tuple ...)", value: { FIELD: { type, value } } }`
+ * — the fields sit one level down under `.value`, keyed by their on-wire Clarity
+ * name. Reading them off the top-level object silently yields `undefined` for
+ * every field, which is how #611 turned real APR/cycle data into zeros.
+ */
+function tupleFields(
+  raw: unknown
+): Record<string, { value?: unknown } | undefined> | null {
+  if (!raw || typeof raw !== "object") return null;
+  const inner = (raw as { value?: unknown }).value;
+  if (!inner || typeof inner !== "object") return null;
+  return inner as Record<string, { value?: unknown } | undefined>;
+}
+
+/**
+ * Read a uint field out of a tuple field map. Returns null and records the key
+ * in `missing` when absent or non-numeric, so a decode miss surfaces as a
+ * warning instead of a plausible-looking zero.
+ */
+function tupleUint(
+  fields: Record<string, { value?: unknown } | undefined> | null,
+  key: string,
+  missing: string[]
+): number | null {
+  const raw = fields?.[key]?.value;
+  if (raw === undefined || raw === null) {
+    missing.push(key);
+    return null;
+  }
+  const num = Number(raw);
+  if (!Number.isFinite(num)) {
+    missing.push(key);
+    return null;
+  }
+  return num;
+}
+
+/**
+ * Unwrap a `cvToJSON` optional. `(some u123)` renders as
+ * `{ type: "(optional uint)", value: { type: "uint", value: "123" } }` and
+ * `none` as a null/undefined `.value`, so the payload needs one extra hop.
+ */
+function optionalUint(raw: unknown): number | null {
+  if (!raw || typeof raw !== "object") return null;
+  const inner = (raw as { value?: unknown }).value;
+  if (inner === undefined || inner === null) return null;
+  // `some` wraps the payload in another {type, value} envelope.
+  const scalar =
+    typeof inner === "object" ? (inner as { value?: unknown }).value : inner;
+  if (scalar === undefined || scalar === null) return null;
+  const num = Number(scalar);
+  return Number.isFinite(num) ? num : null;
+}
 
 /**
  * Call a read-only function on the dual-stacking contract and return a JSON-friendly value.
@@ -131,49 +191,70 @@ Note: Dual Stacking is only available on mainnet.`,
           cycleOverviewRaw,
         ] = values;
 
-        // Parse APR data — returns {min-apr: uint, max-apr: uint} divided by 1_000_000 for %
-        let apr: { minApr: number; maxApr: number; unit: string; note: string } = {
-          minApr: 0,
-          maxApr: 0,
-          unit: "%",
-          note: "Multiplier up to 10x with stacked STX",
-        };
-        if (aprDataRaw && typeof aprDataRaw === "object") {
-          const aprObj = aprDataRaw as Record<string, { value?: string | number }>;
-          const minAprRaw = aprObj["min-apr"]?.value;
-          const maxAprRaw = aprObj["max-apr"]?.value;
+        // Parse APR data — tuple {MAX_APR: uint, MIN_APR: uint, MULTIPLIER: uint}.
+        // Keys are the uppercase on-wire Clarity names, not the camelCase output
+        // names. A field that fails to decode stays null and is named in
+        // `warnings` — a zero here reads as "0% APR, don't enroll" (#611).
+        let apr: {
+          minApr: number | null;
+          maxApr: number | null;
+          multiplier: number | null;
+          unit: string;
+          note: string;
+        } | null = null;
+        if (aprDataRaw) {
+          const missing: string[] = [];
+          const fields = tupleFields(aprDataRaw);
+          const minApr = tupleUint(fields, "MIN_APR", missing);
+          const maxApr = tupleUint(fields, "MAX_APR", missing);
+          const multiplier = tupleUint(fields, "MULTIPLIER", missing);
+          if (missing.length > 0) {
+            warnings.push(
+              `get-apr-data: could not decode tuple field(s): ${missing.join(", ")}`
+            );
+          }
           apr = {
-            minApr: minAprRaw !== undefined ? Number(minAprRaw) / 1_000_000 : 0,
-            maxApr: maxAprRaw !== undefined ? Number(maxAprRaw) / 1_000_000 : 0,
+            minApr: minApr === null ? null : minApr / APR_DIVISOR,
+            maxApr: maxApr === null ? null : maxApr / APR_DIVISOR,
+            multiplier,
             unit: "%",
-            note: "Multiplier up to 10x with stacked STX",
+            note: `Multiplier up to ${multiplier ?? 10}x with stacked STX`,
           };
         }
 
-        // Parse cycle overview — returns tuple with cycle-id, snapshot-index, snapshots-per-cycle
+        // Parse cycle overview — tuple {cycle-id, snapshot-index, snapshots-per-cycle}
         let cycleOverview: {
-          currentCycleId: number;
-          snapshotIndex: number;
-          snapshotsPerCycle: number;
-        } = { currentCycleId: 0, snapshotIndex: 0, snapshotsPerCycle: 0 };
-        if (cycleOverviewRaw && typeof cycleOverviewRaw === "object") {
-          const co = cycleOverviewRaw as Record<string, { value?: string | number }>;
+          currentCycleId: number | null;
+          snapshotIndex: number | null;
+          snapshotsPerCycle: number | null;
+        } | null = null;
+        if (cycleOverviewRaw) {
+          const missing: string[] = [];
+          const fields = tupleFields(cycleOverviewRaw);
           cycleOverview = {
-            currentCycleId: co["cycle-id"]?.value !== undefined ? Number(co["cycle-id"].value) : 0,
-            snapshotIndex:
-              co["snapshot-index"]?.value !== undefined ? Number(co["snapshot-index"].value) : 0,
-            snapshotsPerCycle:
-              co["snapshots-per-cycle"]?.value !== undefined
-                ? Number(co["snapshots-per-cycle"].value)
-                : 0,
+            currentCycleId: tupleUint(fields, "cycle-id", missing),
+            snapshotIndex: tupleUint(fields, "snapshot-index", missing),
+            snapshotsPerCycle: tupleUint(fields, "snapshots-per-cycle", missing),
           };
+          if (missing.length > 0) {
+            warnings.push(
+              `current-overview-data: could not decode tuple field(s): ${missing.join(", ")}`
+            );
+          }
         }
 
-        // Parse minimum enrollment amount
-        let minimumEnrollmentSats = 0;
+        // Parse minimum enrollment amount (plain uint — one {type, value} level)
+        let minimumEnrollmentSats: number | null = null;
         if (minimumAmountRaw !== null && minimumAmountRaw !== undefined) {
-          const raw = minimumAmountRaw as { value?: string | number };
-          minimumEnrollmentSats = raw.value !== undefined ? Number(raw.value) : 0;
+          const raw = (minimumAmountRaw as { value?: unknown }).value;
+          const num = Number(raw);
+          if (raw === undefined || raw === null || !Number.isFinite(num)) {
+            warnings.push(
+              "get-minimum-enrollment-amount: could not decode uint result"
+            );
+          } else {
+            minimumEnrollmentSats = num;
+          }
         }
 
         // Parse boolean enrollment flags. A failed read stays null (unknown)
@@ -250,13 +331,10 @@ Note: Dual Stacking is only available on mainnet.`,
           ]
         );
 
-        let rewardSats = 0;
-        if (rewardRaw !== null && rewardRaw !== undefined) {
-          const raw = rewardRaw as { value?: string | number };
-          rewardSats = raw.value !== undefined ? Number(raw.value) : 0;
-        }
-
-        const rewardBtc = rewardSats / 100_000_000;
+        // Contract returns `(optional uint)` — `none` means no reward recorded
+        // for this cycle/address, which is distinct from a zero reward.
+        const rewardSats = optionalUint(rewardRaw);
+        const rewardBtc = rewardSats === null ? null : rewardSats / 100_000_000;
 
         return createJsonResponse({
           address: resolvedAddress,

--- a/tests/tools/dual-stacking-status.test.ts
+++ b/tests/tools/dual-stacking-status.test.ts
@@ -7,9 +7,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const ADDR = "SP20GPDS5RYB2DV03KG4W08EG6HD11KYPK6FQJE1";
 
-// Clarity hex fixtures (serialized ClarityValues).
+// Clarity hex fixtures (serialized ClarityValues), captured from mainnet
+// `/v2/contracts/call-read` responses.
 const CV_BOOL_FALSE = "04";
 const CV_UINT_10000 = "0100000000000000000000000000002710"; // u10000
+
+// (tuple (MAX_APR u5000000) (MIN_APR u500000) (MULTIPLIER u10))
+const CV_APR_TUPLE =
+  "0c00000003074d41585f41505201000000000000000000000000004c4b40074d494e5f415052010000000000000000000000000007a1200a4d554c5449504c494552010000000000000000000000000000000a";
+// (tuple (cycle-id u7) (snapshot-index u13) (snapshots-per-cycle u14))
+const CV_OVERVIEW_TUPLE =
+  "0c00000003086379636c652d696401000000000000000000000000000000070e736e617073686f742d696e646578010000000000000000000000000000000d13736e617073686f74732d7065722d6379636c65010000000000000000000000000000000e";
 
 const mockCallReadOnly = vi.fn();
 vi.mock("../../src/services/hiro-api.js", () => ({
@@ -61,9 +69,9 @@ describe("dual_stacking_status resilience (#554)", () => {
           case "get-minimum-enrollment-amount":
             return { okay: true, result: `0x${CV_UINT_10000}` };
           case "get-apr-data":
-            return { okay: true, result: `0x${CV_UINT_10000}` };
+            return { okay: true, result: `0x${CV_APR_TUPLE}` };
           case "current-overview-data":
-            return { okay: true, result: `0x${CV_UINT_10000}` };
+            return { okay: true, result: `0x${CV_OVERVIEW_TUPLE}` };
           default:
             throw new Error(`unexpected fn ${fn}`);
         }
@@ -94,6 +102,10 @@ describe("dual_stacking_status resilience (#554)", () => {
     mockCallReadOnly.mockImplementation(async (_c: string, fn: string) => {
       if (fn === "is-enrolled-this-cycle" || fn === "is-enrolled-in-next-cycle")
         return { okay: true, result: `0x${CV_BOOL_FALSE}` };
+      if (fn === "get-apr-data")
+        return { okay: true, result: `0x${CV_APR_TUPLE}` };
+      if (fn === "current-overview-data")
+        return { okay: true, result: `0x${CV_OVERVIEW_TUPLE}` };
       return { okay: true, result: `0x${CV_UINT_10000}` };
     });
 
@@ -101,5 +113,108 @@ describe("dual_stacking_status resilience (#554)", () => {
     const body = JSON.parse(res.content[0].text);
     expect(body.enrolledThisCycle).toBe(false);
     expect(body.warnings).toBeUndefined();
+  });
+});
+
+// cvToJSON nests tuple fields under `.value`, keyed by the on-wire Clarity name.
+// Reading them off the top-level object returned `undefined` for every field,
+// which the old `?? 0` fallbacks turned into a confident-looking 0% APR (#611).
+describe("dual_stacking_status tuple decoding (#611)", () => {
+  let statusTool: RegisteredTool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCallReadOnly.mockImplementation(async (_c: string, fn: string) => {
+      switch (fn) {
+        case "is-enrolled-this-cycle":
+        case "is-enrolled-in-next-cycle":
+          return { okay: true, result: `0x${CV_BOOL_FALSE}` };
+        case "get-minimum-enrollment-amount":
+          return { okay: true, result: `0x${CV_UINT_10000}` };
+        case "get-apr-data":
+          return { okay: true, result: `0x${CV_APR_TUPLE}` };
+        case "current-overview-data":
+          return { okay: true, result: `0x${CV_OVERVIEW_TUPLE}` };
+        default:
+          throw new Error(`unexpected fn ${fn}`);
+      }
+    });
+    const { server, tools } = createTrackingServer();
+    registerDualStackingTools(server as never);
+    statusTool = tools.get("dual_stacking_status")!;
+  });
+
+  it("decodes the APR tuple from its uppercase on-wire keys", async () => {
+    const body = JSON.parse((await statusTool.handler({})).content[0].text);
+    // Raw u500000 / u5000000 scaled down by the 1e6 APR divisor.
+    expect(body.apr.minApr).toBe(0.5);
+    expect(body.apr.maxApr).toBe(5);
+    expect(body.apr.multiplier).toBe(10);
+    expect(body.warnings).toBeUndefined();
+  });
+
+  it("decodes the cycle overview tuple", async () => {
+    const body = JSON.parse((await statusTool.handler({})).content[0].text);
+    expect(body.cycleOverview).toEqual({
+      currentCycleId: 7,
+      snapshotIndex: 13,
+      snapshotsPerCycle: 14,
+    });
+  });
+
+  it("reports undecodable tuple fields as null plus a warning, never as 0", async () => {
+    // A tuple whose keys don't match what the wrapper expects — the exact shape
+    // that previously produced a silent, authoritative-looking 0.
+    // (tuple (WRONG_KEY u1))
+    const CV_WRONG_TUPLE =
+      "0c0000000109" + "57524f4e475f4b45590100000000000000000000000000000001";
+    mockCallReadOnly.mockImplementation(async (_c: string, fn: string) => {
+      if (fn === "get-apr-data")
+        return { okay: true, result: `0x${CV_WRONG_TUPLE}` };
+      if (fn === "current-overview-data")
+        return { okay: true, result: `0x${CV_OVERVIEW_TUPLE}` };
+      if (fn === "get-minimum-enrollment-amount")
+        return { okay: true, result: `0x${CV_UINT_10000}` };
+      return { okay: true, result: `0x${CV_BOOL_FALSE}` };
+    });
+
+    const body = JSON.parse((await statusTool.handler({})).content[0].text);
+    expect(body.apr.minApr).toBeNull();
+    expect(body.apr.maxApr).toBeNull();
+    expect(body.warnings.join(" ")).toMatch(/get-apr-data/);
+    expect(body.warnings.join(" ")).toMatch(/MIN_APR/);
+  });
+});
+
+describe("dual_stacking_get_rewards optional decoding (#611)", () => {
+  let rewardsTool: RegisteredTool;
+
+  // (some u45385) — the contract returns `(optional uint)`, so the payload sits
+  // one envelope deeper than a bare uint.
+  const CV_SOME_45385 = "0a010000000000000000000000000000b149";
+  const CV_NONE = "09";
+
+  function mount() {
+    const { server, tools } = createTrackingServer();
+    registerDualStackingTools(server as never);
+    rewardsTool = tools.get("dual_stacking_get_rewards")!;
+  }
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("unwraps (some uint) instead of yielding NaN", async () => {
+    mockCallReadOnly.mockResolvedValue({ okay: true, result: `0x${CV_SOME_45385}` });
+    mount();
+    const body = JSON.parse((await rewardsTool.handler({ cycle: 7 })).content[0].text);
+    expect(body.rewardSats).toBe(45385);
+    expect(body.rewardBtc).toBeCloseTo(0.00045385, 10);
+  });
+
+  it("reports none as null rather than a zero reward", async () => {
+    mockCallReadOnly.mockResolvedValue({ okay: true, result: `0x${CV_NONE}` });
+    mount();
+    const body = JSON.parse((await rewardsTool.handler({ cycle: 7 })).content[0].text);
+    expect(body.rewardSats).toBeNull();
+    expect(body.rewardBtc).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #611.

## Root cause

`cvToJSON` renders a Clarity tuple as `{ type: "(tuple ...)", value: { FIELD: { type, value } } }` — fields sit one level down under `.value`. The status handler indexed the top-level object directly, so every tuple field resolved to `undefined` and the `?? 0` fallbacks turned it into an authoritative-looking `0`.

There was a second fault on the APR read: the wrapper looked up `min-apr`/`max-apr`, but the contract's on-wire keys are uppercase. Confirmed against the deployed interface:

```
get-apr-data          -> (tuple (MAX_APR uint) (MIN_APR uint) (MULTIPLIER uint))
current-overview-data -> (tuple (cycle-id uint) (snapshot-index uint) (snapshots-per-cycle uint))
```

`minimumEnrollmentSats` was unaffected because a bare `uint` really is `{type, value}` — matching the reporter's observation that simple types survive and tuples zero out.

## Also fixed

`dual_stacking_get_rewards` has the same nesting bug. `reward-amount-for-cycle-and-address` returns `(optional uint128)`, so `Number(raw.value)` was `Number({type,value})` → `NaN` → `rewardSats: null` on every actual reward, while `none` collapsed to `0`. Now unwrapped properly; `none` reports `null` (no reward recorded) rather than a zero reward.

## Behavior change

Fields that fail to decode are now `null` with a `warnings[]` entry naming the read and the missing keys, instead of `0`. Per the issue: a misleading `0%` APR is worse than a visible failure, since an agent asking "should I enroll?" reasonably concludes no. `apr.multiplier` is now surfaced.

## Verification

Live mainnet run of the patched handler:

```json
{
  "minimumEnrollmentSats": 10000,
  "apr": { "minApr": 0.5, "maxApr": 5, "multiplier": 10, "unit": "%" },
  "cycleOverview": { "currentCycleId": 7, "snapshotIndex": 13, "snapshotsPerCycle": 14 }
}
```

Matches the expected-values table in the issue. The pre-existing `is-enrolled-this-cycle` / `AtBlockUnavailable` warning is unchanged.

The existing tests fed a bare `uint` fixture for both tuple reads, which is why this shipped green — fixtures are now real mainnet tuple hex, plus coverage for the wrong-key path and both optional branches. 537 tests pass.