### PR TITLE
chore(deps): bump @aibtc/tx-schemas to ^1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.64.2",
       "license": "MIT",
       "dependencies": {
-        "@aibtc/tx-schemas": "^0.7.0",
+        "@aibtc/tx-schemas": "^1.1.0",
         "@bitflowlabs/core-sdk": "^3.0.0",
         "@buildonspark/spark-sdk": "^0.7.14",
         "@faktoryfun/styx-sdk": "^1.3.5",
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@aibtc/tx-schemas": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.7.0.tgz",
-      "integrity": "sha512-6q8FnEuwRV1OZ3b9uQ831vSdi7a2LdwS9twoSld5r8UIR2T/wH9WO5iTGsDlFmsP//4GtEUjX5HYX/KsKd+NsQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-1.1.0.tgz",
+      "integrity": "sha512-jCautY4s8xT6oYC6l5d5tR9pbKTIziyny3YFI77mcmkoCzZzw7oedARYARuw1DSyxcHpXVoRTL0VM6MlTYA3LQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/aibtcdev/aibtc-mcp-server#readme",
   "license": "MIT",
   "dependencies": {
-    "@aibtc/tx-schemas": "^0.7.0",
+    "@aibtc/tx-schemas": "^1.1.0",
     "@bitflowlabs/core-sdk": "^3.0.0",
     "@buildonspark/spark-sdk": "^0.7.14",
     "@faktoryfun/styx-sdk": "^1.3.5",


### PR DESCRIPTION
Closes #492.

Brings mcp-server in line with the other Wave 2 repos (relay, agent-news, x402-api, landing-page), which moved to `^1.1.0`.

## The migration wasn't needed

#492 deferred this from C2 on the assumption it was "a real type-migration, not a lockfile-only bump." That turned out not to hold for the four symbols this repo imports:

- `TerminalReason` — byte-identical between 0.7.0 and 1.1.0
- `HttpPaymentStatusResponse` — only gains optional fields (`lastOccupant`, `quarantinedNonces`). The `status` enum and `terminalReason` shape are unchanged.

All three parse sites (`x402-payment-state.ts`) use `safeParse` against a `$strip` schema, so added optional fields can't reject responses the running relay already emits.

## Verification

- `npm run build` — clean, zero type errors
- `npm test` — 543 passed, 4 skipped
- `npm ls zod` — dedupes to a single `zod@4.3.6`, no duplicate copy
- Parse behavior compared side by side against a staged 0.7.0 on representative payloads:

| case | 0.7.0 | 1.1.0 |
|---|---|---|
| minimal (no terminalReason) | OK | OK |
| `terminalReason: null` | FAIL | FAIL |
| `terminalReason` enum member | OK | OK |
| full 0.7-era body | OK | OK |
| unknown extra key | OK | OK |
| bare id (no `pay_` prefix) | FAIL | FAIL |

No divergence. The two FAIL rows are pre-existing 0.7.0 behavior, not regressions — the schema has always required `terminalReason` to be omitted rather than `null`, and always enforced the `pay_` id prefix.

## Note on coverage

No test file currently exercises `x402-payment-state.ts` or `HttpPaymentStatusResponse`, so the green suite doesn't by itself cover this path — the side-by-side parse comparison above is what backs the runtime claim. Worth a follow-up to add cases around `resolveCanonicalPaymentStatus`.