### PR TITLE
fix(deps): bump postcss to 8.5.18 (GHSA-r28c-9q8g-f849)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       "devDependencies": {
         "@types/node": "^22.19.13",
         "@types/ws": "^8.18.1",
+        "postcss": "^8.5.18",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.8"
@@ -4926,9 +4927,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "devDependencies": {
     "@types/node": "^22.19.13",
     "@types/ws": "^8.18.1",
+    "postcss": "^8.5.18",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.8"


### PR DESCRIPTION
## Summary
- Dependabot alert #101 flagged a high-severity path-traversal in postcss's previous-source-map auto-loading (GHSA-r28c-9q8g-f849), fixed upstream in 8.5.18.
- `postcss` was only a transitive dev dependency (pulled in via vite/vitest), pinned directly at `^8.5.18` so the patched version is explicit rather than relying on range resolution.

## Test plan
- [x] `npm install` (lockfile + node_modules resync) — `npm ls postcss` resolves cleanly to 8.5.18 everywhere, no invalid/dedup conflicts
- [x] `npx tsc --noEmit` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)