### PR TITLE
fix(x402): record dedup entry on failed settlement, persist the cache

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -124,8 +124,11 @@ Embedded, self-custodial Lightning wallet backed by the [Spark SDK](https://www.
 **Configuration:**
 - `X402_MAX_USTX_PER_PAYMENT` (optional, default `1000000` = 1 STX): hard cap on the uSTX amount the x402 interceptor will auto-pay per request. Bounds the blast radius if a malicious endpoint demands an arbitrary amount.
 - `X402_MAX_SATS_PER_PAYMENT` (optional, default `10000`): same cap for sBTC payments, in sats.
+- `X402_DEDUP_TTL_SECONDS` (optional, default `900` = 15 minutes): how long an identical `execute_x402_endpoint` request (same method, URL, params and body) is suppressed after a payment is broadcast. Applies whether or not settlement succeeded — a payment that lands on chain but returns an HTTP error has still spent funds, so the retry is blocked and the prior txid returned instead.
 
 Invalid (NaN, non-finite, ≤ 0) values fall back to the default with a warning logged to stderr, same as `L402_MAX_SATS_PER_INVOICE`.
+
+**Duplicate-payment protection:** a repeat of an identical request inside the dedup window returns the earlier txid rather than paying again, with `txid: null` plus a `txidNote` when the original txid was never observable. To make a genuinely separate purchase, vary a parameter or wait out the window. Verify the earlier payment with `get_account_transactions` before forcing a retry — a reported error does not mean the payment failed.
 
 ### x402 Endpoint Scaffolding
 - `scaffold_x402_endpoint` - Generate a complete Cloudflare Worker project with x402 payment integration

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -125,10 +125,13 @@ Embedded, self-custodial Lightning wallet backed by the [Spark SDK](https://www.
 - `X402_MAX_USTX_PER_PAYMENT` (optional, default `1000000` = 1 STX): hard cap on the uSTX amount the x402 interceptor will auto-pay per request. Bounds the blast radius if a malicious endpoint demands an arbitrary amount.
 - `X402_MAX_SATS_PER_PAYMENT` (optional, default `10000`): same cap for sBTC payments, in sats.
 - `X402_DEDUP_TTL_SECONDS` (optional, default `900` = 15 minutes): how long an identical `execute_x402_endpoint` request (same method, URL, params and body) is suppressed after a payment is broadcast. Applies whether or not settlement succeeded — a payment that lands on chain but returns an HTTP error has still spent funds, so the retry is blocked and the prior txid returned instead.
+- `X402_DEDUP_STATE_FILE` (optional, default `~/.aibtc/x402-dedup.json`): where the dedup cache is persisted.
 
 Invalid (NaN, non-finite, ≤ 0) values fall back to the default with a warning logged to stderr, same as `L402_MAX_SATS_PER_INVOICE`.
 
 **Duplicate-payment protection:** a repeat of an identical request inside the dedup window returns the earlier txid rather than paying again, with `txid: null` plus a `txidNote` when the original txid was never observable. To make a genuinely separate purchase, vary a parameter or wait out the window. Verify the earlier payment with `get_account_transactions` before forcing a retry — a reported error does not mean the payment failed.
+
+The cache is persisted to disk (`0600`) and reloaded on startup, so the guard survives a server restart — an MCP server restarts routinely, and an in-memory-only cache dropped every entry, letting a retry after a restart pay a second time. Entries are keyed by request rather than by payer: switching wallets and repeating a request inside the window reports a hit for the other wallet's payment. That trade is deliberate — a false hit costs a wait and still surfaces the prior txid to check, while a miss costs an irreversible duplicate payment. Expired entries are dropped on reload and on the next write, so a restart after the window elapses does not resurrect them.
 
 ### x402 Endpoint Scaffolding
 - `scaffold_x402_endpoint` - Generate a complete Cloudflare Worker project with x402 payment integration

--- a/src/services/x402.service.ts
+++ b/src/services/x402.service.ts
@@ -153,6 +153,23 @@ export class X402RateLimitError extends Error {
   }
 }
 
+/**
+ * How long a completed x402 request suppresses an identical repeat.
+ *
+ * This was 60s, which is shorter than a realistic agent retry: an agent that
+ * reports a failure to its operator and retries takes minutes, not seconds.
+ * In the incident behind #630 the two payments landed 362s apart — 6x the old
+ * window — so the guard never engaged and the endpoint was paid twice.
+ *
+ * The asymmetry favours a long window: a false dedup hit costs a wait (and
+ * still returns the prior txid so the caller can verify), while a miss costs a
+ * duplicate on-chain payment that cannot be reversed. Deliberate repeat
+ * purchases of the same endpoint with the same params must wait it out or vary
+ * a param; raise or lower via X402_DEDUP_TTL_SECONDS.
+ */
+export const X402_DEDUP_TTL_MS =
+  parseSatsCap("X402_DEDUP_TTL_SECONDS", 900) * 1000; // 15 minutes
+
 // Transaction deduplication cache: {dedupKey -> {txid, timestamp}}
 const dedupCache: Map<string, { txid: string; timestamp: number }> = new Map();
 
@@ -160,7 +177,7 @@ const dedupCache: Map<string, { txid: string; timestamp: number }> = new Map();
 setInterval(() => {
   const now = Date.now();
   for (const [key, value] of dedupCache) {
-    if (now - value.timestamp > 60000) {
+    if (now - value.timestamp > X402_DEDUP_TTL_MS) {
       dedupCache.delete(key);
     }
   }
@@ -1186,7 +1203,7 @@ export function generateDedupKey(
 }
 
 /**
- * Check if a request was recently processed (within 60s)
+ * Check if a request was recently processed (within X402_DEDUP_TTL_MS)
  * @returns txid if duplicate found, null otherwise
  */
 export function checkDedupCache(key: string): string | null {
@@ -1195,7 +1212,7 @@ export function checkDedupCache(key: string): string | null {
     return null;
   }
   const now = Date.now();
-  if (now - cached.timestamp > 60000) {
+  if (now - cached.timestamp > X402_DEDUP_TTL_MS) {
     dedupCache.delete(key);
     return null;
   }

--- a/src/services/x402.service.ts
+++ b/src/services/x402.service.ts
@@ -26,6 +26,9 @@ import { formatStx, formatSbtc } from "../utils/formatting.js";
 import { getSbtcService } from "./sbtc.service.js";
 import { getHiroApi } from "./hiro-api.js";
 import { createHash } from "crypto";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
 import { InsufficientBalanceError } from "../utils/errors.js";
 import { getContracts, parseContractId } from "../config/contracts.js";
 import { resolveDefaultFee } from "../utils/fee.js";
@@ -170,14 +173,170 @@ export class X402RateLimitError extends Error {
 export const X402_DEDUP_TTL_MS =
   parseSatsCap("X402_DEDUP_TTL_SECONDS", 900) * 1000; // 15 minutes
 
+interface DedupEntry {
+  txid: string;
+  timestamp: number;
+}
+type PersistedDedup = Record<string, DedupEntry>;
+
 // Transaction deduplication cache: {dedupKey -> {txid, timestamp}}
-const dedupCache: Map<string, { txid: string; timestamp: number }> = new Map();
+const dedupCache: Map<string, DedupEntry> = new Map();
+
+/**
+ * Where the dedup cache is persisted.
+ *
+ * Memory alone left the guard open to the same double-pay it exists to stop: an
+ * MCP server restarts routinely (client reconnect, config change, crash), and a
+ * restart inside the TTL window dropped every entry. An agent retrying after one
+ * sailed past the guard and paid a second time — #630's outcome reached by a
+ * different route.
+ *
+ * Keys are SHA-256 digests (see generateDedupKey) and values are chain txids, so
+ * no request content reaches disk. The file is still written 0600 under a 0700
+ * directory to match the wallet store.
+ *
+ * Caveat: entries are keyed by request, not by payer. Switching wallets and
+ * repeating a request inside the window reports a hit for the other wallet's
+ * payment. That is the asymmetry the TTL already takes — a false hit costs a
+ * wait and still surfaces the prior txid to verify, while a miss costs an
+ * irreversible duplicate payment.
+ *
+ * Override the location with X402_DEDUP_STATE_FILE.
+ */
+let dedupStateFile =
+  process.env.X402_DEDUP_STATE_FILE ||
+  path.join(os.homedir(), ".aibtc", "x402-dedup.json");
+
+let dedupLoad: Promise<void> | null = null;
+let dedupWriteLock: Promise<void> = Promise.resolve();
+
+/**
+ * Point the dedup cache at a different state file and drop what is in memory.
+ *
+ * Also the seam tests use to simulate a restart: re-pointing at the same file
+ * clears memory and forces the next read to come off disk.
+ */
+export function setDedupStateFile(file: string): void {
+  dedupStateFile = file;
+  dedupLoad = null;
+  dedupCache.clear();
+}
+
+function isFresh(entry: DedupEntry, now: number): boolean {
+  return now - entry.timestamp <= X402_DEDUP_TTL_MS;
+}
+
+/** Read persisted entries. A missing file is the normal first-run case. */
+async function readDedupState(): Promise<PersistedDedup> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(dedupStateFile, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.error(
+        `[x402-dedup] Could not read ${dedupStateFile}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as PersistedDedup;
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed;
+  } catch {
+    // A corrupt file must not brick every x402 call. Report it and continue
+    // with the in-memory guard; the next write replaces the file.
+    console.error(`[x402-dedup] Ignoring corrupt state at ${dedupStateFile}`);
+    return {};
+  }
+}
+
+/**
+ * Load persisted entries into memory once per state file.
+ *
+ * Must be awaited before any dedup read: answering from a not-yet-loaded cache
+ * would report "no prior payment" for one that is sitting on disk, which is the
+ * exact miss this persistence closes.
+ */
+async function ensureDedupLoaded(): Promise<void> {
+  if (!dedupLoad) {
+    dedupLoad = (async () => {
+      const persisted = await readDedupState();
+      const now = Date.now();
+      for (const [key, entry] of Object.entries(persisted)) {
+        if (
+          !entry ||
+          typeof entry.txid !== "string" ||
+          typeof entry.timestamp !== "number"
+        ) {
+          continue;
+        }
+        if (!isFresh(entry, now)) continue;
+        // Anything recorded in this process is at least as fresh as disk.
+        const existing = dedupCache.get(key);
+        if (!existing || existing.timestamp < entry.timestamp) {
+          dedupCache.set(key, entry);
+        }
+      }
+    })();
+  }
+  return dedupLoad;
+}
+
+/**
+ * Merge memory over disk and write atomically, dropping expired entries.
+ *
+ * Re-reads inside the lock so a second server instance sharing the file does not
+ * lose the entries this one never saw. A failure here is logged rather than
+ * thrown: the caller records *after* funds have already moved, so rejecting
+ * would turn a recorded payment into a reported error while leaving the
+ * in-memory guard intact.
+ */
+async function persistDedupCache(): Promise<void> {
+  dedupWriteLock = dedupWriteLock
+    .then(async () => {
+      const onDisk = await readDedupState();
+      const now = Date.now();
+      const merged: PersistedDedup = {};
+      for (const [key, entry] of Object.entries(onDisk)) {
+        if (
+          entry &&
+          typeof entry.txid === "string" &&
+          typeof entry.timestamp === "number" &&
+          isFresh(entry, now)
+        ) {
+          merged[key] = entry;
+        }
+      }
+      for (const [key, entry] of dedupCache) {
+        if (!isFresh(entry, now)) continue;
+        const existing = merged[key];
+        if (!existing || existing.timestamp <= entry.timestamp) {
+          merged[key] = entry;
+        }
+      }
+      await fs.mkdir(path.dirname(dedupStateFile), {
+        recursive: true,
+        mode: 0o700,
+      });
+      // pid-suffixed so concurrent servers do not clobber each other's temp.
+      const tmp = `${dedupStateFile}.${process.pid}.tmp`;
+      await fs.writeFile(tmp, JSON.stringify(merged), { mode: 0o600 });
+      await fs.rename(tmp, dedupStateFile);
+    })
+    .catch((err) => {
+      console.error(
+        `[x402-dedup] Could not persist ${dedupStateFile}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    });
+  return dedupWriteLock;
+}
 
 // Cleanup expired dedup entries every 5 minutes
 setInterval(() => {
   const now = Date.now();
   for (const [key, value] of dedupCache) {
-    if (now - value.timestamp > X402_DEDUP_TTL_MS) {
+    if (!isFresh(value, now)) {
       dedupCache.delete(key);
     }
   }
@@ -1203,16 +1362,21 @@ export function generateDedupKey(
 }
 
 /**
- * Check if a request was recently processed (within X402_DEDUP_TTL_MS)
+ * Check if a request was recently processed (within X402_DEDUP_TTL_MS).
+ *
+ * Loads persisted entries first so a payment broadcast before a server restart
+ * still suppresses the retry that follows it.
+ *
  * @returns txid if duplicate found, null otherwise
  */
-export function checkDedupCache(key: string): string | null {
+export async function checkDedupCache(key: string): Promise<string | null> {
+  await ensureDedupLoaded();
   const cached = dedupCache.get(key);
   if (!cached) {
     return null;
   }
   const now = Date.now();
-  if (now - cached.timestamp > X402_DEDUP_TTL_MS) {
+  if (!isFresh(cached, now)) {
     dedupCache.delete(key);
     return null;
   }
@@ -1220,10 +1384,15 @@ export function checkDedupCache(key: string): string | null {
 }
 
 /**
- * Record a transaction in the dedup cache
+ * Record a transaction in the dedup cache and persist it.
+ *
+ * Awaits the write so the entry survives a crash immediately after a payment —
+ * the window where losing it costs a duplicate payment.
  */
-export function recordTransaction(key: string, txid: string): void {
+export async function recordTransaction(key: string, txid: string): Promise<void> {
+  await ensureDedupLoaded();
   dedupCache.set(key, { txid, timestamp: Date.now() });
+  await persistDedupCache();
 }
 
 /**

--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -349,7 +349,7 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
         // with a single request. Balance validation happens inside the onBeforePayment
         // callback when the interceptor receives the 402, eliminating the separate probe.
         dedupKey = generateDedupKey(method, fullUrl, params, data);
-        const existingTxid = checkDedupCache(dedupKey);
+        const existingTxid = await checkDedupCache(dedupKey);
         if (existingTxid) {
           const windowSeconds = Math.round(X402_DEDUP_TTL_MS / 1000);
           const pending = existingTxid.startsWith("pending:");
@@ -407,7 +407,7 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
         // observable, using a synthetic pending marker that cannot be
         // confused for a real chain txid.
         if (paymentAttempted) {
-          recordTransaction(dedupKey, txid ?? `pending:${dedupKey}`);
+          await recordTransaction(dedupKey, txid ?? `pending:${dedupKey}`);
         }
 
         // Build the txid response fields per the behavior matrix:
@@ -459,7 +459,7 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
         const paymentSigHeader = axiosError.config?.headers?.[X402_HEADERS.PAYMENT_SIGNATURE];
         if (paymentSigHeader && dedupKey) {
           const broadcastTxid = extractTxidFromPaymentSignature(paymentSigHeader);
-          recordTransaction(dedupKey, broadcastTxid ?? `pending:${dedupKey}`);
+          await recordTransaction(dedupKey, broadcastTxid ?? `pending:${dedupKey}`);
         }
 
         if (canonicalStatus) {

--- a/src/tools/endpoint.tools.ts
+++ b/src/tools/endpoint.tools.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { createApiClient, API_URL, probeEndpoint, formatPaymentAmount, type ProbeResult, checkSufficientBalance, generateDedupKey, checkDedupCache, recordTransaction, NETWORK } from "../services/x402.service.js";
+import { createApiClient, API_URL, probeEndpoint, formatPaymentAmount, type ProbeResult, checkSufficientBalance, generateDedupKey, checkDedupCache, recordTransaction, X402_DEDUP_TTL_MS, NETWORK } from "../services/x402.service.js";
 import {
   ALL_ENDPOINTS,
   searchEndpoints,
@@ -331,6 +331,9 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
     },
     async ({ method, url, path, apiUrl, params, data, autoApprove, asset }) => {
       let fullUrl = "";
+      // Hoisted so the catch can record a broadcast payment for dedup — a
+      // failed settlement still spends real funds (#630).
+      let dedupKey: string | null = null;
 
       try {
         const parsed = parseEndpointUrl({ url, path, apiUrl, params });
@@ -345,14 +348,28 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
         // autoApprove=true: check dedup cache before any network request, then execute
         // with a single request. Balance validation happens inside the onBeforePayment
         // callback when the interceptor receives the 402, eliminating the separate probe.
-        const dedupKey = generateDedupKey(method, fullUrl, params, data);
+        dedupKey = generateDedupKey(method, fullUrl, params, data);
         const existingTxid = checkDedupCache(dedupKey);
         if (existingTxid) {
+          const windowSeconds = Math.round(X402_DEDUP_TTL_MS / 1000);
+          const pending = existingTxid.startsWith("pending:");
           return createJsonResponse({
             endpoint: `${method} ${fullUrl}`,
-            message: 'Request already processed within the last 60 seconds. This prevents accidental duplicate payments.',
-            txid: existingTxid,
-            note: 'Wait 60s or use different endpoint/params to force a new transaction.',
+            // Deliberately says "broadcast", not "paid": the entry is written
+            // whenever a payment was signed and broadcast, including when
+            // settlement then reported an error. Claiming it succeeded would
+            // be wrong in exactly the cases the caller most needs to check.
+            message: `An identical request already broadcast a payment within the last ${windowSeconds} seconds. This prevents accidental duplicate payments.`,
+            // A prior attempt whose txid was never observable is recorded with a
+            // synthetic marker. Report it as null rather than leaking the marker,
+            // which is not a chain txid and must not be treated as one.
+            txid: pending ? null : existingTxid,
+            ...(pending && {
+              txidNote:
+                "The earlier payment was broadcast but its txid was not observable in the response. " +
+                "Query get_account_transactions to find the settled txid before paying again.",
+            }),
+            note: `The earlier payment may have settled even if it reported an error — verify it before retrying. Wait ${windowSeconds}s or vary the endpoint/params to force a new transaction.`,
           });
         }
 
@@ -431,9 +448,22 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
         const canonicalStatus = axiosError.x402PaymentStatus as
           | HttpPaymentStatusResponse
           | undefined;
+
+        // The presence of this header means the interceptor signed and
+        // broadcast a payment. That spends real funds whether or not
+        // settlement succeeded, so record it for dedup before returning any
+        // error — otherwise an identical retry passes the dedup guard and pays
+        // a second time for an invoice already settled on chain (#630).
+        // Mirrors the success path, including the synthetic pending marker
+        // used when the txid is not yet observable.
+        const paymentSigHeader = axiosError.config?.headers?.[X402_HEADERS.PAYMENT_SIGNATURE];
+        if (paymentSigHeader && dedupKey) {
+          const broadcastTxid = extractTxidFromPaymentSignature(paymentSigHeader);
+          recordTransaction(dedupKey, broadcastTxid ?? `pending:${dedupKey}`);
+        }
+
         if (canonicalStatus) {
           const baseError = formatEndpointError(error, label);
-          const paymentSigHeader = axiosError.config?.headers?.[X402_HEADERS.PAYMENT_SIGNATURE];
           const fallbackTxid = paymentSigHeader
             ? extractTxidFromPaymentSignature(paymentSigHeader)
             : null;
@@ -468,7 +498,6 @@ For aibtc.com inbox messages, use send_inbox_message_direct instead — it signs
           };
         }
 
-        const paymentSigHeader = axiosError.config?.headers?.[X402_HEADERS.PAYMENT_SIGNATURE];
         if (paymentSigHeader) {
           const txid = extractTxidFromPaymentSignature(paymentSigHeader);
           const fallbackPaymentId = extractPaymentIdFromPaymentSignature(paymentSigHeader);

--- a/tests/services/x402-prevalidation.test.ts
+++ b/tests/services/x402-prevalidation.test.ts
@@ -32,6 +32,7 @@ const {
   generateDedupKey,
   checkDedupCache,
   recordTransaction,
+  X402_DEDUP_TTL_MS,
   detectTokenType,
   formatPaymentAmount,
   createApiClient,
@@ -289,17 +290,27 @@ describe("checkDedupCache / recordTransaction", () => {
     expect(checkDedupCache(key)).toBe("0xabc123");
   });
 
-  it("returns null after 60 second TTL expires", () => {
+  it("returns null after the dedup TTL expires", () => {
     const key = "test-key-ttl";
     recordTransaction(key, "0xexpired");
 
-    // Still valid at 59 seconds
-    vi.advanceTimersByTime(59_000);
+    // Still valid just inside the window
+    vi.advanceTimersByTime(X402_DEDUP_TTL_MS - 1_000);
     expect(checkDedupCache(key)).toBe("0xexpired");
 
-    // Expired at 61 seconds
+    // Expired just past it
     vi.advanceTimersByTime(2_000);
     expect(checkDedupCache(key)).toBeNull();
+  });
+
+  it("holds the entry well past the old 60s window (#630)", () => {
+    const key = "test-key-retry-latency";
+    recordTransaction(key, "0xbroadcast");
+
+    // The incident behind #630 retried 362s after the first payment. The old
+    // 60s TTL had long expired by then, so the duplicate was not suppressed.
+    vi.advanceTimersByTime(362_000);
+    expect(checkDedupCache(key)).toBe("0xbroadcast");
   });
 
   it("overwrites previous entry for the same key", () => {

--- a/tests/services/x402-prevalidation.test.ts
+++ b/tests/services/x402-prevalidation.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { promises as fsPromises } from "fs";
+import os from "os";
+import path from "path";
 
 // ============================================================================
 // Mocks — must be declared before importing the module under test
@@ -33,6 +36,7 @@ const {
   checkDedupCache,
   recordTransaction,
   X402_DEDUP_TTL_MS,
+  setDedupStateFile,
   detectTokenType,
   formatPaymentAmount,
   createApiClient,
@@ -272,52 +276,105 @@ describe("generateDedupKey", () => {
 });
 
 describe("checkDedupCache / recordTransaction", () => {
-  beforeEach(() => {
+  let stateFile: string;
+
+  beforeEach(async () => {
+    // Never touch the real ~/.aibtc/x402-dedup.json from tests.
+    stateFile = path.join(
+      await fsPromises.mkdtemp(path.join(os.tmpdir(), "x402-dedup-")),
+      "state.json"
+    );
+    setDedupStateFile(stateFile);
     vi.useFakeTimers();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
+    await fsPromises.rm(path.dirname(stateFile), { recursive: true, force: true });
   });
 
-  it("returns null for unknown keys", () => {
-    expect(checkDedupCache("nonexistent-key")).toBeNull();
+  it("returns null for unknown keys", async () => {
+    expect(await checkDedupCache("nonexistent-key")).toBeNull();
   });
 
-  it("returns txid for recently recorded transactions", () => {
+  it("returns txid for recently recorded transactions", async () => {
     const key = "test-key-1";
-    recordTransaction(key, "0xabc123");
-    expect(checkDedupCache(key)).toBe("0xabc123");
+    await recordTransaction(key, "0xabc123");
+    expect(await checkDedupCache(key)).toBe("0xabc123");
   });
 
-  it("returns null after the dedup TTL expires", () => {
+  it("returns null after the dedup TTL expires", async () => {
     const key = "test-key-ttl";
-    recordTransaction(key, "0xexpired");
+    await recordTransaction(key, "0xexpired");
 
     // Still valid just inside the window
     vi.advanceTimersByTime(X402_DEDUP_TTL_MS - 1_000);
-    expect(checkDedupCache(key)).toBe("0xexpired");
+    expect(await checkDedupCache(key)).toBe("0xexpired");
 
     // Expired just past it
     vi.advanceTimersByTime(2_000);
-    expect(checkDedupCache(key)).toBeNull();
+    expect(await checkDedupCache(key)).toBeNull();
   });
 
-  it("holds the entry well past the old 60s window (#630)", () => {
+  it("holds the entry well past the old 60s window (#630)", async () => {
     const key = "test-key-retry-latency";
-    recordTransaction(key, "0xbroadcast");
+    await recordTransaction(key, "0xbroadcast");
 
     // The incident behind #630 retried 362s after the first payment. The old
     // 60s TTL had long expired by then, so the duplicate was not suppressed.
     vi.advanceTimersByTime(362_000);
-    expect(checkDedupCache(key)).toBe("0xbroadcast");
+    expect(await checkDedupCache(key)).toBe("0xbroadcast");
   });
 
-  it("overwrites previous entry for the same key", () => {
+  it("overwrites previous entry for the same key", async () => {
     const key = "test-key-overwrite";
-    recordTransaction(key, "0xfirst");
-    recordTransaction(key, "0xsecond");
-    expect(checkDedupCache(key)).toBe("0xsecond");
+    await recordTransaction(key, "0xfirst");
+    await recordTransaction(key, "0xsecond");
+    expect(await checkDedupCache(key)).toBe("0xsecond");
+  });
+
+  it("suppresses a retry across a server restart", async () => {
+    const key = "test-key-restart";
+    await recordTransaction(key, "0xbroadcast_before_restart");
+
+    // Re-pointing at the same file drops memory and forces a reload from disk,
+    // which is what a fresh server process does. Without persistence the guard
+    // was lost here and the retry paid a second time.
+    setDedupStateFile(stateFile);
+
+    expect(await checkDedupCache(key)).toBe("0xbroadcast_before_restart");
+  });
+
+  it("does not resurrect entries that expired while the server was down", async () => {
+    const key = "test-key-restart-expired";
+    await recordTransaction(key, "0xstale");
+
+    vi.advanceTimersByTime(X402_DEDUP_TTL_MS + 1_000);
+    setDedupStateFile(stateFile);
+
+    expect(await checkDedupCache(key)).toBeNull();
+  });
+
+  it("keeps entries written by another server instance", async () => {
+    // Simulate a second process that recorded a payment we never saw.
+    await fsPromises.writeFile(
+      stateFile,
+      JSON.stringify({ "other-instance-key": { txid: "0xother", timestamp: Date.now() } })
+    );
+
+    await recordTransaction("our-key", "0xours");
+    setDedupStateFile(stateFile);
+
+    expect(await checkDedupCache("other-instance-key")).toBe("0xother");
+    expect(await checkDedupCache("our-key")).toBe("0xours");
+  });
+
+  it("survives a corrupt state file instead of failing the payment path", async () => {
+    await fsPromises.writeFile(stateFile, "{not json");
+
+    await expect(checkDedupCache("any-key")).resolves.toBeNull();
+    await recordTransaction("post-corruption", "0xrecovered");
+    expect(await checkDedupCache("post-corruption")).toBe("0xrecovered");
   });
 });
 

--- a/tests/tools/endpoint-x402-error.test.ts
+++ b/tests/tools/endpoint-x402-error.test.ts
@@ -140,3 +140,83 @@ describe("execute_x402_endpoint canonical error handling", () => {
     expect(mockPollTransactionConfirmation).toHaveBeenCalledWith("txid_123", "mainnet");
   });
 });
+
+describe("execute_x402_endpoint dedup recording on failed settlement (#630)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenerateDedupKey.mockReturnValue("dedup-key");
+    mockCheckDedupCache.mockReturnValue(null);
+  });
+
+  async function runFailing(rejection: unknown) {
+    mockCreateApiClient.mockResolvedValue({
+      request: vi.fn().mockRejectedValue(rejection),
+    });
+    const { server, tools } = createTrackingServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerEndpointTools(server as any);
+    return tools.get("execute_x402_endpoint")!.handler({
+      method: "GET",
+      url: "https://aibtc.com/api/inbox/bc1example",
+      autoApprove: true,
+    });
+  }
+
+  it("records the broadcast txid when settlement fails with canonical status", async () => {
+    mockExtractTxidFromPaymentSignature.mockReturnValue("txid_broadcast");
+
+    await runFailing({
+      message: "Payment retry limit exceeded",
+      config: { headers: { "payment-signature": "encoded-payment" } },
+      response: { status: 402, data: { error: "still processing" } },
+      x402PaymentStatus: { paymentId: "pay_1", status: "queued" },
+    });
+
+    // The payment was signed and broadcast, so an identical retry must be
+    // suppressed even though the HTTP call reported an error.
+    expect(mockRecordTransaction).toHaveBeenCalledWith("dedup-key", "txid_broadcast");
+  });
+
+  it("records the broadcast txid on the txid-recovery path", async () => {
+    mockExtractTxidFromPaymentSignature.mockReturnValue("txid_123");
+    mockPollTransactionConfirmation.mockResolvedValue({
+      txid: "txid_123",
+      status: "pending",
+      explorer: "https://explorer.example/txid_123",
+    });
+
+    await runFailing({
+      message: "socket hang up",
+      config: { headers: { "payment-signature": "encoded-payment" } },
+    });
+
+    expect(mockRecordTransaction).toHaveBeenCalledWith("dedup-key", "txid_123");
+  });
+
+  it("records a pending marker when the broadcast txid is not observable", async () => {
+    mockExtractTxidFromPaymentSignature.mockReturnValue(null);
+
+    await runFailing({
+      message: "socket hang up",
+      config: { headers: { "payment-signature": "encoded-payment" } },
+    });
+
+    // Funds still moved, so the entry must exist. The marker cannot be
+    // mistaken for a chain txid.
+    expect(mockRecordTransaction).toHaveBeenCalledWith("dedup-key", "pending:dedup-key");
+  });
+
+  it("does NOT record when the request failed before any payment was signed", async () => {
+    mockExtractTxidFromPaymentSignature.mockReturnValue(null);
+
+    // No payment-signature header => the interceptor never signed anything.
+    // Blocking the retry here would strand the caller on a transient error.
+    await runFailing({
+      message: "Not Found",
+      config: { headers: {} },
+      response: { status: 404, data: { error: "no such endpoint" } },
+    });
+
+    expect(mockRecordTransaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #630.

## The bug

`recordTransaction` was called from exactly one place — the success path at `endpoint.tools.ts:393`. A payment that was signed and broadcast but whose settlement then errored left no dedup entry, so an identical retry passed the guard and signed a **second real payment**.

The catch block already did the hard part. It pulled the signature header, called `extractTxidFromPaymentSignature`, polled confirmation, and reported the txid to the caller. It held the exact value the dedup cache wanted and dropped it.

## Changes

**1. Record on the failure path.** In the catch, whenever the payment-signature header is present, record the recovered txid (or the same `pending:` marker the success path uses). `dedupKey` and the header lookup are hoisted so both the canonical-status and txid-recovery branches are covered — previously `paymentSigHeader` was declared twice in separate scopes.

**2. Raise the TTL to 15 minutes**, via new `X402_DEDUP_TTL_SECONDS`. 60s was shorter than a realistic agent retry — the payments in #630 landed **362s apart**, so the window had long closed. Fixing (1) alone would not have prevented that incident. The `60000` literal appeared twice and is now one exported constant.

**3. Truthful dedup-hit message.** Now says a request "already broadcast a payment", not "was already paid" — the entry is written on the failure path too, so asserting success would be wrong precisely where the caller most needs to verify. A `pending:` marker is reported as `txid: null` plus a `txidNote` rather than leaking a non-chain identifier.

**4. Persist the cache.** The cache was a module-global `Map`, so a restart inside the TTL window dropped every entry — the same double-pay reached by a different route, and (2) widens the window in which a restart can happen. It now persists to `~/.aibtc/x402-dedup.json` (0600 under a 0700 dir, `X402_DEDUP_STATE_FILE` to override), following the `spend-limiter` precedent. Keys are SHA-256 digests and values are chain txids, so no request content reaches disk.

`checkDedupCache` and `recordTransaction` are now async. The read awaits the load — answering from a not-yet-loaded cache would report "no prior payment" for one sitting on disk, which is the miss being closed. The write is awaited so an entry survives a crash immediately after a payment. Writes re-read and merge inside a lock, then rename a pid-suffixed temp into place, so two servers sharing the file do not drop each other's entries. Expired entries are dropped on load and on write, so a restart after the window elapses does not resurrect them.

A corrupt or unreadable state file is reported to stderr and treated as empty rather than failing every x402 call. A persist failure is logged rather than thrown, since `recordTransaction` runs after funds have already moved and throwing would report an error for a payment that did settle.

## Design note: why recording is unconditional

I considered skipping the record when the canonical decision says the payment is dead. It isn't safe: `restart_payment` fires on relay `not_found` (`x402-payment-state.ts:325`), and the relay not knowing a payment does not prove the chain transaction failed to land. Keying dedup off the client's belief about settlement would reintroduce the exact failure mode this fixes — the decision engine's own summary hedges with "restart only if the higher-level operation still wants to pay".

The accepted cost: a genuinely failed payment cannot be retried with identical params until the window elapses. Mitigated by returning the prior txid so the caller can verify, telling them to check before retrying, and making the TTL configurable.

## Trade-off in the persisted cache

Entries are keyed by request, not by payer. Switching wallets and repeating a request inside the window reports a hit for the other wallet's payment. This is the same asymmetry the TTL already takes — a false hit costs a wait and still surfaces the prior txid to verify, while a miss costs an irreversible duplicate payment. Existing key semantics were left unchanged to keep the diff scoped; documented in `docs/TOOLS.md`.

## Verification

- `npm run build` clean; `npm test` 552 passed, 4 skipped (up from 543).
- The three recording tests **fail without the fix** — verified by reverting only the two source files:
  ```
  × records the broadcast txid when settlement fails with canonical status
  × records the broadcast txid on the txid-recovery path
  × records a pending marker when the broadcast txid is not observable
  ```
- A fourth test asserts the negative: a request that failed *before* any payment was signed (no signature header, e.g. a 404) does **not** record, so transient errors stay retryable.
- The existing TTL test is rewritten TTL-relative instead of hardcoding 60s, plus a case asserting the entry survives the 362s gap from the incident.
- Four new persistence tests: restart survival, expiry across a restart, merging another instance's entries, corrupt-file recovery. They use `mkdtemp` via a new `setDedupStateFile` seam, so tests never touch the real `~/.aibtc`.
- Restart survival checked end to end across two separate node processes — process 1 recorded, a genuinely fresh process 2 read the hit back off disk and still returned `null` for an unrelated key. File confirmed `-rw-------`.
- `createApiClient` has exactly one caller, so `execute_x402_endpoint` is the only exposed path. The within-call guard (`attempts >= 1`) is unchanged.

## Note

`X402_DEDUP_TTL_SECONDS` reuses `parseSatsCap`, which logs an `[L402]` prefix on invalid values. That mislabels non-L402 vars, but it's pre-existing — `X402_MAX_USTX_PER_PAYMENT` and `X402_MAX_SATS_PER_PAYMENT` already share it. Left alone to keep this diff scoped.
