### PR TITLE
feat(news): add accepted signal filter

### DIFF
--- a/src/tools/news.tools.ts
+++ b/src/tools/news.tools.ts
@@ -270,7 +270,7 @@ export function registerNewsTools(server: McpServer): void {
 
 Supports optional filters:
 - beat: filter by beat slug — active beats: "aibtc-network", "bitcoin-macro", "quantum". Retired beats return 410 Gone.
-- status: filter by signal status (e.g. "submitted", "approved", "rejected")
+- status: filter by signal status (e.g. "submitted", "approved", "rejected"). Use "accepted" to include both approved and brief_included signals.
 - agent: filter by BTC address of the correspondent
 - tag: filter by tag slug
 - since: ISO timestamp — only return signals newer than this
@@ -285,9 +285,9 @@ No authentication required.`,
           .optional()
           .describe("Filter by beat slug — active beats: aibtc-network, bitcoin-macro, quantum. Retired legacy slugs return 410 Gone."),
         status: z
-          .enum(["submitted", "approved", "replaced", "rejected", "brief_included"])
+          .enum(["submitted", "approved", "replaced", "rejected", "brief_included", "accepted"])
           .optional()
-          .describe("Filter by signal status (e.g. 'submitted' for pending review)"),
+          .describe("Filter by signal status; 'accepted' includes approved and brief_included signals"),
         agent: z
           .string()
           .optional()

--- a/tests/tools/news-list-signals.test.ts
+++ b/tests/tools/news-list-signals.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { registerNewsTools } from "../../src/tools/news.tools.js";
+
+interface RegisteredTool {
+  config: {
+    inputSchema: Record<string, { safeParse: (value: unknown) => { success: boolean } }>;
+  };
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+function createTrackingServer() {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    registerTool: vi.fn(
+      (
+        name: string,
+        config: RegisteredTool["config"],
+        handler: RegisteredTool["handler"]
+      ) => {
+        tools.set(name, { config, handler });
+      }
+    ),
+  };
+
+  return { server, tools };
+}
+
+describe("news_list_signals accepted filter", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("exposes accepted as a valid read-only status and forwards it to the API", async () => {
+    const { server, tools } = createTrackingServer();
+    registerNewsTools(server as never);
+
+    const tool = tools.get("news_list_signals");
+    if (!tool) throw new Error("news_list_signals was not registered");
+
+    expect(tool.config.inputSchema.status.safeParse("accepted").success).toBe(true);
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ signals: [], total: 0 }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await tool.handler({
+      status: "accepted",
+      agent: "bc1qexample",
+      since: "2026-07-14T12:10:00Z",
+      limit: 50,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [requestUrl] = fetchMock.mock.calls[0] as unknown as [string];
+    const url = new URL(requestUrl);
+    expect(url.searchParams.get("status")).toBe("accepted");
+    expect(url.searchParams.get("agent")).toBe("bc1qexample");
+    expect(url.searchParams.get("since")).toBe("2026-07-14T12:10:00Z");
+    expect(url.searchParams.get("limit")).toBe("50");
+  });
+});


### PR DESCRIPTION
## Summary

Add `accepted` to the read-only `news_list_signals` status filter and document it as the union of `approved` and `brief_included`.

## Why

Editorially accepted signals transition from `approved` to `brief_included` after brief compilation. The companion agent-news change proposed in [agent-news#873](https://github.com/aibtcdev/agent-news/issues/873) and implemented by [agent-news#880](https://github.com/aibtcdev/agent-news/pull/880) adds a virtual `status=accepted` API filter. Without this MCP schema update, clients cannot request that new filter through `news_list_signals`.

## Impact

- Existing exact status values remain unchanged.
- `accepted` is exposed only as a list filter; it is not a stored lifecycle state.
- The handler forwards `status=accepted` with the other query parameters unchanged.

## Validation

- `vitest run tests/tools/news-list-signals.test.ts tests/tools/tool-registration.test.ts tests/tools/register-all.test.ts` — 11/11 passed
- `tsc` — passed
- `git diff --check origin/main...HEAD` — passed

AI assistance disclosure: implementation, tests, and PR wording were prepared with GPT-5 Codex and verified locally against the repository's pinned dependencies.