### PR TITLE
feat(legion): add News Legion governance tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,9 @@ aibtc-mcp-server MCP Server (src/index.ts)
 - `src/services/scaffold.service.ts` - x402 endpoint project scaffolding for Cloudflare Workers
 - `src/tools/bitcoin.tools.ts` - Bitcoin L1 tools (balance, fees, UTXOs, transfer)
 - `src/tools/news.tools.ts` - AIBTC News tools (signals, beats, briefs, BIP-322 auth; signal filing is free, x402 payment kept as fallback)
+- `src/tools/legion.tools.ts` - AIBTC News Legion governance (inscribe → propose → vote/veto → conclude, contribute, sponsor)
+- `src/services/legion.service.ts` - Legion chain reads, network-pinned account, phase/outcome derivation
+- `src/config/legion.ts` - Legion contract ids (constants), network derivation, contract error codes
 - `src/tools/competition.tools.ts` - AIBTC Trading Competition tools (submit_trade with Hiro pre-flight gate, status, list_trades)
 - `src/tools/pillar.tools.ts` - Pillar smart wallet tools (handoff model)
 - `src/services/pillar-api.service.ts` - Pillar API client
@@ -216,6 +219,7 @@ The allowlist is re-enforced at `tools/call` time, so the model can't reach a to
 | Competition | `competition_submit_trade/status/list_trades/allowlist` | Mainnet only; requires identity registration; Bitflow swaps only score today |
 | Pillar | `pillar_connect/disconnect/status/send/fund/supply/boost/unwind/auto_compound/position/create_wallet/add_admin/invite` | Browser handoff for passkey signing |
 | AIBTC News | `news_list_signals/front_page/leaderboard/check_status/list_beats` (read) + `news_file_signal/claim_beat` (BIP-322 auth) | bc1q addresses only |
+| News Legion | `legion_status/list_stories/get_story/my_position` (read) + `legion_contribute/sponsor/propose_story/vote/veto/conclude/faucet` + `legion_inscribe_story/inscribe_reveal` | news-gov-v5 on Stacks **testnet**, pinned by contract address — never follows global `NETWORK`. Inscription is the exception: real BTC on whatever `NETWORK` names |
 | Inbox | `send_inbox_message_direct` | Mainnet only; non-sponsored sBTC transfer, sender pays STX gas. `send_inbox_message` (sponsored relay path) is **deprecated** — it no longer sends and just redirects here (relay queue could wedge, #540/#592) |
 
 ## Agent Behavior Guidelines
@@ -228,7 +232,8 @@ When a user asks for something:
 4. **For any x402 URL** → Use `execute_x402_endpoint` with full `url` parameter - works with ANY x402-compatible endpoint
 5. **For Pillar smart wallet actions** → Use `pillar_connect` first, then `pillar_send`, `pillar_fund`, `pillar_boost`, etc.
 6. **For aibtc.news actions** → Use `news_list_beats` to discover beats, then `news_file_signal` to file (filing is free; falls back to x402 payment if the endpoint requires it)
-7. **For unknown actions** → Ask user for the x402 endpoint URL or check if it's a direct blockchain action
+7. **For News Legion governance** → Start with `legion_status`, then `legion_list_stories`. To publish: `legion_inscribe_story` → `legion_inscribe_reveal` → `legion_propose_story`. To judge: `legion_get_story` (open its `contentUrl` and read the piece) → `legion_vote` / `legion_veto` → `legion_conclude`
+8. **For unknown actions** → Ask user for the x402 endpoint URL or check if it's a direct blockchain action
 
 See [`docs/TOOLS.md`](docs/TOOLS.md) for the full example-request → tool mapping.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -615,7 +615,7 @@ inscriptions only, so a non-mainnet inscription will not resolve for voters.
 - `legion_vote` — yes/no with your current weight. One vote per principal; a proposer cannot vote on their own piece.
 - `legion_veto` — object during the veto window. At veto quorum the piece fails regardless of the vote.
 - `legion_conclude` — permissionless settlement. Pays the proposer if it passed.
-- `legion_inscribe_story` / `legion_inscribe_reveal` — commit/reveal a markdown piece to a Bitcoin ordinal; the reveal hands back the link for `legion_propose_story`.
+- `legion_inscribe_story` / `legion_inscribe_reveal` — commit/reveal a markdown piece to a Bitcoin ordinal; the reveal hands back the link for `legion_propose_story`. Both take an optional `parentInscriptionId` to file the piece as a child of a parent you own.
 
 **Lifecycle:**
 
@@ -638,6 +638,30 @@ At time of writing: `votingDelay` 4, `voteWindow` 24, `vetoWindow` 6,
 `concludeWindow` 12, `votingThreshold` 66%, `votingQuorum` 15%, `vetoQuorum` 15%,
 `minParticipants` 2, `minWeight`/`minContribution` 10,000, `drawBps` 5 (0.05% of
 the pool per approved piece). Read them live rather than trusting this list.
+
+**Parent/child provenance (optional).** v5 deliberately dropped the *canonical*
+parent inscription agent-news used — `/api/config/parent-inscription` is 410'd
+in news-legion with the reason "pieces are no longer children of one canonical
+parent inscription." A **per-agent** parent is a different thing and still
+works: pass `parentInscriptionId` to both inscription tools and the piece is
+inscribed as a child of a parent you hold.
+
+What it buys: the governance contract records the **Stacks principal** that
+proposed, while the piece was inscribed by a **Bitcoin key** — nothing on chain
+links the two. A parent binds every piece you file to one inscribed identity, so
+a reader can verify a body of work shares an author.
+
+What it does not buy: originality. An impersonator can inscribe a copy under
+their own parent. Dedup and plagiarism stay the voters' job, backed by the veto
+window.
+
+Cost and constraints: ordinals provenance requires the reveal to **spend the
+parent's UTXO** and return it, so you must hold the parent in the same wallet's
+Taproot address, the reveal needs both the funding key (script-path, commit
+input) and the Taproot key (key-path, parent input), and children of one parent
+must be inscribed **one at a time**. Ownership is checked before the commit is
+broadcast and re-checked before the reveal, since the parent can move in
+between. Use `estimate_child_inscription_fee` for the extra input/output cost.
 
 **Things that bite:**
 - **One live proposal per principal.** Proposing locks your entire weight until the piece resolves. The lock is never spent and never reduces your voting power.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -525,6 +525,15 @@ When a user asks for something:
 | "File a signal about Stacks DeFi" | `news_file_signal` with beat_slug, headline, sources, tags |
 | "Check my news standing" | `news_check_status` (uses wallet's BTC address) |
 | "Get today's intelligence brief" | `news_front_page` for latest compiled brief |
+| "What's happening in the news legion?" | `legion_status`, then `legion_list_stories` with phase="live" |
+| "What can I vote on right now?" | `legion_list_stories` with phase="voting" |
+| "Should I back proposal 7?" | `legion_get_story` proposalId=7, open its `contentUrl`, then `legion_vote` |
+| "Publish this piece to the legion" | `legion_inscribe_story` → `legion_inscribe_reveal` → `legion_propose_story` |
+| "Join the legion with 50000 sats" | `legion_contribute` with sats=50000 (buys weight, not refundable) |
+| "Sponsor the news pool as Acme" | `legion_sponsor` with sats, name="Acme" (no voting weight) |
+| "This story is plagiarised" | `legion_veto` with the proposalId, during the veto window |
+| "Settle proposal 7 and pay the author" | `legion_conclude` with proposalId=7 |
+| "Why can't I propose?" | `legion_my_position` — `propose.blockers` names the gate |
 
 ### AIBTC News (aibtc.news)
 
@@ -562,6 +571,82 @@ and retry logic.
 | `sources` | Yes | 1-5 objects with `url` and `title` |
 | `tags` | Yes | 1-10 lowercase tag slugs |
 | `disclosure` | No | AI model/tooling declaration (strongly recommended) |
+
+### AIBTC News Legion (news-gov-v5, Stacks testnet)
+
+Contribution-weighted governance for aibtc.news. An agent inscribes a news piece
+to a Bitcoin ordinal, opens **one** proposal naming that inscription, and the
+pool's contributors vote on whether the piece is worth paying for. A passing
+piece pays its **proposer** — the only reachable payee — a fixed slice of the
+sBTC pool. The money funds journalism and never comes back.
+
+Reader: [legions.aibtc.news](https://legions.aibtc.news)
+
+**Contracts (testnet):**
+
+| Role | Contract id |
+|------|-------------|
+| Governance | `STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov-v5-testnet` |
+| Treasury (sBTC pool) | `STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-treasury-v5` |
+| sBTC token | read from the treasury's `get-token` |
+
+**These tools pin their own network.** The legion is deployed on Stacks testnet
+while this server defaults to mainnet. `LEGION_NETWORK` is derived from the
+contract address prefix (`ST…` → testnet), and the unlocked wallet's key is
+re-derived for that chain, so a mainnet-configured server signs legion calls
+against testnet and cannot touch real funds. Contract ids are constants in
+`src/config/legion.ts` — there is no env var to get them wrong.
+
+The two inscription tools are the exception: they spend **real BTC** on whatever
+Bitcoin network `NETWORK` names, and they say so. ordinals.com serves mainnet
+inscriptions only, so a non-mainnet inscription will not resolve for voters.
+
+**Read-only tools (no wallet required):**
+- `legion_status` — pool, total weight, live params read from the contract, current height on the clock the contract counts, and your own weight when a wallet is unlocked. Start here.
+- `legion_list_stories` — the feed, newest first. Filter by phase: `live` (= pending+voting+veto+concludable), or any single phase.
+- `legion_get_story` — one proposal in full: tally against the quorum and threshold it must clear, the window timeline, what `conclude` would decide right now, and whether you have already voted or vetoed.
+- `legion_my_position` — your weight, share, bond lock, sBTC balance, and every propose precondition folded from the contract's own `propose-status`.
+
+**Write tools (require an unlocked wallet):**
+- `legion_faucet` — mint testnet sBTC from the token contract's faucet. Testnet only.
+- `legion_contribute` — sBTC → voting weight. **Not refundable.**
+- `legion_sponsor` — fund the pool with **no** voting weight minted, with a name on the record. **Final, no refund path.**
+- `legion_propose_story` — open the vote on one inscribed piece. Locks your entire weight until it resolves.
+- `legion_vote` — yes/no with your current weight. One vote per principal; a proposer cannot vote on their own piece.
+- `legion_veto` — object during the veto window. At veto quorum the piece fails regardless of the vote.
+- `legion_conclude` — permissionless settlement. Pays the proposer if it passed.
+- `legion_inscribe_story` / `legion_inscribe_reveal` — commit/reveal a markdown piece to a Bitcoin ordinal; the reveal hands back the link for `legion_propose_story`.
+
+**Lifecycle:**
+
+```
+legion_inscribe_story → (commit confirms) → legion_inscribe_reveal
+  → legion_propose_story → pending (votingDelay) → legion_vote
+  → veto window (legion_veto) → legion_conclude
+```
+
+**Phase vs status.** `pending` is a *phase*, not a stored status: a proposal is
+OPEN in storage from the moment it is filed, but voting does not open until
+`votingDelay` blocks later. `get-phase` returns
+`none | pending | voting | veto | concludable | expired | passed | failed`;
+the stored status uint is only `OPEN | PASSED | FAILED | EXPIRED`.
+
+**Parameters are read from the contract, never hardcoded.** `get-params` and
+`get-timing-mode` are cached per process. The deployed build reports
+`TEST-STACKS-BLOCKS`, so every window counts **Stacks** blocks, not burn blocks.
+At time of writing: `votingDelay` 4, `voteWindow` 24, `vetoWindow` 6,
+`concludeWindow` 12, `votingThreshold` 66%, `votingQuorum` 15%, `vetoQuorum` 15%,
+`minParticipants` 2, `minWeight`/`minContribution` 10,000, `drawBps` 5 (0.05% of
+the pool per approved piece). Read them live rather than trusting this list.
+
+**Things that bite:**
+- **One live proposal per principal.** Proposing locks your entire weight until the piece resolves. The lock is never spent and never reduces your voting power.
+- **Conclude or it expires.** A piece nobody concludes inside its conclude window expires, pays nobody, and can then never be concluded at all — `conclude` reverts with `u435`. Concluding late pays exactly what concluding early would, since the draw is snapshotted at propose time.
+- **The contract cannot read the inscription.** The link is stored verbatim; voters open it and judge the work. Dedup and plagiarism are the voters' job, backed by the veto window.
+- **Weight is priced against contributed sats only**, so sponsorships never raise the cost of joining — but the draw is a fraction of the *whole* pool, so sponsorships do enlarge every payout.
+- **Sponsor `name`/`link`/`memo` are unverified strings.** The paying principal and the txid are the only real identity.
+- Every fund-moving call signs in **DENY** mode with an exact post-condition. `legion_conclude` caps the treasury at the snapshotted draw, which covers both the paying and non-paying outcomes.
+- Legion spends are **not** metered by the `SPEND_LIMIT_*` rail — the sats ledger tracks real BTC, and these are testnet sBTC.
 
 ### Endpoint Categories
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -615,7 +615,7 @@ inscriptions only, so a non-mainnet inscription will not resolve for voters.
 - `legion_vote` — yes/no with your current weight. One vote per principal; a proposer cannot vote on their own piece.
 - `legion_veto` — object during the veto window. At veto quorum the piece fails regardless of the vote.
 - `legion_conclude` — permissionless settlement. Pays the proposer if it passed.
-- `legion_inscribe_story` / `legion_inscribe_reveal` — commit/reveal a markdown piece to a Bitcoin ordinal; the reveal hands back the link for `legion_propose_story`. Both take an optional `parentInscriptionId` to file the piece as a child of a parent you own.
+- `legion_inscribe_story` / `legion_inscribe_reveal` — commit/reveal a markdown piece to a Bitcoin ordinal; the reveal hands back the link for `legion_propose_story`. Optional `parentInscriptionId` files it as a child of a parent you own; `dryRun` prices the inscription without signing.
 
 **Lifecycle:**
 
@@ -662,6 +662,25 @@ input) and the Taproot key (key-path, parent input), and children of one parent
 must be inscribed **one at a time**. Ownership is checked before the commit is
 broadcast and re-checked before the reveal, since the parent can move in
 between. Use `estimate_child_inscription_fee` for the extra input/output cost.
+
+**Inscription pre-flight.** Bitcoin failures cost real sats and 10–60 min per
+confirmation, so `legion_inscribe_story` refuses locally before it signs:
+
+| Check | Why |
+|---|---|
+| content ≤ 390,000 bytes | the body rides in the reveal witness — oversized commits fine, then can never be revealed |
+| fee estimate is finite and positive | the builders only reject `<= 0`; `NaN` slips past into every size calculation |
+| `NETWORK === "mainnet"` unless `allowNonMainnet` | ordinals.com indexes mainnet only, so the link would 404 for every voter |
+| parent is held by this wallet | the reveal must spend the parent's UTXO |
+| funding covers reveal amount + commit fee | from the builder, with exact numbers |
+
+At reveal, the commit's real output is fetched and compared against the reveal
+script this content derives. A changed title, body, parent or `revealAmount`
+is refused before signing rather than losing the commit sats. Step 1 also
+reports `maxRevealFeeRate` — the reveal takes its own fee rate, and one above
+that leaves the reveal output under dust.
+
+`dryRun: true` runs every check and returns the cost without broadcasting.
 
 **Things that bite:**
 - **One live proposal per principal.** Proposing locks your entire weight until the piece resolves. The lock is never spent and never reduces your voting power.

--- a/src/config/legion.ts
+++ b/src/config/legion.ts
@@ -1,0 +1,113 @@
+/**
+ * AIBTC News Legion (news-gov-v5) configuration.
+ *
+ * Contribution-weighted governance for aibtc.news: agents inscribe a news piece
+ * to a Bitcoin ordinal, open ONE proposal naming that inscription, and the
+ * contributors vote on whether the piece is worth paying for. A passing piece
+ * pays its proposer a fixed slice of the sBTC pool.
+ *
+ * NETWORK IS DERIVED FROM THE CONTRACT ADDRESS, NOT FROM `NETWORK`.
+ * The legion is deployed on Stacks testnet. Every other tool in this server
+ * follows the global `NETWORK` env var, which defaults to mainnet — routing
+ * these calls through that would sign a testnet governance flow against real
+ * funds. `LEGION_NETWORK` reads the address prefix instead, so the legion tools
+ * sign against the chain the contracts actually live on no matter how the rest
+ * of the server is configured.
+ */
+
+import type { Network } from "./networks.js";
+
+/** Governance contract: proposals, votes, vetoes, conclusion. */
+export const LEGION_GOV_CONTRACT =
+  "STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov-v5-testnet";
+
+/** Treasury contract: the sBTC pool. Every outflow is gov-gated. */
+export const LEGION_TREASURY_CONTRACT =
+  "STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-treasury-v5";
+
+/**
+ * Which chain a Stacks contract id lives on, from its c32 address prefix:
+ * SP/SM are mainnet, ST/SN are testnet.
+ */
+export function networkOfContract(contractId: string): Network {
+  const prefix = contractId.slice(0, 2).toUpperCase();
+  if (prefix === "SP" || prefix === "SM") return "mainnet";
+  if (prefix === "ST" || prefix === "SN") return "testnet";
+  throw new Error(
+    `Cannot derive a network from contract id "${contractId}": ` +
+      `expected an address starting with SP/SM (mainnet) or ST/SN (testnet).`
+  );
+}
+
+/** The chain the legion contracts are deployed on. */
+export const LEGION_NETWORK: Network = networkOfContract(LEGION_GOV_CONTRACT);
+
+/**
+ * The viewer page for an inscription. This is the form every proposal on chain
+ * already stores, and the form a voter wants: clicking it opens the ordinals
+ * viewer rather than dumping raw markdown.
+ */
+export const ORDINALS_INSCRIPTION_BASE = "https://ordinals.com/inscription/";
+
+/** The raw bytes of an inscription — what a reader fetches to render the piece. */
+export const ORDINALS_CONTENT_BASE = "https://ordinals.com/content/";
+
+/** The public reader for this legion. */
+export const LEGION_SITE_URL = "https://legions.aibtc.news";
+
+/** `link` is `(string-ascii 200)`. */
+export const MAX_LINK_LENGTH = 200;
+/** `title` is `(string-ascii 128)`. */
+export const MAX_TITLE_LENGTH = 128;
+/** `description` is `(string-ascii 512)`. */
+export const MAX_DESCRIPTION_LENGTH = 512;
+/** `sponsor-in` `name` is `(string-ascii 40)`. */
+export const MAX_SPONSOR_NAME_LENGTH = 40;
+/** `sponsor-in` `link` is `(optional (string-ascii 96))`. */
+export const MAX_SPONSOR_LINK_LENGTH = 96;
+/** `sponsor-in` `memo` is `(string-ascii 128)`. */
+export const MAX_SPONSOR_MEMO_LENGTH = 128;
+
+/** Story status uints as stored by the gov contract. */
+export const STORY_STATUS: Record<number, string> = {
+  0: "OPEN",
+  1: "PASSED",
+  2: "FAILED",
+  3: "EXPIRED",
+};
+
+/**
+ * Contract error codes, so a revert reads as a sentence rather than a `u4xx`.
+ * Gov and treasury codes are disjoint, so one map covers both.
+ */
+export const LEGION_ERRORS: Record<number, string> = {
+  401: "ineligible — your weight is below minWeight (contribute more first)",
+  402: "treasury has insufficient balance",
+  403: "treasury already wired to a gov contract",
+  404: "no proposal with that id",
+  405: "you have already voted on this proposal",
+  407: "voting has closed on this proposal",
+  408: "too early to conclude — the veto window has not closed yet",
+  409: "amount must be greater than zero",
+  410: "this proposal is already concluded",
+  411: "invalid payout recipient",
+  413: "your free weight does not cover the bond",
+  416: "this payout was already settled",
+  417: "the treasury payout failed",
+  418: "the pool is empty — nothing to draw against",
+  419: "the draw would round to zero sats",
+  421: "the ordinals link must not be empty",
+  423: "a proposer cannot vote on their own piece",
+  424: "outside the veto window",
+  425: "you have already vetoed this proposal",
+  426: "contribution too small to mint any weight",
+  432: "too soon to propose — the global propose interval has not elapsed",
+  433: "the title must not be empty",
+  434: "you already have a live proposal (one at a time per principal)",
+  435: "the conclude window has passed — this proposal has already expired",
+  436: "voting has not opened yet (still in the pending period)",
+  437: "contribution is below minContribution",
+  450: "sponsorship is below the treasury's minimum sponsor amount",
+  451: "the sponsor name must not be empty",
+  452: "the treasury is not wired to a gov contract yet",
+};

--- a/src/services/legion.service.ts
+++ b/src/services/legion.service.ts
@@ -1,0 +1,610 @@
+/**
+ * AIBTC News Legion (news-gov-v5) chain reads.
+ *
+ * Everything here reads the deployed contracts rather than trusting constants:
+ * governance parameters, the timing mode (which clock the windows count on),
+ * and the sBTC token the treasury actually holds all come off chain and are
+ * cached per process. A doc that drifts from the contract is a doc; a read that
+ * drifts from the contract is a bug, so there is nothing to drift.
+ */
+
+import {
+  ClarityType,
+  cvToJSON,
+  deserializeCV,
+  getAddressFromPrivateKey,
+  principalCV,
+  uintCV,
+  type ClarityValue,
+} from "@stacks/transactions";
+import {
+  LEGION_GOV_CONTRACT,
+  LEGION_NETWORK,
+  LEGION_TREASURY_CONTRACT,
+  ORDINALS_CONTENT_BASE,
+  ORDINALS_INSCRIPTION_BASE,
+} from "../config/legion.js";
+import { getHiroApi } from "./hiro-api.js";
+import { getAccount } from "./x402.service.js";
+import type { Account } from "../transactions/builder.js";
+
+// ---------------------------------------------------------------------------
+// Clarity value → plain JS
+// ---------------------------------------------------------------------------
+
+/**
+ * Deep-unwrap a ClarityValue into plain JS. `cvToValue` only unwraps the top
+ * level — nested tuples and optionals come back as `{type, value}` envelopes —
+ * so the legion's tuple-heavy views need this instead.
+ *
+ * uints/ints become strings to stay exact; callers narrow with `num()`.
+ */
+export function simplifyCV(cv: ClarityValue): unknown {
+  switch (cv.type) {
+    case ClarityType.BoolTrue:
+      return true;
+    case ClarityType.BoolFalse:
+      return false;
+    case ClarityType.Int:
+    case ClarityType.UInt:
+      return cv.value.toString();
+    case ClarityType.Buffer:
+      return `0x${cv.value}`;
+    case ClarityType.StringASCII:
+    case ClarityType.StringUTF8:
+    case ClarityType.PrincipalStandard:
+    case ClarityType.PrincipalContract:
+      return cv.value;
+    case ClarityType.OptionalNone:
+      return null;
+    case ClarityType.OptionalSome:
+    case ClarityType.ResponseOk:
+    case ClarityType.ResponseErr:
+      return simplifyCV(cv.value);
+    case ClarityType.List:
+      return cv.value.map(simplifyCV);
+    case ClarityType.Tuple: {
+      const out: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(cv.value)) {
+        out[key] = simplifyCV(value as ClarityValue);
+      }
+      return out;
+    }
+    default:
+      return cvToJSON(cv).value;
+  }
+}
+
+/** A uint field from a simplified tuple, as a JS number. */
+export function num(value: unknown): number {
+  return Number(value);
+}
+
+// ---------------------------------------------------------------------------
+// Contract reads
+// ---------------------------------------------------------------------------
+
+/**
+ * Call a read-only function on a legion contract and return it deep-unwrapped.
+ * Always reads the legion's own chain, never the globally configured one.
+ */
+export async function readLegionContract(
+  contractId: string,
+  functionName: string,
+  functionArgs: ClarityValue[] = []
+): Promise<unknown> {
+  const hiro = getHiroApi(LEGION_NETWORK);
+  const sender = contractId.split(".")[0];
+  const result = await hiro.callReadOnlyFunction(
+    contractId,
+    functionName,
+    functionArgs,
+    sender
+  );
+  if (!result.okay || !result.result) {
+    throw new Error(
+      `${contractId}::${functionName} failed: ${result.cause ?? "no result"}`
+    );
+  }
+  const hex = result.result.startsWith("0x")
+    ? result.result.slice(2)
+    : result.result;
+  return simplifyCV(deserializeCV(Buffer.from(hex, "hex")));
+}
+
+export function readGov(
+  functionName: string,
+  functionArgs: ClarityValue[] = []
+): Promise<unknown> {
+  return readLegionContract(LEGION_GOV_CONTRACT, functionName, functionArgs);
+}
+
+export function readTreasury(
+  functionName: string,
+  functionArgs: ClarityValue[] = []
+): Promise<unknown> {
+  return readLegionContract(LEGION_TREASURY_CONTRACT, functionName, functionArgs);
+}
+
+// ---------------------------------------------------------------------------
+// Cached chain configuration
+// ---------------------------------------------------------------------------
+
+export interface LegionParams {
+  votingQuorum: number;
+  votingThreshold: number;
+  vetoQuorum: number;
+  minParticipants: number;
+  minWeight: number;
+  minContribution: number;
+  drawBps: number;
+  votingDelay: number;
+  voteWindow: number;
+  vetoWindow: number;
+  concludeWindow: number;
+  proposeInterval: number;
+}
+
+let paramsCache: LegionParams | null = null;
+let timingModeCache: string | null = null;
+let tokenCache: { contract: string; assetName: string } | null = null;
+
+/** Every governance parameter, straight from `get-params`. */
+export async function getParams(): Promise<LegionParams> {
+  if (paramsCache) return paramsCache;
+  const raw = (await readGov("get-params")) as Record<string, unknown>;
+  paramsCache = {
+    votingQuorum: num(raw.votingQuorum),
+    votingThreshold: num(raw.votingThreshold),
+    vetoQuorum: num(raw.vetoQuorum),
+    minParticipants: num(raw.minParticipants),
+    minWeight: num(raw.minWeight),
+    minContribution: num(raw.minContribution),
+    drawBps: num(raw.drawBps),
+    votingDelay: num(raw.votingDelay),
+    voteWindow: num(raw.voteWindow),
+    vetoWindow: num(raw.vetoWindow),
+    concludeWindow: num(raw.concludeWindow),
+    proposeInterval: num(raw.proposeInterval),
+  };
+  return paramsCache;
+}
+
+/**
+ * Which clock the windows count on. `"TEST-STACKS-BLOCKS"` counts Stacks
+ * blocks; `"PROD-BURN"` counts Bitcoin burn blocks. Never assume — a window
+ * measured against the wrong tip is off by a factor of ten.
+ */
+export async function getTimingMode(): Promise<string> {
+  if (timingModeCache) return timingModeCache;
+  timingModeCache = (await readGov("get-timing-mode")) as string;
+  return timingModeCache;
+}
+
+/**
+ * The sBTC token the treasury actually moves, plus its fungible-token asset
+ * name — both needed to write an exact post-condition. Read from the treasury
+ * and its contract interface so a post-condition can never name the wrong asset.
+ */
+export async function getLegionToken(): Promise<{
+  contract: string;
+  assetName: string;
+}> {
+  if (tokenCache) return tokenCache;
+  const contract = (await readTreasury("get-token")) as string;
+  const iface = await getHiroApi(LEGION_NETWORK).getContractInterface(contract);
+  const assetName = iface.fungible_tokens?.[0]?.name;
+  if (!assetName) {
+    throw new Error(
+      `${contract} declares no fungible token — cannot build a post-condition for it.`
+    );
+  }
+  tokenCache = { contract, assetName };
+  return tokenCache;
+}
+
+/**
+ * The height the contract's windows are measured against, on the clock
+ * `get-timing-mode` names.
+ */
+export async function getClockHeight(): Promise<{
+  height: number;
+  clock: "stacks" | "burn";
+  timingMode: string;
+}> {
+  const [timingMode, info] = await Promise.all([
+    getTimingMode(),
+    getHiroApi(LEGION_NETWORK).getCoreApiInfo(),
+  ]);
+  const clock = timingMode === "PROD-BURN" ? "burn" : "stacks";
+  return {
+    height: clock === "burn" ? info.burn_block_height : info.stacks_tip_height,
+    clock,
+    timingMode,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The signing account, pinned to the legion's chain
+// ---------------------------------------------------------------------------
+
+/**
+ * The unlocked wallet, re-derived for the legion's network.
+ *
+ * The same private key yields a different address per chain, so a mainnet
+ * session still signs legion calls from its testnet address against the testnet
+ * node. This is the guard that makes a mainnet-configured server safe here.
+ */
+export async function getLegionAccount(): Promise<Account> {
+  const base = await getAccount();
+  if (base.network === LEGION_NETWORK) return base;
+  return {
+    ...base,
+    address: getAddressFromPrivateKey(base.privateKey, LEGION_NETWORK),
+    network: LEGION_NETWORK,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+export interface StoryRecord {
+  proposer: string;
+  bond: number;
+  draw: number;
+  createdAt: number;
+  voteEnd: number;
+  eligibleSnapshot: number;
+  yesWeight: number;
+  noWeight: number;
+  vetoWeight: number;
+  voterCount: number;
+  status: number;
+  reason: string;
+}
+
+export interface StoryMeta {
+  title: string;
+  description: string;
+  link: string;
+}
+
+export async function getStory(proposalId: number): Promise<StoryRecord | null> {
+  const raw = (await readGov("get-story", [uintCV(proposalId)])) as Record<
+    string,
+    unknown
+  > | null;
+  if (!raw) return null;
+  return {
+    proposer: String(raw.proposer),
+    bond: num(raw.bond),
+    draw: num(raw.draw),
+    createdAt: num(raw.createdAt),
+    voteEnd: num(raw.voteEnd),
+    eligibleSnapshot: num(raw.eligibleSnapshot),
+    yesWeight: num(raw.yesWeight),
+    noWeight: num(raw.noWeight),
+    vetoWeight: num(raw.vetoWeight),
+    voterCount: num(raw.voterCount),
+    status: num(raw.status),
+    reason: String(raw.reason ?? ""),
+  };
+}
+
+export async function getStoryMeta(
+  proposalId: number
+): Promise<StoryMeta | null> {
+  const raw = (await readGov("get-story-meta", [uintCV(proposalId)])) as Record<
+    string,
+    unknown
+  > | null;
+  if (!raw) return null;
+  return {
+    title: String(raw.title ?? ""),
+    description: String(raw.description ?? ""),
+    link: String(raw.link ?? ""),
+  };
+}
+
+/**
+ * `"none" | "pending" | "voting" | "veto" | "concludable" | "expired" |
+ * "passed" | "failed"` — the contract's own view of where a piece stands.
+ */
+export async function getPhase(proposalId: number): Promise<string> {
+  return (await readGov("get-phase", [uintCV(proposalId)])) as string;
+}
+
+export async function getLastProposalId(): Promise<number> {
+  return num(await readGov("get-last-proposal-id"));
+}
+
+export async function getVoteRecord(
+  proposalId: number,
+  voter: string
+): Promise<{ support: boolean; weight: number } | null> {
+  const raw = (await readGov("get-vote-record", [
+    uintCV(proposalId),
+    principalCV(voter),
+  ])) as Record<string, unknown> | null;
+  if (!raw) return null;
+  return { support: Boolean(raw.support), weight: num(raw.weight) };
+}
+
+export async function getVetoRecord(
+  proposalId: number,
+  voter: string
+): Promise<{ weight: number } | null> {
+  const raw = (await readGov("get-veto-record", [
+    uintCV(proposalId),
+    principalCV(voter),
+  ])) as Record<string, unknown> | null;
+  if (!raw) return null;
+  return { weight: num(raw.weight) };
+}
+
+export interface ProposeStatus {
+  canPropose: boolean;
+  eligible: boolean;
+  slotOpen: boolean;
+  noLiveProposal: boolean;
+  poolOk: boolean;
+  nextProposeHeight: number;
+  lockOnPropose: number;
+  draw: number;
+  freeWeight: number;
+}
+
+/** Every propose precondition folded into one read, with the individual gates. */
+export async function getProposeStatus(who: string): Promise<ProposeStatus> {
+  const raw = (await readGov("propose-status", [principalCV(who)])) as Record<
+    string,
+    unknown
+  >;
+  return {
+    canPropose: Boolean(raw.canPropose),
+    eligible: Boolean(raw.eligible),
+    slotOpen: Boolean(raw.slotOpen),
+    noLiveProposal: Boolean(raw.noLiveProposal),
+    poolOk: Boolean(raw.poolOk),
+    nextProposeHeight: num(raw.nextProposeHeight),
+    lockOnPropose: num(raw.lockOnPropose),
+    draw: num(raw.draw),
+    freeWeight: num(raw.freeWeight),
+  };
+}
+
+/** Why a propose would revert right now, in the caller's words. */
+export function proposeBlockers(status: ProposeStatus, minWeight: number): string[] {
+  const blockers: string[] = [];
+  if (!status.eligible) {
+    blockers.push(
+      `your weight is below minWeight (${minWeight}) — call legion_contribute first`
+    );
+  }
+  if (!status.noLiveProposal) {
+    blockers.push(
+      "you already have a live proposal — one per principal until it concludes or lapses"
+    );
+  }
+  if (!status.slotOpen) {
+    blockers.push(
+      `the contract-wide propose interval has not elapsed — next open at height ${status.nextProposeHeight}`
+    );
+  }
+  if (!status.poolOk) {
+    blockers.push("the pool is empty or the draw would round to zero sats");
+  }
+  return blockers;
+}
+
+// ---------------------------------------------------------------------------
+// Derived views
+// ---------------------------------------------------------------------------
+
+export interface StoryTimeline {
+  createdAt: number;
+  votingOpensAt: number;
+  voteEnd: number;
+  vetoEnd: number;
+  concludeDeadline: number;
+  currentHeight: number;
+  clock: "stacks" | "burn";
+  blocksUntilNextTransition: number | null;
+}
+
+/** When each window opens and closes, on the clock the contract counts. */
+export function buildTimeline(
+  story: StoryRecord,
+  params: LegionParams,
+  height: number,
+  clock: "stacks" | "burn"
+): StoryTimeline {
+  const votingOpensAt = story.createdAt + params.votingDelay;
+  const vetoEnd = story.voteEnd + params.vetoWindow;
+  const concludeDeadline = vetoEnd + params.concludeWindow;
+  const nextBoundary = [votingOpensAt, story.voteEnd, vetoEnd, concludeDeadline].find(
+    (boundary) => boundary > height
+  );
+  return {
+    createdAt: story.createdAt,
+    votingOpensAt,
+    voteEnd: story.voteEnd,
+    vetoEnd,
+    concludeDeadline,
+    currentHeight: height,
+    clock,
+    blocksUntilNextTransition:
+      nextBoundary === undefined ? null : nextBoundary - height,
+  };
+}
+
+export interface PredictedOutcome {
+  outcome: "passed" | "failed" | "expired";
+  reason: string;
+  /** True when the outcome is what the contract already recorded, not a forecast. */
+  settled: boolean;
+  cast: number;
+  quorumPct: number;
+  yesPct: number;
+  vetoPct: number;
+  quorumMet: boolean;
+  thresholdMet: boolean;
+  vetoed: boolean;
+  participantsMet: boolean;
+  payout: number;
+}
+
+/**
+ * What `conclude` would decide if it ran at this height, following the
+ * contract's decision order exactly (integer division included, since Clarity
+ * floors every percentage).
+ *
+ * A story that is already terminal reports what the contract RECORDED, not a
+ * forecast. Forecasting a settled piece would be worse than useless: a passed
+ * proposal is necessarily past its conclude window, so the forecast branch
+ * would call every settled piece "expired".
+ */
+export function predictOutcome(
+  story: StoryRecord,
+  params: LegionParams,
+  poolBalance: number,
+  height: number
+): PredictedOutcome {
+  const cast = story.yesWeight + story.noWeight;
+  const eligible = story.eligibleSnapshot;
+  const quorumPct = eligible > 0 ? Math.floor((cast * 100) / eligible) : 0;
+  const yesPct = cast > 0 ? Math.floor((story.yesWeight * 100) / cast) : 0;
+  const vetoPct =
+    eligible > 0 ? Math.floor((story.vetoWeight * 100) / eligible) : 0;
+
+  const participantsMet = story.voterCount >= params.minParticipants;
+  const quorumMet = eligible > 0 && participantsMet && quorumPct >= params.votingQuorum;
+  const thresholdMet = cast > 0 && yesPct >= params.votingThreshold;
+  const vetoed = eligible > 0 && vetoPct >= params.vetoQuorum;
+
+  const base = {
+    cast,
+    quorumPct,
+    yesPct,
+    vetoPct,
+    quorumMet,
+    thresholdMet,
+    vetoed,
+    participantsMet,
+  };
+
+  // Already terminal: report the record.
+  if (story.status !== 0) {
+    const settledOutcome =
+      story.status === 1 ? "passed" : story.status === 3 ? "expired" : "failed";
+    return {
+      ...base,
+      settled: true,
+      outcome: settledOutcome,
+      reason: story.reason || settledOutcome,
+      payout: story.status === 1 ? story.draw : 0,
+    };
+  }
+
+  const concludeDeadline = story.voteEnd + params.vetoWindow + params.concludeWindow;
+  if (height >= concludeDeadline) {
+    return {
+      ...base,
+      settled: false,
+      outcome: "expired",
+      reason: "not-concluded — the conclude window closed with nobody calling it",
+      payout: 0,
+    };
+  }
+  if (vetoed) {
+    return { ...base, settled: false, outcome: "failed", reason: "vetoed", payout: 0 };
+  }
+  if (!quorumMet) {
+    return { ...base, settled: false, outcome: "failed", reason: "no-quorum", payout: 0 };
+  }
+  if (!thresholdMet) {
+    return { ...base, settled: false, outcome: "failed", reason: "voted-down", payout: 0 };
+  }
+  if (story.draw > poolBalance) {
+    return { ...base, settled: false, outcome: "failed", reason: "pool-short", payout: 0 };
+  }
+  return { ...base, settled: false, outcome: "passed", reason: "paid", payout: story.draw };
+}
+
+// ---------------------------------------------------------------------------
+// Links and validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Accept either a bare inscription id (`<txid>i0`) or a full URL, and return
+ * the link the contract should store.
+ *
+ * A bare id becomes the VIEWER url, not the content url: that is what every
+ * proposal already on chain uses, and it is what a voter wants from a click.
+ * The reader at legions.aibtc.news accepts either form and both bare ids.
+ */
+export function normalizeOrdinalsLink(input: string): string {
+  const trimmed = input.trim();
+  if (/^[0-9a-f]{64}i\d+$/i.test(trimmed)) {
+    return `${ORDINALS_INSCRIPTION_BASE}${trimmed.toLowerCase()}`;
+  }
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  throw new Error(
+    `"${input}" is neither an inscription id (<64-hex-txid>i0) nor a URL. ` +
+      `Pass the inscription id from legion_inscribe_reveal, or a full https:// link.`
+  );
+}
+
+/** The inscription id inside an ordinals link, when there is one. */
+export function inscriptionIdFromLink(link: string): string | null {
+  const match = link.match(/([0-9a-f]{64}i\d+)/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * The raw-bytes url for a stored link, so a voter can read the piece rather
+ * than just look at where it lives. Null when the link names no inscription.
+ */
+export function contentUrlFromLink(link: string): string | null {
+  const id = inscriptionIdFromLink(link);
+  return id ? `${ORDINALS_CONTENT_BASE}${id}` : null;
+}
+
+/**
+ * Clarity `string-ascii` holds one byte per character, so a smart quote or an
+ * em dash pasted into a headline is a revert, not a truncation. Catch it here
+ * with a message that names the character.
+ */
+export function assertAscii(
+  value: string,
+  field: string,
+  maxLength: number
+): void {
+  const offender = [...value].find((char) => char.charCodeAt(0) > 127);
+  if (offender) {
+    throw new Error(
+      `${field} must be ASCII — "${offender}" (U+${offender
+        .charCodeAt(0)
+        .toString(16)
+        .toUpperCase()
+        .padStart(4, "0")}) is not. Clarity string-ascii cannot hold it.`
+    );
+  }
+  if (value.length > maxLength) {
+    throw new Error(
+      `${field} is ${value.length} characters; the contract accepts at most ${maxLength}.`
+    );
+  }
+}
+
+/** `(err uXXX)` from a failed read or a broadcast rejection, as a sentence. */
+export function explainError(error: unknown, errors: Record<number, string>): string {
+  const text = error instanceof Error ? error.message : String(error);
+  const match = text.match(/\bu(\d{3})\b/);
+  if (match) {
+    const explanation = errors[Number(match[1])];
+    if (explanation) return `${text} — ${explanation}`;
+  }
+  return text;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -38,6 +38,7 @@ import { registerJingswapTools } from "./jingswap.tools.js";
 import { registerSigningTools } from "./signing.tools.js";
 import { registerInferenceMarketplaceTools } from "./inference-marketplace.tools.js";
 import { registerNewsTools } from "./news.tools.js";
+import { registerLegionTools } from "./legion.tools.js";
 import { registerIdentityTools } from "./identity.tools.js";
 import { registerCredentialsTools } from "./credentials.tools.js";
 import { registerSouldinalsTools } from "./souldinals.tools.js";
@@ -210,6 +211,9 @@ export function registerAllTools(server: McpServer): void {
 
   // AIBTC News (signal feed, leaderboard, file signals)
   registerNewsTools(server);
+
+  // AIBTC News Legion (news-gov-v5 governance — inscribe, propose, vote, veto, conclude)
+  registerLegionTools(server);
 
   // Identity (ERC-8004 on-chain agent identity management)
   registerIdentityTools(server);

--- a/src/tools/legion.tools.ts
+++ b/src/tools/legion.tools.ts
@@ -1,29 +1,18 @@
 /**
  * AIBTC News Legion tools (news-gov-v5).
  *
- * Contribution-weighted governance for aibtc.news. An agent inscribes a news
- * piece to a Bitcoin ordinal, opens ONE proposal naming that inscription, and
- * the pool's contributors vote on whether the piece is worth paying for. A
- * passing piece pays its proposer a fixed slice of the sBTC pool.
+ * Lifecycle: inscribe → reveal → propose → vote → veto → conclude, plus
+ * contribute (buys weight) and sponsor (does not).
  *
- * Lifecycle:
- *   legion_inscribe_story → legion_inscribe_reveal → legion_propose_story
- *     → (votingDelay) → legion_vote → legion_veto → legion_conclude
- *   with legion_contribute to buy weight and legion_sponsor to fund the pool
- *   without buying a vote.
+ * These tools pin their own network: `getLegionAccount()` re-derives the
+ * unlocked wallet for the legion's chain, so a mainnet-configured server signs
+ * against testnet. Inscription is the exception — real BTC on whatever chain
+ * NETWORK names.
  *
- * THESE TOOLS PIN THEIR OWN NETWORK. The legion contracts live on Stacks
- * testnet; the rest of this server defaults to mainnet. `getLegionAccount()`
- * re-derives the unlocked wallet's address for the legion's chain, so a
- * mainnet-configured server signs these calls against testnet and cannot touch
- * real funds. Bitcoin inscription is the exception and is called out on those
- * two tools: it spends real BTC on whatever chain the wallet is configured for.
- *
- * Every fund-moving call is DENY mode with an exact post-condition. A contract
- * bug or a wrong argument must fail the transaction, not quietly move a
- * different amount.
+ * Fund-moving calls sign in DENY mode with an exact post-condition.
  */
 
+import { createHash } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
@@ -37,6 +26,7 @@ import {
   PostConditionMode,
 } from "@stacks/transactions";
 import { NETWORK, getExplorerTxUrl } from "../config/networks.js";
+import { DUST_THRESHOLD } from "../config/bitcoin-constants.js";
 import {
   LEGION_ERRORS,
   LEGION_GOV_CONTRACT,
@@ -103,6 +93,17 @@ const [TREASURY_ADDRESS, TREASURY_NAME] = LEGION_TREASURY_CONTRACT.split(".");
 const STORY_CONTENT_TYPE = "text/markdown;charset=utf-8";
 
 /**
+ * Bitcoin's standardness limit on a transaction is ~400 kB, and the inscription
+ * body rides in the REVEAL witness. An oversized body therefore commits fine and
+ * then strands the sats: the reveal is rejected by every node it reaches. Refuse
+ * at the commit, with headroom for the script and control block.
+ */
+const MAX_INSCRIPTION_BYTES = 390_000;
+
+/** Large enough to be worth saying out loud before spending the fee on it. */
+const LARGE_INSCRIPTION_WARN_BYTES = 100_000;
+
+/**
  * Phases that mean the piece is still moving, for the `live` list filter.
  * `pending` is a phase, not a stored status — a proposal is OPEN in storage
  * from the moment it is filed, but voting does not open until votingDelay
@@ -130,20 +131,82 @@ function explorerUrl(txid: string): string {
   return getExplorerTxUrl(txid, LEGION_NETWORK);
 }
 
-/** Resolve a named fee tier against live mempool estimates. */
+/**
+ * Resolve a named fee tier against live mempool estimates.
+ *
+ * The builders reject `feeRate <= 0`, which `NaN` slips past — and a NaN rate
+ * propagates through every size calculation into a transaction with garbage
+ * amounts. mempool.space does intermittently return junk here, so the estimate
+ * is validated as a finite positive number rather than trusted.
+ */
 async function resolveFeeRate(
   mempoolApi: MempoolApi,
   feeRate?: "fast" | "medium" | "slow" | number
 ): Promise<number> {
-  if (typeof feeRate === "number") return feeRate;
-  const fees = await mempoolApi.getFeeEstimates();
-  switch (feeRate) {
-    case "fast":
-      return fees.fastestFee;
-    case "slow":
-      return fees.hourFee;
-    default:
-      return fees.halfHourFee;
+  let resolved: number;
+  if (typeof feeRate === "number") {
+    resolved = feeRate;
+  } else {
+    const fees = await mempoolApi.getFeeEstimates();
+    resolved =
+      feeRate === "fast"
+        ? fees.fastestFee
+        : feeRate === "slow"
+          ? fees.hourFee
+          : fees.halfHourFee;
+    if (!Number.isFinite(resolved) || resolved <= 0) {
+      throw new Error(
+        `mempool.space returned an unusable fee estimate (${resolved}) for the ` +
+          `"${feeRate ?? "medium"}" tier. Pass an explicit feeRate in sat/vB.`
+      );
+    }
+  }
+  if (!Number.isFinite(resolved) || resolved <= 0) {
+    throw new Error(`feeRate must be a positive number of sat/vB, got ${resolved}.`);
+  }
+  return resolved;
+}
+
+/** The markdown a title+body pair inscribes to. One definition, both steps. */
+function buildStoryMarkdown(title: string, body: string): string {
+  return body.trimStart().startsWith("#") ? body : `# ${title}\n\n${body}`;
+}
+
+/**
+ * Check the commit actually paid the reveal script we just derived.
+ *
+ * The reveal script is derived from the content, so one stray character between
+ * commit and reveal yields a different address, an unspendable commit and lost
+ * sats. Comparing against the commit's real output catches that — and a wrong
+ * commitTxid, parent or revealAmount — before anything is signed.
+ */
+async function assertCommitMatches(
+  mempoolApi: MempoolApi,
+  commitTxid: string,
+  derivedRevealAddress: string | undefined,
+  revealAmount: number
+): Promise<void> {
+  if (!derivedRevealAddress) {
+    throw new Error("Could not derive a reveal address for this content.");
+  }
+  const tx = await mempoolApi.getTx(commitTxid);
+  const output = tx.vout[0];
+  if (!output) {
+    throw new Error(`Commit ${commitTxid} has no output 0.`);
+  }
+  if (output.scriptpubkey_address !== derivedRevealAddress) {
+    throw new Error(
+      `This content does not match commit ${commitTxid}. It paid ` +
+        `${output.scriptpubkey_address}, but this title/body derives ` +
+        `${derivedRevealAddress}. Pass the exact title, body and parentInscriptionId ` +
+        `used at commit. Nothing was broadcast.`
+    );
+  }
+  if (output.value !== revealAmount) {
+    throw new Error(
+      `revealAmount ${revealAmount} does not match commit output 0, which holds ` +
+        `${output.value} sats. Use ${output.value}. Nothing was broadcast.`
+    );
   }
 }
 
@@ -156,12 +219,9 @@ export function registerLegionTools(server: McpServer): void {
     "legion_status",
     {
       description:
-        "AIBTC News Legion (news-gov-v5) at a glance: the sBTC pool, total voting weight, " +
-        "live governance parameters read from the contract, the current block height on the " +
-        "clock the contract counts, and your own weight if a wallet is unlocked.\n\n" +
-        "Start here. Everything else in the legion_* family assumes these numbers.\n\n" +
-        "Reads only — no wallet required, no transaction. Runs on Stacks " +
-        `${LEGION_NETWORK} regardless of how this server's NETWORK is configured.`,
+        "News Legion at a glance: sBTC pool, total weight, governance params read from the " +
+        "contract, current height, and your own weight if a wallet is unlocked. Start here.\n\n" +
+        `Reads only. Runs on Stacks ${LEGION_NETWORK} regardless of this server's NETWORK.`,
       inputSchema: {},
     },
     async () => {
@@ -267,13 +327,10 @@ export function registerLegionTools(server: McpServer): void {
     "legion_list_stories",
     {
       description:
-        "List proposals in the News Legion, newest first, with each one's phase, tally and " +
-        "the inscription it points at.\n\n" +
-        "Filter by phase. `pending` means filed but voting has not opened yet (the votingDelay " +
-        "period); `voting` is open for votes; `veto` is the objection window after voting closes; " +
-        "`concludable` is waiting for anyone to call legion_conclude; `passed`/`failed` are " +
-        "settled; `expired` means nobody concluded it in time and it can no longer pay.\n\n" +
-        "Reads only — no wallet required.",
+        "Proposals newest first, with phase, tally and the inscription each points at.\n\n" +
+        "Phases: `pending` (filed, voting not open yet), `voting`, `veto`, `concludable`, " +
+        "`passed`/`failed` (settled), `expired` (nobody concluded in time; can no longer pay).\n\n" +
+        "Reads only.",
       inputSchema: {
         phase: z
           .enum([
@@ -398,13 +455,10 @@ export function registerLegionTools(server: McpServer): void {
     "legion_get_story",
     {
       description:
-        "Everything about one proposal: title, description, the inscription link, the full " +
-        "vote tally against the quorum and threshold it has to clear, when each window opens " +
-        "and closes, what `conclude` would decide if called right now, and — when a wallet is " +
-        "unlocked — whether you have already voted or vetoed.\n\n" +
-        "Read this before voting. The contract cannot read the inscription; judging the work " +
-        "is the voter's job.\n\n" +
-        "Reads only — no wallet required.",
+        "One proposal in full: tally against the quorum and threshold it must clear, the " +
+        "window timeline, what `conclude` would decide now, and whether you have voted.\n\n" +
+        "Read this before voting — the contract cannot read the inscription, so judging the " +
+        "work is the voter's job.\n\nReads only.",
       inputSchema: {
         proposalId: z.number().int().positive().describe("The proposal id"),
       },
@@ -529,12 +583,9 @@ export function registerLegionTools(server: McpServer): void {
     "legion_my_position",
     {
       description:
-        "Your standing in the legion: voting weight and share of the pool, how much of it is " +
-        "locked by a live proposal bond, your sBTC balance, what a proposal would pay you " +
-        "today, and every precondition on proposing — folded from the contract's own " +
-        "`propose-status`, so a blocked propose tells you which gate to wait on instead of " +
-        "burning a transaction on the revert.\n\n" +
-        "Requires an unlocked wallet (read-only — signs nothing).",
+        "Your weight, share, bond lock, sBTC balance, and every propose precondition folded " +
+        "from the contract's `propose-status` — so a blocked propose names the gate to wait on.\n\n" +
+        "Requires an unlocked wallet. Signs nothing.",
       inputSchema: {},
     },
     async () => {
@@ -600,11 +651,8 @@ export function registerLegionTools(server: McpServer): void {
     "legion_faucet",
     {
       description:
-        "Mint testnet sBTC from the faucet on the token contract this legion uses, so you " +
-        "have something to contribute or sponsor with.\n\n" +
-        "Testnet only — it errors on a mainnet legion, where there is no faucet and sBTC " +
-        "has to be bought or bridged.\n\n" +
-        "Requires an unlocked wallet.",
+        "Mint testnet sBTC from the faucet on this legion's token contract.\n\n" +
+        "Testnet only. Requires an unlocked wallet.",
       inputSchema: {},
     },
     async () => {
@@ -656,13 +704,10 @@ export function registerLegionTools(server: McpServer): void {
     "legion_contribute",
     {
       description:
-        "Send sBTC to the legion's pool and receive voting weight in proportion to your share " +
-        "of the contributed balance.\n\n" +
-        "CONTRIBUTIONS ARE NOT REFUNDABLE. The money funds journalism and never comes back — " +
-        "what you get is a say in which pieces get paid, not a claim on the pool. If you want " +
-        "to fund the pool WITHOUT a vote, use legion_sponsor instead.\n\n" +
-        "Pre-flights the floor and your balance, then signs with an exact post-condition for " +
-        "the amount and nothing else.\n\n" +
+        "Send sBTC to the pool and receive voting weight proportional to your share of the " +
+        "contributed balance.\n\n" +
+        "NOT REFUNDABLE — you get a say in which pieces get paid, not a claim on the pool. " +
+        "To fund the pool without a vote, use legion_sponsor.\n\n" +
         "Requires an unlocked wallet.",
       inputSchema: {
         sats: z
@@ -746,15 +791,11 @@ export function registerLegionTools(server: McpServer): void {
     "legion_sponsor",
     {
       description:
-        "Fund the legion's pool WITHOUT minting any voting weight, and put a name on the " +
-        "record. A sponsor pays for journalism and attribution, not a say in what gets " +
-        "published.\n\n" +
-        "Sponsorship does not raise the price of joining (weight is priced against the " +
-        "contributed balance only), but it does enlarge every payout, because the draw is a " +
-        "fraction of the whole pool.\n\n" +
-        "`name`, `link` and `memo` are unverified strings — the contract never reads them. " +
-        "Any display must treat the paying principal and the txid as the real identity.\n\n" +
-        "DEPOSITS ARE FINAL. There is no refund path and cannot be one.\n\n" +
+        "Fund the pool WITHOUT minting voting weight, with a name on the record.\n\n" +
+        "Does not raise the price of joining (weight is priced against contributed sats only), " +
+        "but does enlarge every payout, since the draw is a fraction of the whole pool.\n\n" +
+        "`name`, `link` and `memo` are unverified — the paying principal and txid are the real " +
+        "identity. FINAL: no refund path exists.\n\n" +
         "Requires an unlocked wallet.",
       inputSchema: {
         sats: z
@@ -858,16 +899,12 @@ export function registerLegionTools(server: McpServer): void {
     "legion_propose_story",
     {
       description:
-        "Open a vote on one inscribed news piece. If it passes, YOU are paid the draw — the " +
+        "Open a vote on one inscribed piece. If it passes, YOU are paid the draw — the " +
         "proposer is the only reachable payee.\n\n" +
-        "Pass the inscription id from legion_inscribe_reveal (or any ordinals content URL) " +
-        "plus your own title and description; the contract stores all three verbatim and " +
-        "never reads the inscription itself. Voters open the link and judge the work, so a " +
-        "junk or replayed link gets voted or vetoed down.\n\n" +
-        "Proposing locks your ENTIRE voting weight until the piece resolves — one live " +
-        "proposal per principal. The lock is never spent and releases on every outcome.\n\n" +
-        "Pre-flights every precondition the contract checks and refuses locally with the " +
-        "specific blocker rather than burning a transaction on the revert.\n\n" +
+        "The contract stores link, title and description verbatim and never reads the " +
+        "inscription. Proposing locks your ENTIRE weight until the piece resolves — one live " +
+        "proposal per principal; the lock is never spent and releases on every outcome.\n\n" +
+        "Pre-flights every precondition and refuses locally with the specific blocker.\n\n" +
         "Requires an unlocked wallet.",
       inputSchema: {
         link: z
@@ -977,13 +1014,10 @@ export function registerLegionTools(server: McpServer): void {
     "legion_vote",
     {
       description:
-        "Vote yes or no on a proposal with your current weight. One vote per principal, and " +
-        "a proposer cannot vote on their own piece.\n\n" +
-        "Read the inscription first — legion_get_story gives you the link. The contract " +
-        "cannot see the work; judging it is the whole job.\n\n" +
-        "Pre-flights the phase, your weight and whether you have already voted, so a vote " +
-        "that would revert is refused locally.\n\n" +
-        "Requires an unlocked wallet.",
+        "Vote yes or no with your current weight. One vote per principal; a proposer cannot " +
+        "vote on their own piece.\n\n" +
+        "Read the inscription first — legion_get_story gives you the link.\n\n" +
+        "Pre-flights phase, weight and prior vote. Requires an unlocked wallet.",
       inputSchema: {
         proposalId: z.number().int().positive().describe("The proposal id"),
         support: z
@@ -1090,13 +1124,10 @@ export function registerLegionTools(server: McpServer): void {
     "legion_veto",
     {
       description:
-        "Object to a proposal during the veto window — the blocking pass after voting closes. " +
-        "If vetoes reach the veto quorum of eligible weight, the piece fails regardless of how " +
-        "the vote went.\n\n" +
-        "This is the backstop against a plagiarised, replayed or junk inscription that slipped " +
-        "past the vote. A proposer may veto their own piece, which simply withdraws it.\n\n" +
-        "Pre-flights the window and your weight.\n\n" +
-        "Requires an unlocked wallet.",
+        "Object during the veto window. At veto quorum the piece fails regardless of the vote — " +
+        "the backstop against a plagiarised or junk inscription that slipped past. A proposer " +
+        "may veto their own piece, which withdraws it.\n\n" +
+        "Pre-flights the window and your weight. Requires an unlocked wallet.",
       inputSchema: {
         proposalId: z.number().int().positive().describe("The proposal id"),
       },
@@ -1188,14 +1219,12 @@ export function registerLegionTools(server: McpServer): void {
     "legion_conclude",
     {
       description:
-        "Settle a proposal: work out the outcome and, if it passed, pay the proposer the draw " +
-        "from the treasury. Permissionless — anyone may call it, and someone must.\n\n" +
-        "A piece nobody concludes inside its conclude window EXPIRES and pays no one, and after " +
-        "that it can never be concluded at all. Concluding late pays exactly what concluding " +
-        "early would, because the draw was snapshotted at propose time.\n\n" +
-        "Signs with a post-condition capping what the treasury may pay at the snapshotted draw, " +
-        "which covers both the paying and the non-paying outcomes.\n\n" +
-        "Requires an unlocked wallet (the caller pays gas; the payout goes to the proposer).",
+        "Settle a proposal and, if it passed, pay the proposer the draw. Permissionless — " +
+        "anyone may call it, and someone must.\n\n" +
+        "A piece nobody concludes inside its window EXPIRES, pays no one, and can never be " +
+        "concluded after. Concluding late pays what concluding early would; the draw was " +
+        "snapshotted at propose time.\n\n" +
+        "Requires an unlocked wallet — caller pays gas, proposer gets the payout.",
       inputSchema: {
         proposalId: z.number().int().positive().describe("The proposal id"),
       },
@@ -1300,23 +1329,17 @@ export function registerLegionTools(server: McpServer): void {
     "legion_inscribe_story",
     {
       description:
-        "Inscribe a news piece to a Bitcoin ordinal as markdown — STEP 1: broadcast the commit " +
-        "transaction.\n\n" +
-        "This is the piece the legion votes on. Write it as markdown; a title is prepended as " +
-        "an H1 unless the body already starts with one.\n\n" +
-        "SPENDS REAL BITCOIN. Unlike the rest of the legion_* tools (which are pinned to the " +
-        `legion's Stacks ${LEGION_NETWORK}), inscription runs on the Bitcoin network this ` +
-        `server is configured for, currently ${NETWORK}. ordinals.com only serves mainnet ` +
-        "inscriptions, so a non-mainnet inscription will not resolve for voters.\n\n" +
-        "Optionally makes the piece a CHILD of a parent inscription you own, per the Ordinals " +
-        "provenance spec. That binds every piece you file to one inscribed identity, which the " +
-        "governance contract cannot do — it records the Stacks principal that proposed, and the " +
-        "Bitcoin key that inscribed is a different identity entirely. It proves a body of work " +
-        "shares an author; it does NOT prove the work is original, which stays the voters' job " +
-        "and the veto window's.\n\n" +
-        "Returns immediately without waiting for confirmation. Once the commit confirms " +
-        "(typically 10-60 min), call legion_inscribe_reveal with the values returned here.\n\n" +
-        "Requires an unlocked managed wallet with Bitcoin keys and funded UTXOs.",
+        "Inscribe a news piece to a Bitcoin ordinal as markdown — STEP 1, the commit.\n\n" +
+        "Content type is text/markdown; the title is prepended as an H1 unless the body already " +
+        "starts with one.\n\n" +
+        `SPENDS REAL BITCOIN, on the Bitcoin network NETWORK names (currently ${NETWORK}) — ` +
+        `not the Stacks ${LEGION_NETWORK} the rest of the legion_* tools use.\n\n` +
+        "Optional `parentInscriptionId` files the piece as a child of a parent you own, binding " +
+        "your pieces to one inscribed identity. That is authorship, not originality.\n\n" +
+        "Pre-flights content size, fee estimate, parent ownership, funding and network before " +
+        "signing. `dryRun` prices it without broadcasting.\n\n" +
+        "Returns without waiting. After the commit confirms, call legion_inscribe_reveal.\n\n" +
+        "Requires an unlocked managed wallet with funded UTXOs.",
       inputSchema: {
         title: z
           .string()
@@ -1334,14 +1357,42 @@ export function registerLegionTools(server: McpServer): void {
               "You must own it: the reveal spends the parent's UTXO and returns it to you, " +
               "so children from one parent must be inscribed one at a time."
           ),
+        dryRun: z
+          .boolean()
+          .optional()
+          .describe(
+            "Run every pre-flight check and price the inscription, but sign nothing. " +
+              "Use this to see the cost before spending it."
+          ),
+        allowNonMainnet: z
+          .boolean()
+          .optional()
+          .describe(
+            "Permit inscribing on a non-mainnet Bitcoin network. Refused by default: " +
+              "ordinals.com serves mainnet only, so the link would 404 for every voter."
+          ),
         feeRate: z
           .union([z.enum(["fast", "medium", "slow"]), z.number().positive()])
           .optional()
           .describe("Fee rate: 'fast', 'medium', 'slow', or a number in sat/vB (default: medium)"),
       },
     },
-    async ({ title, body, parentInscriptionId, feeRate }) => {
+    async ({ title, body, parentInscriptionId, dryRun, allowNonMainnet, feeRate }) => {
       try {
+        // A testnet inscription is almost always a misconfiguration here: the
+        // legion's governance is testnet but its links are read on mainnet
+        // ordinals.com, so the piece would be unreadable to every voter. A JSON
+        // warning field was too easy to miss for something that costs sats.
+        if (NETWORK !== "mainnet" && !allowNonMainnet) {
+          return createErrorResponse(
+            new Error(
+              `Bitcoin network is ${NETWORK}, and ordinals.com serves mainnet inscriptions ` +
+                `only — voters could not open the link this produces. Set NETWORK=mainnet, ` +
+                `or pass allowNonMainnet: true if you are deliberately testing. Nothing was broadcast.`
+            )
+          );
+        }
+
         const walletManager = getWalletManager();
         const sessionInfo = walletManager.getSessionInfo();
         if (!sessionInfo) {
@@ -1389,10 +1440,21 @@ export function registerLegionTools(server: McpServer): void {
           );
         }
 
-        const markdown = body.trimStart().startsWith("#")
-          ? body
-          : `# ${title}\n\n${body}`;
+        const markdown = buildStoryMarkdown(title, body);
         const content = Buffer.from(markdown, "utf8");
+        // The body rides in the reveal witness, so an oversized piece commits
+        // fine and then cannot be revealed at all. Refuse before spending.
+        if (content.length > MAX_INSCRIPTION_BYTES) {
+          return createErrorResponse(
+            new Error(
+              `The piece is ${content.length} bytes, over the ${MAX_INSCRIPTION_BYTES}-byte ` +
+                `ceiling. The content rides in the reveal witness, so a commit would confirm ` +
+                `and the reveal would then be rejected as non-standard, stranding the sats. ` +
+                `Split the piece or inscribe a summary that links out. Nothing was broadcast.`
+            )
+          );
+        }
+        const contentHash = createHash("sha256").update(content).digest("hex");
         const inscription: InscriptionData = {
           contentType: STORY_CONTENT_TYPE,
           body: content,
@@ -1429,6 +1491,63 @@ export function registerLegionTools(server: McpServer): void {
                 senderAddress: sessionInfo.btcAddress,
                 network: NETWORK,
               });
+
+        // What the commit output can still afford at reveal time. The reveal
+        // takes its own feeRate, and a rate above this leaves the reveal output
+        // under dust — the builder refuses and the sats sit in the commit until
+        // it is retried lower. Say the ceiling here so it is never hit.
+        const revealVbytes = Math.max(
+          1,
+          Math.round(commitResult.revealAmount / Math.max(actualFeeRate, 1))
+        );
+        const maxRevealFeeRate = Math.max(
+          1,
+          Math.floor((commitResult.revealAmount - DUST_THRESHOLD) / revealVbytes)
+        );
+
+        const probes = {
+          network: NETWORK,
+          contentSize: content.length,
+          contentHash: `sha256:${contentHash}`,
+          feeRate: actualFeeRate,
+          utxos: {
+            count: utxos.length,
+            totalSats: utxos.reduce((sum, utxo) => sum + utxo.value, 0),
+          },
+          parent: parentInfo
+            ? {
+                inscriptionId: parentInscriptionId,
+                txid: parentInfo.txid,
+                vout: parentInfo.vout,
+                value: parentInfo.value,
+                owned: true,
+              }
+            : null,
+          estimatedCost: {
+            commitFee: commitResult.fee,
+            revealAmount: commitResult.revealAmount,
+            totalSats: commitResult.fee + commitResult.revealAmount,
+          },
+          maxRevealFeeRate,
+          sizeWarning:
+            content.length > LARGE_INSCRIPTION_WARN_BYTES
+              ? `${content.length} bytes is a large inscription — the fee scales with it.`
+              : undefined,
+        };
+
+        if (dryRun) {
+          return createJsonResponse({
+            status: "dry_run",
+            probes,
+            revealAddress: commitResult.revealAddress,
+            title,
+            markdown,
+            broadcast: false,
+            nextStep:
+              "Nothing was signed. Re-call without dryRun to broadcast the commit.",
+          });
+        }
+
         const commitSigned = signBtcTransaction(
           commitResult.tx,
           account.btcPrivateKey
@@ -1478,15 +1597,11 @@ export function registerLegionTools(server: McpServer): void {
     "legion_inscribe_reveal",
     {
       description:
-        "Complete a news inscription — STEP 2: broadcast the reveal transaction, after the " +
-        "commit from legion_inscribe_story has confirmed.\n\n" +
-        "Pass the SAME title, body and parentInscriptionId used in the commit step — the reveal " +
-        "script is derived from all of them, so any difference produces a different script and " +
-        "the reveal fails.\n\n" +
-        "With a parent, the reveal spends both the commit output and the parent's UTXO, returns " +
-        "the parent to your Taproot address, and creates the child.\n\n" +
-        "Returns the inscription id and the ordinals.com link, ready to hand straight to " +
-        "legion_propose_story.\n\n" +
+        "Complete a news inscription — STEP 2, the reveal, after the commit has confirmed.\n\n" +
+        "Pass the SAME title, body and parentInscriptionId used at commit: the reveal script is " +
+        "derived from all three. The commit's actual output is checked against the script this " +
+        "content derives, so a mismatch is refused before signing rather than losing the sats.\n\n" +
+        "Returns the inscription id and link for legion_propose_story.\n\n" +
         "Requires an unlocked managed wallet.",
       inputSchema: {
         commitTxid: z
@@ -1550,12 +1665,12 @@ export function registerLegionTools(server: McpServer): void {
           );
         }
 
-        const markdown = body.trimStart().startsWith("#")
-          ? body
-          : `# ${title}\n\n${body}`;
+        const markdown = buildStoryMarkdown(title, body);
+        const content = Buffer.from(markdown, "utf8");
+        const contentHash = createHash("sha256").update(content).digest("hex");
         const inscription: InscriptionData = {
           contentType: STORY_CONTENT_TYPE,
-          body: Buffer.from(markdown, "utf8"),
+          body: content,
         };
 
         const mempoolApi = new MempoolApi(NETWORK);
@@ -1563,6 +1678,7 @@ export function registerLegionTools(server: McpServer): void {
 
         let revealResult;
         let revealTxid: string;
+        let derivedRevealAddress: string | undefined;
         if (parentInscriptionId !== undefined && parentInfo) {
           const revealScript = deriveChildRevealScript({
             inscription,
@@ -1570,6 +1686,8 @@ export function registerLegionTools(server: McpServer): void {
             senderPubKey: account.btcPublicKey,
             network: NETWORK,
           });
+          derivedRevealAddress = revealScript.address;
+          await assertCommitMatches(mempoolApi, commitTxid, derivedRevealAddress, revealAmount);
           revealResult = buildChildRevealTransaction({
             commitTxid,
             commitVout: 0,
@@ -1597,6 +1715,8 @@ export function registerLegionTools(server: McpServer): void {
             senderPubKey: account.btcPublicKey,
             network: NETWORK,
           });
+          derivedRevealAddress = revealScript.address;
+          await assertCommitMatches(mempoolApi, commitTxid, derivedRevealAddress, revealAmount);
           revealResult = buildRevealTransaction({
             commitTxid,
             commitVout: 0,
@@ -1635,12 +1755,8 @@ export function registerLegionTools(server: McpServer): void {
             explorerUrl: getMempoolTxUrl(revealTxid, NETWORK),
           },
           recipientAddress: sessionInfo.taprootAddress,
+          contentHash: `sha256:${contentHash}`,
           parentInscriptionId: parentInscriptionId ?? null,
-          provenance: parentInscriptionId
-            ? `Child of ${parentInscriptionId}. Anyone can verify from the chain that this ` +
-              `piece and every other child share one inscriber — which is authorship, not ` +
-              `originality. Judging the work is still the voters' job.`
-            : undefined,
           warning:
             NETWORK === "mainnet"
               ? undefined

--- a/src/tools/legion.tools.ts
+++ b/src/tools/legion.tools.ts
@@ -1,0 +1,1530 @@
+/**
+ * AIBTC News Legion tools (news-gov-v5).
+ *
+ * Contribution-weighted governance for aibtc.news. An agent inscribes a news
+ * piece to a Bitcoin ordinal, opens ONE proposal naming that inscription, and
+ * the pool's contributors vote on whether the piece is worth paying for. A
+ * passing piece pays its proposer a fixed slice of the sBTC pool.
+ *
+ * Lifecycle:
+ *   legion_inscribe_story → legion_inscribe_reveal → legion_propose_story
+ *     → (votingDelay) → legion_vote → legion_veto → legion_conclude
+ *   with legion_contribute to buy weight and legion_sponsor to fund the pool
+ *   without buying a vote.
+ *
+ * THESE TOOLS PIN THEIR OWN NETWORK. The legion contracts live on Stacks
+ * testnet; the rest of this server defaults to mainnet. `getLegionAccount()`
+ * re-derives the unlocked wallet's address for the legion's chain, so a
+ * mainnet-configured server signs these calls against testnet and cannot touch
+ * real funds. Bitcoin inscription is the exception and is called out on those
+ * two tools: it spends real BTC on whatever chain the wallet is configured for.
+ *
+ * Every fund-moving call is DENY mode with an exact post-condition. A contract
+ * bug or a wrong argument must fail the transaction, not quietly move a
+ * different amount.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  Pc,
+  boolCV,
+  noneCV,
+  principalCV,
+  someCV,
+  stringAsciiCV,
+  uintCV,
+  PostConditionMode,
+} from "@stacks/transactions";
+import { NETWORK, getExplorerTxUrl } from "../config/networks.js";
+import {
+  LEGION_ERRORS,
+  LEGION_GOV_CONTRACT,
+  LEGION_NETWORK,
+  LEGION_SITE_URL,
+  LEGION_TREASURY_CONTRACT,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_LINK_LENGTH,
+  MAX_SPONSOR_LINK_LENGTH,
+  MAX_SPONSOR_MEMO_LENGTH,
+  MAX_SPONSOR_NAME_LENGTH,
+  MAX_TITLE_LENGTH,
+  ORDINALS_CONTENT_BASE,
+  ORDINALS_INSCRIPTION_BASE,
+  STORY_STATUS,
+} from "../config/legion.js";
+import {
+  assertAscii,
+  buildTimeline,
+  contentUrlFromLink,
+  explainError,
+  getClockHeight,
+  getLastProposalId,
+  getLegionAccount,
+  getLegionToken,
+  getParams,
+  getPhase,
+  getProposeStatus,
+  getStory,
+  getStoryMeta,
+  getVetoRecord,
+  getVoteRecord,
+  inscriptionIdFromLink,
+  normalizeOrdinalsLink,
+  num,
+  predictOutcome,
+  proposeBlockers,
+  readGov,
+  readLegionContract,
+  readTreasury,
+} from "../services/legion.service.js";
+import { callContract } from "../transactions/builder.js";
+import { getWalletManager } from "../services/wallet-manager.js";
+import { MempoolApi, getMempoolTxUrl } from "../services/mempool-api.js";
+import {
+  buildCommitTransaction,
+  buildRevealTransaction,
+  deriveRevealScript,
+  type InscriptionData,
+} from "../transactions/inscription-builder.js";
+import { signBtcTransaction } from "../transactions/bitcoin-builder.js";
+import { createErrorResponse, createJsonResponse } from "../utils/index.js";
+
+const [GOV_ADDRESS, GOV_NAME] = LEGION_GOV_CONTRACT.split(".");
+const [TREASURY_ADDRESS, TREASURY_NAME] = LEGION_TREASURY_CONTRACT.split(".");
+
+/** Markdown, so the inscription renders as a story rather than a wall of text. */
+const STORY_CONTENT_TYPE = "text/markdown;charset=utf-8";
+
+/**
+ * Phases that mean the piece is still moving, for the `live` list filter.
+ * `pending` is a phase, not a stored status — a proposal is OPEN in storage
+ * from the moment it is filed, but voting does not open until votingDelay
+ * blocks later.
+ */
+const LIVE_PHASES = ["pending", "voting", "veto", "concludable"];
+
+/** Errors surface as sentences, with the contract's `uXXX` still attached. */
+function legionError(error: unknown) {
+  return createErrorResponse(new Error(explainError(error, LEGION_ERRORS)));
+}
+
+/** An sBTC balance on the legion's chain, in sats. */
+async function sbtcBalance(address: string): Promise<number> {
+  const token = await getLegionToken();
+  return num(
+    await readLegionContract(token.contract, "get-balance", [
+      principalCV(address),
+    ])
+  );
+}
+
+/** The block explorer link for a legion transaction. */
+function explorerUrl(txid: string): string {
+  return getExplorerTxUrl(txid, LEGION_NETWORK);
+}
+
+/** Resolve a named fee tier against live mempool estimates. */
+async function resolveFeeRate(
+  mempoolApi: MempoolApi,
+  feeRate?: "fast" | "medium" | "slow" | number
+): Promise<number> {
+  if (typeof feeRate === "number") return feeRate;
+  const fees = await mempoolApi.getFeeEstimates();
+  switch (feeRate) {
+    case "fast":
+      return fees.fastestFee;
+    case "slow":
+      return fees.hourFee;
+    default:
+      return fees.halfHourFee;
+  }
+}
+
+export function registerLegionTools(server: McpServer): void {
+  // ==========================================================================
+  // legion_status — the whole legion in one read
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_status",
+    {
+      description:
+        "AIBTC News Legion (news-gov-v5) at a glance: the sBTC pool, total voting weight, " +
+        "live governance parameters read from the contract, the current block height on the " +
+        "clock the contract counts, and your own weight if a wallet is unlocked.\n\n" +
+        "Start here. Everything else in the legion_* family assumes these numbers.\n\n" +
+        "Reads only — no wallet required, no transaction. Runs on Stacks " +
+        `${LEGION_NETWORK} regardless of how this server's NETWORK is configured.`,
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const [
+          params,
+          clock,
+          pool,
+          weighted,
+          totalWeight,
+          lastProposalId,
+          nextProposeHeight,
+          quoteDraw,
+          minSponsor,
+          govWiring,
+        ] = await Promise.all([
+          getParams(),
+          getClockHeight(),
+          readTreasury("get-balance"),
+          readTreasury("get-weighted-balance"),
+          readGov("get-total-weight"),
+          getLastProposalId(),
+          readGov("get-next-propose-height"),
+          readGov("quote-draw"),
+          readTreasury("get-min-sponsor"),
+          readTreasury("get-gov"),
+        ]);
+
+        const walletManager = getWalletManager();
+        let you: Record<string, unknown> | undefined;
+        if (walletManager.isUnlocked() || process.env.CLIENT_MNEMONIC) {
+          const account = await getLegionAccount();
+          const [weight, freeWeight, liveProposal, balance] = await Promise.all([
+            readGov("get-weight", [principalCV(account.address)]),
+            readGov("get-free-weight", [principalCV(account.address)]),
+            readGov("get-live-proposal", [principalCV(account.address)]),
+            sbtcBalance(account.address),
+          ]);
+          you = {
+            address: account.address,
+            weight: num(weight),
+            freeWeight: num(freeWeight),
+            liveProposalId: liveProposal === null ? null : num(liveProposal),
+            sbtcBalanceSats: balance,
+            sharePct:
+              num(totalWeight) > 0
+                ? Number(((num(weight) * 100) / num(totalWeight)).toFixed(4))
+                : 0,
+          };
+        }
+
+        return createJsonResponse({
+          network: LEGION_NETWORK,
+          contracts: {
+            governance: LEGION_GOV_CONTRACT,
+            treasury: LEGION_TREASURY_CONTRACT,
+            sbtcToken: (await getLegionToken()).contract,
+            treasuryWiredTo: govWiring,
+          },
+          site: LEGION_SITE_URL,
+          clock: {
+            timingMode: clock.timingMode,
+            countsOn: `${clock.clock} blocks`,
+            currentHeight: clock.height,
+          },
+          pool: {
+            balanceSats: num(pool),
+            weightedBalanceSats: num(weighted),
+            sponsoredSats: num(pool) - num(weighted),
+            note:
+              "New weight is priced against weightedBalance (contributed sats only), " +
+              "so sponsorships never raise the cost of joining — but the draw is a " +
+              "fraction of the WHOLE pool, so they do enlarge every payout.",
+          },
+          governance: {
+            totalWeight: num(totalWeight),
+            lastProposalId,
+            nextProposeHeight: num(nextProposeHeight),
+            proposeSlotOpen: num(nextProposeHeight) <= clock.height,
+            currentDrawSats: num(quoteDraw),
+            minSponsorSats: num(minSponsor),
+            params,
+          },
+          you,
+          nextSteps: [
+            "legion_list_stories — what is open for a vote right now",
+            "legion_my_position — your weight, bond and whether you can propose",
+            "legion_contribute — buy voting weight with sBTC",
+            "legion_sponsor — fund the pool without buying a vote",
+          ],
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_list_stories — the feed
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_list_stories",
+    {
+      description:
+        "List proposals in the News Legion, newest first, with each one's phase, tally and " +
+        "the inscription it points at.\n\n" +
+        "Filter by phase. `pending` means filed but voting has not opened yet (the votingDelay " +
+        "period); `voting` is open for votes; `veto` is the objection window after voting closes; " +
+        "`concludable` is waiting for anyone to call legion_conclude; `passed`/`failed` are " +
+        "settled; `expired` means nobody concluded it in time and it can no longer pay.\n\n" +
+        "Reads only — no wallet required.",
+      inputSchema: {
+        phase: z
+          .enum([
+            "all",
+            "live",
+            "pending",
+            "voting",
+            "veto",
+            "concludable",
+            "passed",
+            "failed",
+            "expired",
+          ])
+          .optional()
+          .describe(
+            "Filter by phase. 'live' means pending+voting+veto+concludable. Default: all"
+          ),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(50)
+          .optional()
+          .describe("How many proposals to scan back from the newest (default 10)"),
+      },
+    },
+    async ({ phase = "all", limit = 10 }) => {
+      try {
+        const [params, clock, lastProposalId, pool] = await Promise.all([
+          getParams(),
+          getClockHeight(),
+          getLastProposalId(),
+          readTreasury("get-balance"),
+        ]);
+
+        if (lastProposalId === 0) {
+          return createJsonResponse({
+            network: LEGION_NETWORK,
+            totalProposals: 0,
+            stories: [],
+            message: "No proposals have been filed in this legion yet.",
+          });
+        }
+
+        const firstId = Math.max(1, lastProposalId - limit + 1);
+        const ids: number[] = [];
+        for (let id = lastProposalId; id >= firstId; id--) ids.push(id);
+
+        const rows = await Promise.all(
+          ids.map(async (proposalId) => {
+            const [story, meta, storyPhase] = await Promise.all([
+              getStory(proposalId),
+              getStoryMeta(proposalId),
+              getPhase(proposalId),
+            ]);
+            if (!story) return null;
+            const timeline = buildTimeline(story, params, clock.height, clock.clock);
+            const prediction = predictOutcome(
+              story,
+              params,
+              num(pool),
+              clock.height
+            );
+            return {
+              proposalId,
+              phase: storyPhase,
+              status: STORY_STATUS[story.status],
+              reason: story.reason || undefined,
+              title: meta?.title ?? "",
+              link: meta?.link ?? "",
+              inscriptionId: meta ? inscriptionIdFromLink(meta.link) : null,
+              contentUrl: meta ? contentUrlFromLink(meta.link) : null,
+              proposer: story.proposer,
+              drawSats: story.draw,
+              tally: {
+                yes: story.yesWeight,
+                no: story.noWeight,
+                veto: story.vetoWeight,
+                voters: story.voterCount,
+                eligible: story.eligibleSnapshot,
+              },
+              blocksUntilNextTransition: timeline.blocksUntilNextTransition,
+              ifConcludedNow: prediction.settled
+                ? undefined
+                : `${prediction.outcome} (${prediction.reason})`,
+            };
+          })
+        );
+
+        const stories = rows
+          .filter((row): row is NonNullable<typeof row> => row !== null)
+          .filter((row) => {
+            if (phase === "all") return true;
+            if (phase === "live") return LIVE_PHASES.includes(row.phase);
+            return row.phase === phase;
+          });
+
+        return createJsonResponse({
+          network: LEGION_NETWORK,
+          currentHeight: clock.height,
+          clock: `${clock.clock} blocks`,
+          totalProposals: lastProposalId,
+          scanned: ids.length,
+          filter: phase,
+          stories,
+          note:
+            "Call legion_get_story for the full record, the timeline and what conclude " +
+            "would decide. Open the link to read the piece before voting — the contract " +
+            "cannot see the inscription and does not check it.",
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_get_story — one proposal in full
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_get_story",
+    {
+      description:
+        "Everything about one proposal: title, description, the inscription link, the full " +
+        "vote tally against the quorum and threshold it has to clear, when each window opens " +
+        "and closes, what `conclude` would decide if called right now, and — when a wallet is " +
+        "unlocked — whether you have already voted or vetoed.\n\n" +
+        "Read this before voting. The contract cannot read the inscription; judging the work " +
+        "is the voter's job.\n\n" +
+        "Reads only — no wallet required.",
+      inputSchema: {
+        proposalId: z.number().int().positive().describe("The proposal id"),
+      },
+    },
+    async ({ proposalId }) => {
+      try {
+        const [params, clock, story, meta, storyPhase, pool] = await Promise.all([
+          getParams(),
+          getClockHeight(),
+          getStory(proposalId),
+          getStoryMeta(proposalId),
+          getPhase(proposalId),
+          readTreasury("get-balance"),
+        ]);
+
+        if (!story) {
+          return createErrorResponse(
+            new Error(
+              `No proposal ${proposalId} in ${LEGION_GOV_CONTRACT}. ` +
+                `Call legion_list_stories to see what exists.`
+            )
+          );
+        }
+
+        const timeline = buildTimeline(story, params, clock.height, clock.clock);
+        const prediction = predictOutcome(story, params, num(pool), clock.height);
+
+        const walletManager = getWalletManager();
+        let you: Record<string, unknown> | undefined;
+        if (walletManager.isUnlocked() || process.env.CLIENT_MNEMONIC) {
+          const account = await getLegionAccount();
+          const [voteRecord, vetoRecord, weight] = await Promise.all([
+            getVoteRecord(proposalId, account.address),
+            getVetoRecord(proposalId, account.address),
+            readGov("get-weight", [principalCV(account.address)]),
+          ]);
+          you = {
+            address: account.address,
+            weight: num(weight),
+            isProposer: account.address === story.proposer,
+            voted: voteRecord,
+            vetoed: vetoRecord,
+            canVoteNow:
+              storyPhase === "voting" &&
+              !voteRecord &&
+              account.address !== story.proposer &&
+              num(weight) >= params.minWeight,
+            canVetoNow:
+              storyPhase === "veto" &&
+              !vetoRecord &&
+              num(weight) >= params.minWeight,
+            canConcludeNow: storyPhase === "concludable",
+          };
+        }
+
+        return createJsonResponse({
+          proposalId,
+          network: LEGION_NETWORK,
+          phase: storyPhase,
+          status: STORY_STATUS[story.status],
+          reason: story.reason || undefined,
+          title: meta?.title ?? "",
+          description: meta?.description ?? "",
+          link: meta?.link ?? "",
+          inscriptionId: meta ? inscriptionIdFromLink(meta.link) : null,
+          contentUrl: meta ? contentUrlFromLink(meta.link) : null,
+          proposer: story.proposer,
+          drawSats: story.draw,
+          bondWeight: story.bond,
+          tally: {
+            yesWeight: story.yesWeight,
+            noWeight: story.noWeight,
+            vetoWeight: story.vetoWeight,
+            castWeight: prediction.cast,
+            voterCount: story.voterCount,
+            eligibleSnapshot: story.eligibleSnapshot,
+          },
+          thresholds: {
+            quorumPct: prediction.quorumPct,
+            quorumRequiredPct: params.votingQuorum,
+            quorumMet: prediction.quorumMet,
+            yesPct: prediction.yesPct,
+            thresholdRequiredPct: params.votingThreshold,
+            thresholdMet: prediction.thresholdMet,
+            vetoPct: prediction.vetoPct,
+            vetoQuorumPct: params.vetoQuorum,
+            vetoed: prediction.vetoed,
+            participants: `${story.voterCount}/${params.minParticipants}`,
+            participantsMet: prediction.participantsMet,
+          },
+          timeline: {
+            ...timeline,
+            explanation:
+              `Filed at ${timeline.createdAt}. Voting opens at ${timeline.votingOpensAt} ` +
+              `and closes at ${timeline.voteEnd}. Veto runs until ${timeline.vetoEnd}. ` +
+              `Conclude must be called before ${timeline.concludeDeadline} — after that ` +
+              `the piece has expired and can no longer be concluded at all.`,
+          },
+          outcome: {
+            settled: prediction.settled,
+            label: prediction.settled ? "recorded on chain" : "if concluded now",
+            outcome: prediction.outcome,
+            reason: prediction.reason,
+            payoutSats: prediction.payout,
+            payee: prediction.payout > 0 ? story.proposer : null,
+          },
+          you,
+          readTheWork: meta ? contentUrlFromLink(meta.link) ?? meta.link : undefined,
+          storyUrl: LEGION_SITE_URL,
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_my_position — your standing
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_my_position",
+    {
+      description:
+        "Your standing in the legion: voting weight and share of the pool, how much of it is " +
+        "locked by a live proposal bond, your sBTC balance, what a proposal would pay you " +
+        "today, and every precondition on proposing — folded from the contract's own " +
+        "`propose-status`, so a blocked propose tells you which gate to wait on instead of " +
+        "burning a transaction on the revert.\n\n" +
+        "Requires an unlocked wallet (read-only — signs nothing).",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const account = await getLegionAccount();
+        const [params, clock, weight, freeWeight, locked, liveProposal, totalWeight, proposeStatus, balance, quoteDraw] =
+          await Promise.all([
+            getParams(),
+            getClockHeight(),
+            readGov("get-weight", [principalCV(account.address)]),
+            readGov("get-free-weight", [principalCV(account.address)]),
+            readGov("locked-of", [principalCV(account.address)]),
+            readGov("get-live-proposal", [principalCV(account.address)]),
+            readGov("get-total-weight"),
+            getProposeStatus(account.address),
+            sbtcBalance(account.address),
+            readGov("quote-draw"),
+          ]);
+
+        const blockers = proposeBlockers(proposeStatus, params.minWeight);
+
+        return createJsonResponse({
+          address: account.address,
+          network: LEGION_NETWORK,
+          currentHeight: clock.height,
+          weight: num(weight),
+          freeWeight: num(freeWeight),
+          lockedWeight: num(locked),
+          sharePct:
+            num(totalWeight) > 0
+              ? Number(((num(weight) * 100) / num(totalWeight)).toFixed(4))
+              : 0,
+          totalWeight: num(totalWeight),
+          sbtcBalanceSats: balance,
+          liveProposalId: liveProposal === null ? null : num(liveProposal),
+          canVote: num(weight) >= params.minWeight,
+          propose: {
+            canPropose: proposeStatus.canPropose,
+            blockers: blockers.length > 0 ? blockers : undefined,
+            weightLockedOnPropose: proposeStatus.lockOnPropose,
+            wouldPaySats: proposeStatus.draw,
+            nextProposeHeight: proposeStatus.nextProposeHeight,
+            note:
+              "Proposing locks your ENTIRE weight until the piece resolves. The lock is " +
+              "never spent and never reduces your voting power — it exists only to enforce " +
+              "one live proposal per principal, and releases on every outcome.",
+          },
+          currentDrawSats: num(quoteDraw),
+          minWeightToVoteOrPropose: params.minWeight,
+          minContributionSats: params.minContribution,
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_faucet — testnet sBTC
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_faucet",
+    {
+      description:
+        "Mint testnet sBTC from the faucet on the token contract this legion uses, so you " +
+        "have something to contribute or sponsor with.\n\n" +
+        "Testnet only — it errors on a mainnet legion, where there is no faucet and sBTC " +
+        "has to be bought or bridged.\n\n" +
+        "Requires an unlocked wallet.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        if (LEGION_NETWORK !== "testnet") {
+          return createErrorResponse(
+            new Error(
+              `The legion is on ${LEGION_NETWORK}, which has no sBTC faucet. ` +
+                `Acquire sBTC with sbtc_deposit or styx_deposit instead.`
+            )
+          );
+        }
+        const account = await getLegionAccount();
+        const token = await getLegionToken();
+        const [tokenAddress, tokenName] = token.contract.split(".");
+
+        const result = await callContract(account, {
+          contractAddress: tokenAddress,
+          contractName: tokenName,
+          functionName: "faucet",
+          functionArgs: [],
+          // A faucet mints rather than transfers, and mints have no sender to
+          // write a condition against.
+          postConditionMode: PostConditionMode.Allow,
+          postConditions: [],
+        });
+
+        return createJsonResponse({
+          success: true,
+          txid: result.txid,
+          explorerUrl: explorerUrl(result.txid),
+          address: account.address,
+          token: token.contract,
+          network: LEGION_NETWORK,
+          nextStep:
+            "Once it confirms, call legion_contribute to turn sBTC into voting weight.",
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_contribute — buy voting weight
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_contribute",
+    {
+      description:
+        "Send sBTC to the legion's pool and receive voting weight in proportion to your share " +
+        "of the contributed balance.\n\n" +
+        "CONTRIBUTIONS ARE NOT REFUNDABLE. The money funds journalism and never comes back — " +
+        "what you get is a say in which pieces get paid, not a claim on the pool. If you want " +
+        "to fund the pool WITHOUT a vote, use legion_sponsor instead.\n\n" +
+        "Pre-flights the floor and your balance, then signs with an exact post-condition for " +
+        "the amount and nothing else.\n\n" +
+        "Requires an unlocked wallet.",
+      inputSchema: {
+        sats: z
+          .number()
+          .int()
+          .positive()
+          .describe("Amount of sBTC to contribute, in sats"),
+      },
+    },
+    async ({ sats }) => {
+      try {
+        const account = await getLegionAccount();
+        const [params, token, balance, weightBefore] = await Promise.all([
+          getParams(),
+          getLegionToken(),
+          sbtcBalance(account.address),
+          readGov("get-weight", [principalCV(account.address)]),
+        ]);
+
+        if (sats < params.minContribution) {
+          return createErrorResponse(
+            new Error(
+              `${sats} sats is below the legion's minimum contribution of ` +
+                `${params.minContribution} sats (u437).`
+            )
+          );
+        }
+        if (balance < sats) {
+          return createErrorResponse(
+            new Error(
+              `Your sBTC balance is ${balance} sats — not enough to contribute ${sats}. ` +
+                (LEGION_NETWORK === "testnet"
+                  ? "Call legion_faucet for testnet sBTC."
+                  : "Acquire sBTC first.")
+            )
+          );
+        }
+
+        const quotedWeight = num(await readGov("quote-weight", [uintCV(sats)]));
+
+        const result = await callContract(account, {
+          contractAddress: GOV_ADDRESS,
+          contractName: GOV_NAME,
+          functionName: "contribute",
+          functionArgs: [uintCV(sats)],
+          postConditionMode: PostConditionMode.Deny,
+          postConditions: [
+            Pc.principal(account.address)
+              .willSendEq(sats)
+              .ft(token.contract as `${string}.${string}`, token.assetName),
+          ],
+        });
+
+        return createJsonResponse({
+          success: true,
+          txid: result.txid,
+          explorerUrl: explorerUrl(result.txid),
+          address: account.address,
+          contributedSats: sats,
+          expectedWeightMinted: quotedWeight,
+          weightBefore: num(weightBefore),
+          expectedWeightAfter: num(weightBefore) + quotedWeight,
+          network: LEGION_NETWORK,
+          warning: "Contributions are final. There is no withdrawal path.",
+          nextStep:
+            quotedWeight + num(weightBefore) >= params.minWeight
+              ? "Once it confirms you can legion_vote and legion_propose_story."
+              : `You will still be below minWeight (${params.minWeight}) — contribute more to vote or propose.`,
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_sponsor — fund the pool, weight-less
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_sponsor",
+    {
+      description:
+        "Fund the legion's pool WITHOUT minting any voting weight, and put a name on the " +
+        "record. A sponsor pays for journalism and attribution, not a say in what gets " +
+        "published.\n\n" +
+        "Sponsorship does not raise the price of joining (weight is priced against the " +
+        "contributed balance only), but it does enlarge every payout, because the draw is a " +
+        "fraction of the whole pool.\n\n" +
+        "`name`, `link` and `memo` are unverified strings — the contract never reads them. " +
+        "Any display must treat the paying principal and the txid as the real identity.\n\n" +
+        "DEPOSITS ARE FINAL. There is no refund path and cannot be one.\n\n" +
+        "Requires an unlocked wallet.",
+      inputSchema: {
+        sats: z
+          .number()
+          .int()
+          .positive()
+          .describe("Amount of sBTC to sponsor, in sats (must meet the treasury's minimum)"),
+        name: z
+          .string()
+          .min(1)
+          .max(MAX_SPONSOR_NAME_LENGTH)
+          .describe(`Sponsor name as it should be attributed (ASCII, ≤${MAX_SPONSOR_NAME_LENGTH} chars)`),
+        link: z
+          .string()
+          .max(MAX_SPONSOR_LINK_LENGTH)
+          .optional()
+          .describe(`Optional sponsor URL (ASCII, ≤${MAX_SPONSOR_LINK_LENGTH} chars)`),
+        memo: z
+          .string()
+          .max(MAX_SPONSOR_MEMO_LENGTH)
+          .optional()
+          .describe(`Optional free-form note on the record (ASCII, ≤${MAX_SPONSOR_MEMO_LENGTH} chars)`),
+      },
+    },
+    async ({ sats, name, link, memo }) => {
+      try {
+        assertAscii(name, "name", MAX_SPONSOR_NAME_LENGTH);
+        if (link) assertAscii(link, "link", MAX_SPONSOR_LINK_LENGTH);
+        if (memo) assertAscii(memo, "memo", MAX_SPONSOR_MEMO_LENGTH);
+
+        const account = await getLegionAccount();
+        const [token, minSponsor, balance] = await Promise.all([
+          getLegionToken(),
+          readTreasury("get-min-sponsor"),
+          sbtcBalance((await getLegionAccount()).address),
+        ]);
+
+        if (sats < num(minSponsor)) {
+          return createErrorResponse(
+            new Error(
+              `${sats} sats is below the treasury's minimum sponsorship of ` +
+                `${num(minSponsor)} sats (u450).`
+            )
+          );
+        }
+        if (balance < sats) {
+          return createErrorResponse(
+            new Error(
+              `Your sBTC balance is ${balance} sats — not enough to sponsor ${sats}.`
+            )
+          );
+        }
+
+        const result = await callContract(account, {
+          contractAddress: TREASURY_ADDRESS,
+          contractName: TREASURY_NAME,
+          functionName: "sponsor-in",
+          functionArgs: [
+            uintCV(sats),
+            stringAsciiCV(name),
+            link ? someCV(stringAsciiCV(link)) : noneCV(),
+            stringAsciiCV(memo ?? ""),
+          ],
+          postConditionMode: PostConditionMode.Deny,
+          postConditions: [
+            Pc.principal(account.address)
+              .willSendEq(sats)
+              .ft(token.contract as `${string}.${string}`, token.assetName),
+          ],
+        });
+
+        return createJsonResponse({
+          success: true,
+          txid: result.txid,
+          explorerUrl: explorerUrl(result.txid),
+          from: account.address,
+          sponsoredSats: sats,
+          name,
+          link: link ?? null,
+          memo: memo ?? "",
+          mintedWeight: 0,
+          network: LEGION_NETWORK,
+          warning:
+            "Final. No refund path exists. This mints no voting weight — use " +
+            "legion_contribute if you wanted a vote.",
+          note:
+            "How long a sponsor badge shows is decided off-chain by the reader at " +
+            `${LEGION_SITE_URL}, not by the contract.`,
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_propose_story — open the vote on an inscribed piece
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_propose_story",
+    {
+      description:
+        "Open a vote on one inscribed news piece. If it passes, YOU are paid the draw — the " +
+        "proposer is the only reachable payee.\n\n" +
+        "Pass the inscription id from legion_inscribe_reveal (or any ordinals content URL) " +
+        "plus your own title and description; the contract stores all three verbatim and " +
+        "never reads the inscription itself. Voters open the link and judge the work, so a " +
+        "junk or replayed link gets voted or vetoed down.\n\n" +
+        "Proposing locks your ENTIRE voting weight until the piece resolves — one live " +
+        "proposal per principal. The lock is never spent and releases on every outcome.\n\n" +
+        "Pre-flights every precondition the contract checks and refuses locally with the " +
+        "specific blocker rather than burning a transaction on the revert.\n\n" +
+        "Requires an unlocked wallet.",
+      inputSchema: {
+        link: z
+          .string()
+          .min(1)
+          .describe(
+            "Inscription id (<64-hex-txid>i0) or a full ordinals URL. " +
+              "A bare id is expanded to " + ORDINALS_INSCRIPTION_BASE + "<id>"
+          ),
+        title: z
+          .string()
+          .min(1)
+          .max(MAX_TITLE_LENGTH)
+          .describe(`Headline (ASCII, ≤${MAX_TITLE_LENGTH} chars)`),
+        description: z
+          .string()
+          .max(MAX_DESCRIPTION_LENGTH)
+          .optional()
+          .describe(
+            `Why this piece is worth paying for (ASCII, ≤${MAX_DESCRIPTION_LENGTH} chars). ` +
+              "Stored on chain but not emitted in the event — voters read it via legion_get_story."
+          ),
+      },
+    },
+    async ({ link, title, description }) => {
+      try {
+        const normalizedLink = normalizeOrdinalsLink(link);
+        assertAscii(normalizedLink, "link", MAX_LINK_LENGTH);
+        assertAscii(title, "title", MAX_TITLE_LENGTH);
+        const body = description ?? "";
+        assertAscii(body, "description", MAX_DESCRIPTION_LENGTH);
+
+        const account = await getLegionAccount();
+        const [params, proposeStatus, clock] = await Promise.all([
+          getParams(),
+          getProposeStatus(account.address),
+          getClockHeight(),
+        ]);
+
+        if (!proposeStatus.canPropose) {
+          const blockers = proposeBlockers(proposeStatus, params.minWeight);
+          return createErrorResponse(
+            new Error(
+              `Cannot propose right now: ${blockers.join("; ")}. ` +
+                `Current height ${clock.height}. Nothing was signed.`
+            )
+          );
+        }
+
+        const result = await callContract(account, {
+          contractAddress: GOV_ADDRESS,
+          contractName: GOV_NAME,
+          functionName: "propose-story",
+          functionArgs: [
+            stringAsciiCV(normalizedLink),
+            stringAsciiCV(title),
+            stringAsciiCV(body),
+          ],
+          // The bond is weight, not sats: no sBTC moves on propose, so DENY with
+          // no conditions is exactly right.
+          postConditionMode: PostConditionMode.Deny,
+          postConditions: [],
+        });
+
+        const votingOpensAt = clock.height + params.votingDelay;
+        const voteEnd = votingOpensAt + params.voteWindow;
+
+        return createJsonResponse({
+          success: true,
+          txid: result.txid,
+          explorerUrl: explorerUrl(result.txid),
+          proposer: account.address,
+          link: normalizedLink,
+          inscriptionId: inscriptionIdFromLink(normalizedLink),
+          title,
+          description: body,
+          network: LEGION_NETWORK,
+          weightLocked: proposeStatus.lockOnPropose,
+          expectedDrawSats: proposeStatus.draw,
+          expectedTimeline: {
+            note: "Approximate — the contract snapshots these at the block that mines the tx.",
+            filedAtAbout: clock.height,
+            votingOpensAbout: votingOpensAt,
+            voteEndsAbout: voteEnd,
+            vetoEndsAbout: voteEnd + params.vetoWindow,
+            concludeDeadlineAbout:
+              voteEnd + params.vetoWindow + params.concludeWindow,
+            clock: `${clock.clock} blocks`,
+          },
+          nextSteps: [
+            "legion_list_stories to pick up the assigned proposalId once it confirms",
+            `Votes cannot be cast for ~${params.votingDelay} blocks (the pending period)`,
+            "Someone must call legion_conclude inside the conclude window or the piece expires and pays nobody",
+          ],
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_vote
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_vote",
+    {
+      description:
+        "Vote yes or no on a proposal with your current weight. One vote per principal, and " +
+        "a proposer cannot vote on their own piece.\n\n" +
+        "Read the inscription first — legion_get_story gives you the link. The contract " +
+        "cannot see the work; judging it is the whole job.\n\n" +
+        "Pre-flights the phase, your weight and whether you have already voted, so a vote " +
+        "that would revert is refused locally.\n\n" +
+        "Requires an unlocked wallet.",
+      inputSchema: {
+        proposalId: z.number().int().positive().describe("The proposal id"),
+        support: z
+          .boolean()
+          .describe("true = yes (pay this piece), false = no"),
+      },
+    },
+    async ({ proposalId, support }) => {
+      try {
+        const account = await getLegionAccount();
+        const [params, story, storyPhase, weight, existingVote, clock] =
+          await Promise.all([
+            getParams(),
+            getStory(proposalId),
+            getPhase(proposalId),
+            readGov("get-weight", [principalCV(account.address)]),
+            getVoteRecord(proposalId, account.address),
+            getClockHeight(),
+          ]);
+
+        if (!story) {
+          return createErrorResponse(
+            new Error(`No proposal ${proposalId} in this legion (u404).`)
+          );
+        }
+        if (existingVote) {
+          return createErrorResponse(
+            new Error(
+              `You already voted ${existingVote.support ? "yes" : "no"} on proposal ` +
+                `${proposalId} with ${existingVote.weight} weight (u405). Votes cannot be changed.`
+            )
+          );
+        }
+        if (account.address === story.proposer) {
+          return createErrorResponse(
+            new Error(
+              `You are the proposer of ${proposalId} and cannot vote on your own piece (u423). ` +
+                `You may still legion_veto it to withdraw it.`
+            )
+          );
+        }
+        if (storyPhase === "pending") {
+          const opensAt = story.createdAt + params.votingDelay;
+          return createErrorResponse(
+            new Error(
+              `Proposal ${proposalId} is still pending — voting opens at height ${opensAt}, ` +
+                `and the tip is ${clock.height} (${opensAt - clock.height} blocks to go, u436).`
+            )
+          );
+        }
+        if (storyPhase !== "voting") {
+          return createErrorResponse(
+            new Error(
+              `Proposal ${proposalId} is in the "${storyPhase}" phase — voting is closed (u407). ` +
+                (storyPhase === "veto"
+                  ? "You can still legion_veto it."
+                  : "Nothing was signed.")
+            )
+          );
+        }
+        if (num(weight) < params.minWeight) {
+          return createErrorResponse(
+            new Error(
+              `Your weight is ${num(weight)}, below the minWeight of ${params.minWeight} (u401). ` +
+                `Call legion_contribute first.`
+            )
+          );
+        }
+
+        const result = await callContract(account, {
+          contractAddress: GOV_ADDRESS,
+          contractName: GOV_NAME,
+          functionName: "vote",
+          functionArgs: [uintCV(proposalId), boolCV(support)],
+          // Voting moves nothing.
+          postConditionMode: PostConditionMode.Deny,
+          postConditions: [],
+        });
+
+        return createJsonResponse({
+          success: true,
+          txid: result.txid,
+          explorerUrl: explorerUrl(result.txid),
+          proposalId,
+          support,
+          votedWith: num(weight),
+          voter: account.address,
+          network: LEGION_NETWORK,
+          voteEnd: story.voteEnd,
+          blocksLeftToVote: story.voteEnd - clock.height,
+          note: "One vote per principal — this cannot be changed or withdrawn.",
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_veto
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_veto",
+    {
+      description:
+        "Object to a proposal during the veto window — the blocking pass after voting closes. " +
+        "If vetoes reach the veto quorum of eligible weight, the piece fails regardless of how " +
+        "the vote went.\n\n" +
+        "This is the backstop against a plagiarised, replayed or junk inscription that slipped " +
+        "past the vote. A proposer may veto their own piece, which simply withdraws it.\n\n" +
+        "Pre-flights the window and your weight.\n\n" +
+        "Requires an unlocked wallet.",
+      inputSchema: {
+        proposalId: z.number().int().positive().describe("The proposal id"),
+      },
+    },
+    async ({ proposalId }) => {
+      try {
+        const account = await getLegionAccount();
+        const [params, story, storyPhase, weight, existingVeto, clock] =
+          await Promise.all([
+            getParams(),
+            getStory(proposalId),
+            getPhase(proposalId),
+            readGov("get-weight", [principalCV(account.address)]),
+            getVetoRecord(proposalId, account.address),
+            getClockHeight(),
+          ]);
+
+        if (!story) {
+          return createErrorResponse(
+            new Error(`No proposal ${proposalId} in this legion (u404).`)
+          );
+        }
+        if (existingVeto) {
+          return createErrorResponse(
+            new Error(
+              `You already vetoed proposal ${proposalId} with ${existingVeto.weight} weight (u425).`
+            )
+          );
+        }
+        if (storyPhase !== "veto") {
+          const vetoEnd = story.voteEnd + params.vetoWindow;
+          return createErrorResponse(
+            new Error(
+              `Proposal ${proposalId} is in the "${storyPhase}" phase — the veto window is ` +
+                `[${story.voteEnd}, ${vetoEnd}) and the tip is ${clock.height} (u424). ` +
+                (storyPhase === "voting"
+                  ? "Vote no with legion_vote while voting is still open."
+                  : "Nothing was signed.")
+            )
+          );
+        }
+        if (num(weight) < params.minWeight) {
+          return createErrorResponse(
+            new Error(
+              `Your weight is ${num(weight)}, below the minWeight of ${params.minWeight} (u401).`
+            )
+          );
+        }
+
+        const result = await callContract(account, {
+          contractAddress: GOV_ADDRESS,
+          contractName: GOV_NAME,
+          functionName: "veto",
+          functionArgs: [uintCV(proposalId)],
+          postConditionMode: PostConditionMode.Deny,
+          postConditions: [],
+        });
+
+        const vetoWeightAfter = story.vetoWeight + num(weight);
+        const vetoPctAfter =
+          story.eligibleSnapshot > 0
+            ? Math.floor((vetoWeightAfter * 100) / story.eligibleSnapshot)
+            : 0;
+
+        return createJsonResponse({
+          success: true,
+          txid: result.txid,
+          explorerUrl: explorerUrl(result.txid),
+          proposalId,
+          vetoedWith: num(weight),
+          vetoWeightAfter,
+          vetoPctAfter,
+          vetoQuorumPct: params.vetoQuorum,
+          wouldBlock: vetoPctAfter >= params.vetoQuorum,
+          network: LEGION_NETWORK,
+          vetoEnd: story.voteEnd + params.vetoWindow,
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_conclude
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_conclude",
+    {
+      description:
+        "Settle a proposal: work out the outcome and, if it passed, pay the proposer the draw " +
+        "from the treasury. Permissionless — anyone may call it, and someone must.\n\n" +
+        "A piece nobody concludes inside its conclude window EXPIRES and pays no one, and after " +
+        "that it can never be concluded at all. Concluding late pays exactly what concluding " +
+        "early would, because the draw was snapshotted at propose time.\n\n" +
+        "Signs with a post-condition capping what the treasury may pay at the snapshotted draw, " +
+        "which covers both the paying and the non-paying outcomes.\n\n" +
+        "Requires an unlocked wallet (the caller pays gas; the payout goes to the proposer).",
+      inputSchema: {
+        proposalId: z.number().int().positive().describe("The proposal id"),
+      },
+    },
+    async ({ proposalId }) => {
+      try {
+        const account = await getLegionAccount();
+        const [params, story, storyPhase, clock, pool, token] = await Promise.all([
+          getParams(),
+          getStory(proposalId),
+          getPhase(proposalId),
+          getClockHeight(),
+          readTreasury("get-balance"),
+          getLegionToken(),
+        ]);
+
+        if (!story) {
+          return createErrorResponse(
+            new Error(`No proposal ${proposalId} in this legion (u404).`)
+          );
+        }
+        if (storyPhase === "passed" || storyPhase === "failed") {
+          return createErrorResponse(
+            new Error(
+              `Proposal ${proposalId} is already concluded: ${STORY_STATUS[story.status]}` +
+                `${story.reason ? ` (${story.reason})` : ""} (u410).`
+            )
+          );
+        }
+        if (storyPhase === "expired") {
+          return createErrorResponse(
+            new Error(
+              `Proposal ${proposalId} has expired — its conclude window closed at height ` +
+                `${story.voteEnd + params.vetoWindow + params.concludeWindow} and the tip is ` +
+                `${clock.height} (u435). It can no longer be concluded and pays nobody. ` +
+                `The proposer's bond has already released itself.`
+            )
+          );
+        }
+        if (storyPhase !== "concludable") {
+          const vetoEnd = story.voteEnd + params.vetoWindow;
+          return createErrorResponse(
+            new Error(
+              `Proposal ${proposalId} is in the "${storyPhase}" phase — conclude opens at height ` +
+                `${vetoEnd} and the tip is ${clock.height} (${vetoEnd - clock.height} blocks to go, u408).`
+            )
+          );
+        }
+
+        const prediction = predictOutcome(story, params, num(pool), clock.height);
+
+        const result = await callContract(account, {
+          contractAddress: GOV_ADDRESS,
+          contractName: GOV_NAME,
+          functionName: "conclude",
+          functionArgs: [uintCV(proposalId)],
+          postConditionMode: PostConditionMode.Deny,
+          // The treasury pays either the whole snapshotted draw or nothing at
+          // all, and the outcome is decided on chain at mining time. A cap of
+          // the draw covers both, and covers nothing larger.
+          postConditions: [
+            Pc.principal(LEGION_TREASURY_CONTRACT)
+              .willSendLte(story.draw)
+              .ft(token.contract as `${string}.${string}`, token.assetName),
+          ],
+        });
+
+        return createJsonResponse({
+          success: true,
+          txid: result.txid,
+          explorerUrl: explorerUrl(result.txid),
+          proposalId,
+          concludedBy: account.address,
+          network: LEGION_NETWORK,
+          expectedOutcome: prediction.outcome,
+          expectedReason: prediction.reason,
+          expectedPayoutSats: prediction.payout,
+          payee: prediction.payout > 0 ? story.proposer : null,
+          tally: {
+            yes: story.yesWeight,
+            no: story.noWeight,
+            veto: story.vetoWeight,
+            cast: prediction.cast,
+            eligible: story.eligibleSnapshot,
+            voters: story.voterCount,
+          },
+          note:
+            "Expected outcome is computed from the tally as of now with the contract's own " +
+            "decision order; the chain decides for real at the block that mines this tx.",
+        });
+      } catch (error) {
+        return legionError(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_inscribe_story — step 1 of 2 (Bitcoin, not Stacks)
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_inscribe_story",
+    {
+      description:
+        "Inscribe a news piece to a Bitcoin ordinal as markdown — STEP 1: broadcast the commit " +
+        "transaction.\n\n" +
+        "This is the piece the legion votes on. Write it as markdown; a title is prepended as " +
+        "an H1 unless the body already starts with one.\n\n" +
+        "SPENDS REAL BITCOIN. Unlike the rest of the legion_* tools (which are pinned to the " +
+        `legion's Stacks ${LEGION_NETWORK}), inscription runs on the Bitcoin network this ` +
+        `server is configured for, currently ${NETWORK}. ordinals.com only serves mainnet ` +
+        "inscriptions, so a non-mainnet inscription will not resolve for voters.\n\n" +
+        "Returns immediately without waiting for confirmation. Once the commit confirms " +
+        "(typically 10-60 min), call legion_inscribe_reveal with the values returned here.\n\n" +
+        "Requires an unlocked managed wallet with Bitcoin keys and funded UTXOs.",
+      inputSchema: {
+        title: z
+          .string()
+          .min(1)
+          .describe("Headline. Prepended to the body as an H1 unless the body already has one."),
+        body: z
+          .string()
+          .min(1)
+          .describe("The piece itself, as markdown."),
+        feeRate: z
+          .union([z.enum(["fast", "medium", "slow"]), z.number().positive()])
+          .optional()
+          .describe("Fee rate: 'fast', 'medium', 'slow', or a number in sat/vB (default: medium)"),
+      },
+    },
+    async ({ title, body, feeRate }) => {
+      try {
+        const walletManager = getWalletManager();
+        const sessionInfo = walletManager.getSessionInfo();
+        if (!sessionInfo) {
+          return createErrorResponse(
+            new Error("Wallet not unlocked. Use wallet_unlock first.")
+          );
+        }
+        if (!sessionInfo.btcAddress || !sessionInfo.taprootAddress) {
+          return createErrorResponse(
+            new Error(
+              "This wallet has no Bitcoin addresses. Inscription needs a managed wallet."
+            )
+          );
+        }
+        const account = walletManager.getAccount();
+        if (!account?.btcPrivateKey || !account.btcPublicKey) {
+          return createErrorResponse(
+            new Error("Bitcoin keys not available. Wallet may not be unlocked.")
+          );
+        }
+
+        const markdown = body.trimStart().startsWith("#")
+          ? body
+          : `# ${title}\n\n${body}`;
+        const content = Buffer.from(markdown, "utf8");
+        const inscription: InscriptionData = {
+          contentType: STORY_CONTENT_TYPE,
+          body: content,
+        };
+
+        const mempoolApi = new MempoolApi(NETWORK);
+        const actualFeeRate = await resolveFeeRate(mempoolApi, feeRate);
+
+        const utxos = await mempoolApi.getUtxos(sessionInfo.btcAddress);
+        if (utxos.length === 0) {
+          return createErrorResponse(
+            new Error(
+              `No UTXOs at ${sessionInfo.btcAddress}. Fund the address before inscribing.`
+            )
+          );
+        }
+
+        const commitResult = buildCommitTransaction({
+          utxos,
+          inscription,
+          feeRate: actualFeeRate,
+          senderPubKey: account.btcPublicKey,
+          senderAddress: sessionInfo.btcAddress,
+          network: NETWORK,
+        });
+        const commitSigned = signBtcTransaction(
+          commitResult.tx,
+          account.btcPrivateKey
+        );
+        const commitTxid = await mempoolApi.broadcastTransaction(
+          commitSigned.txHex
+        );
+
+        return createJsonResponse({
+          status: "commit_broadcast",
+          bitcoinNetwork: NETWORK,
+          commitTxid,
+          commitExplorerUrl: getMempoolTxUrl(commitTxid, NETWORK),
+          revealAddress: commitResult.revealAddress,
+          revealAmount: commitResult.revealAmount,
+          commitFee: commitResult.fee,
+          feeRate: actualFeeRate,
+          contentType: STORY_CONTENT_TYPE,
+          contentSize: content.length,
+          title,
+          markdown,
+          warning:
+            NETWORK === "mainnet"
+              ? undefined
+              : `This is a ${NETWORK} inscription. ordinals.com serves mainnet only, so the ` +
+                `link it produces will not resolve for legion voters.`,
+          nextStep:
+            "Wait for the commit to confirm, then call legion_inscribe_reveal with this " +
+            "commitTxid and revealAmount plus the same title and body.",
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // legion_inscribe_reveal — step 2 of 2
+  // ==========================================================================
+
+  server.registerTool(
+    "legion_inscribe_reveal",
+    {
+      description:
+        "Complete a news inscription — STEP 2: broadcast the reveal transaction, after the " +
+        "commit from legion_inscribe_story has confirmed.\n\n" +
+        "Pass the SAME title and body used in the commit step — the reveal script is derived " +
+        "from the content, so any difference produces a different script and the reveal fails.\n\n" +
+        "Returns the inscription id and the ordinals.com link, ready to hand straight to " +
+        "legion_propose_story.\n\n" +
+        "Requires an unlocked managed wallet.",
+      inputSchema: {
+        commitTxid: z
+          .string()
+          .length(64)
+          .describe("Txid of the confirmed commit transaction"),
+        revealAmount: z
+          .number()
+          .positive()
+          .describe("revealAmount from the legion_inscribe_story response"),
+        title: z.string().min(1).describe("Same title used in the commit step"),
+        body: z.string().min(1).describe("Same body used in the commit step"),
+        feeRate: z
+          .union([z.enum(["fast", "medium", "slow"]), z.number().positive()])
+          .optional()
+          .describe("Fee rate for the reveal tx (default: medium)"),
+      },
+    },
+    async ({ commitTxid, revealAmount, title, body, feeRate }) => {
+      try {
+        const walletManager = getWalletManager();
+        const sessionInfo = walletManager.getSessionInfo();
+        if (!sessionInfo?.taprootAddress) {
+          return createErrorResponse(
+            new Error(
+              "Wallet not unlocked, or it has no Taproot address. Use wallet_unlock first."
+            )
+          );
+        }
+        const account = walletManager.getAccount();
+        if (!account?.btcPrivateKey || !account.btcPublicKey) {
+          return createErrorResponse(
+            new Error("Bitcoin keys not available. Wallet may not be unlocked.")
+          );
+        }
+
+        const markdown = body.trimStart().startsWith("#")
+          ? body
+          : `# ${title}\n\n${body}`;
+        const inscription: InscriptionData = {
+          contentType: STORY_CONTENT_TYPE,
+          body: Buffer.from(markdown, "utf8"),
+        };
+
+        const mempoolApi = new MempoolApi(NETWORK);
+        const actualFeeRate = await resolveFeeRate(mempoolApi, feeRate);
+
+        const revealScript = deriveRevealScript({
+          inscription,
+          senderPubKey: account.btcPublicKey,
+          network: NETWORK,
+        });
+        const revealResult = buildRevealTransaction({
+          commitTxid,
+          commitVout: 0,
+          commitAmount: revealAmount,
+          revealScript,
+          recipientAddress: sessionInfo.taprootAddress,
+          feeRate: actualFeeRate,
+          network: NETWORK,
+        });
+        const revealSigned = signBtcTransaction(
+          revealResult.tx,
+          account.btcPrivateKey
+        );
+        const revealTxid = await mempoolApi.broadcastTransaction(
+          revealSigned.txHex
+        );
+
+        const inscriptionId = `${revealTxid}i0`;
+        const link = `${ORDINALS_INSCRIPTION_BASE}${inscriptionId}`;
+        const contentUrl = `${ORDINALS_CONTENT_BASE}${inscriptionId}`;
+
+        return createJsonResponse({
+          status: "success",
+          bitcoinNetwork: NETWORK,
+          inscriptionId,
+          link,
+          contentUrl,
+          title,
+          contentType: STORY_CONTENT_TYPE,
+          commit: {
+            txid: commitTxid,
+            explorerUrl: getMempoolTxUrl(commitTxid, NETWORK),
+          },
+          reveal: {
+            txid: revealTxid,
+            fee: revealResult.fee,
+            explorerUrl: getMempoolTxUrl(revealTxid, NETWORK),
+          },
+          recipientAddress: sessionInfo.taprootAddress,
+          warning:
+            NETWORK === "mainnet"
+              ? undefined
+              : `This is a ${NETWORK} inscription; ordinals.com serves mainnet only, so ` +
+                `voters will not be able to open ${link}.`,
+          nextStep:
+            `Once the reveal confirms, call legion_propose_story with link "${inscriptionId}" ` +
+            `to open the vote. The inscription must be readable before voters can judge it.`,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+}

--- a/src/tools/legion.tools.ts
+++ b/src/tools/legion.tools.ts
@@ -87,6 +87,12 @@ import {
   deriveRevealScript,
   type InscriptionData,
 } from "../transactions/inscription-builder.js";
+import {
+  buildChildCommitTransaction,
+  buildChildRevealTransaction,
+  deriveChildRevealScript,
+  lookupParentInscription,
+} from "../transactions/child-inscription-builder.js";
 import { signBtcTransaction } from "../transactions/bitcoin-builder.js";
 import { createErrorResponse, createJsonResponse } from "../utils/index.js";
 
@@ -1302,6 +1308,12 @@ export function registerLegionTools(server: McpServer): void {
         `legion's Stacks ${LEGION_NETWORK}), inscription runs on the Bitcoin network this ` +
         `server is configured for, currently ${NETWORK}. ordinals.com only serves mainnet ` +
         "inscriptions, so a non-mainnet inscription will not resolve for voters.\n\n" +
+        "Optionally makes the piece a CHILD of a parent inscription you own, per the Ordinals " +
+        "provenance spec. That binds every piece you file to one inscribed identity, which the " +
+        "governance contract cannot do — it records the Stacks principal that proposed, and the " +
+        "Bitcoin key that inscribed is a different identity entirely. It proves a body of work " +
+        "shares an author; it does NOT prove the work is original, which stays the voters' job " +
+        "and the veto window's.\n\n" +
         "Returns immediately without waiting for confirmation. Once the commit confirms " +
         "(typically 10-60 min), call legion_inscribe_reveal with the values returned here.\n\n" +
         "Requires an unlocked managed wallet with Bitcoin keys and funded UTXOs.",
@@ -1314,13 +1326,21 @@ export function registerLegionTools(server: McpServer): void {
           .string()
           .min(1)
           .describe("The piece itself, as markdown."),
+        parentInscriptionId: z
+          .string()
+          .optional()
+          .describe(
+            "Optional parent inscription id (e.g. 'abc…i0') to file this piece under. " +
+              "You must own it: the reveal spends the parent's UTXO and returns it to you, " +
+              "so children from one parent must be inscribed one at a time."
+          ),
         feeRate: z
           .union([z.enum(["fast", "medium", "slow"]), z.number().positive()])
           .optional()
           .describe("Fee rate: 'fast', 'medium', 'slow', or a number in sat/vB (default: medium)"),
       },
     },
-    async ({ title, body, feeRate }) => {
+    async ({ title, body, parentInscriptionId, feeRate }) => {
       try {
         const walletManager = getWalletManager();
         const sessionInfo = walletManager.getSessionInfo();
@@ -1340,6 +1360,32 @@ export function registerLegionTools(server: McpServer): void {
         if (!account?.btcPrivateKey || !account.btcPublicKey) {
           return createErrorResponse(
             new Error("Bitcoin keys not available. Wallet may not be unlocked.")
+          );
+        }
+        // Provenance is signed by the Taproot key that holds the parent, not by
+        // the funding key, so a parented piece needs both.
+        if (parentInscriptionId && (!account.taprootPrivateKey || !account.taprootPublicKey)) {
+          return createErrorResponse(
+            new Error(
+              "Taproot keys not available, so this wallet cannot spend a parent inscription. " +
+                "Inscribe without parentInscriptionId, or use a managed wallet."
+            )
+          );
+        }
+
+        // Verify ownership before spending anything: the reveal must spend the
+        // parent's UTXO, so a parent someone else holds is unusable and the
+        // commit fee would be burned discovering that later.
+        const parentInfo = parentInscriptionId
+          ? await lookupParentInscription(parentInscriptionId)
+          : null;
+        if (parentInfo && parentInfo.address !== sessionInfo.taprootAddress) {
+          return createErrorResponse(
+            new Error(
+              `Parent inscription ${parentInscriptionId} is held by ${parentInfo.address}, ` +
+                `not by your Taproot address ${sessionInfo.taprootAddress}. ` +
+                `You must own a parent to file children under it. Nothing was broadcast.`
+            )
           );
         }
 
@@ -1364,14 +1410,25 @@ export function registerLegionTools(server: McpServer): void {
           );
         }
 
-        const commitResult = buildCommitTransaction({
-          utxos,
-          inscription,
-          feeRate: actualFeeRate,
-          senderPubKey: account.btcPublicKey,
-          senderAddress: sessionInfo.btcAddress,
-          network: NETWORK,
-        });
+        const commitResult =
+          parentInscriptionId !== undefined
+            ? buildChildCommitTransaction({
+                utxos,
+                inscription,
+                parentInscriptionId,
+                feeRate: actualFeeRate,
+                senderPubKey: account.btcPublicKey,
+                senderAddress: sessionInfo.btcAddress,
+                network: NETWORK,
+              })
+            : buildCommitTransaction({
+                utxos,
+                inscription,
+                feeRate: actualFeeRate,
+                senderPubKey: account.btcPublicKey,
+                senderAddress: sessionInfo.btcAddress,
+                network: NETWORK,
+              });
         const commitSigned = signBtcTransaction(
           commitResult.tx,
           account.btcPrivateKey
@@ -1393,6 +1450,10 @@ export function registerLegionTools(server: McpServer): void {
           contentSize: content.length,
           title,
           markdown,
+          parentInscriptionId: parentInscriptionId ?? null,
+          parentUtxo: parentInfo
+            ? { txid: parentInfo.txid, vout: parentInfo.vout, value: parentInfo.value }
+            : undefined,
           warning:
             NETWORK === "mainnet"
               ? undefined
@@ -1400,7 +1461,8 @@ export function registerLegionTools(server: McpServer): void {
                 `link it produces will not resolve for legion voters.`,
           nextStep:
             "Wait for the commit to confirm, then call legion_inscribe_reveal with this " +
-            "commitTxid and revealAmount plus the same title and body.",
+            "commitTxid and revealAmount plus the same title and body" +
+            (parentInscriptionId ? " and the same parentInscriptionId." : "."),
         });
       } catch (error) {
         return createErrorResponse(error);
@@ -1418,8 +1480,11 @@ export function registerLegionTools(server: McpServer): void {
       description:
         "Complete a news inscription — STEP 2: broadcast the reveal transaction, after the " +
         "commit from legion_inscribe_story has confirmed.\n\n" +
-        "Pass the SAME title and body used in the commit step — the reveal script is derived " +
-        "from the content, so any difference produces a different script and the reveal fails.\n\n" +
+        "Pass the SAME title, body and parentInscriptionId used in the commit step — the reveal " +
+        "script is derived from all of them, so any difference produces a different script and " +
+        "the reveal fails.\n\n" +
+        "With a parent, the reveal spends both the commit output and the parent's UTXO, returns " +
+        "the parent to your Taproot address, and creates the child.\n\n" +
         "Returns the inscription id and the ordinals.com link, ready to hand straight to " +
         "legion_propose_story.\n\n" +
         "Requires an unlocked managed wallet.",
@@ -1434,13 +1499,17 @@ export function registerLegionTools(server: McpServer): void {
           .describe("revealAmount from the legion_inscribe_story response"),
         title: z.string().min(1).describe("Same title used in the commit step"),
         body: z.string().min(1).describe("Same body used in the commit step"),
+        parentInscriptionId: z
+          .string()
+          .optional()
+          .describe("Same parentInscriptionId used in the commit step, if any"),
         feeRate: z
           .union([z.enum(["fast", "medium", "slow"]), z.number().positive()])
           .optional()
           .describe("Fee rate for the reveal tx (default: medium)"),
       },
     },
-    async ({ commitTxid, revealAmount, title, body, feeRate }) => {
+    async ({ commitTxid, revealAmount, title, body, parentInscriptionId, feeRate }) => {
       try {
         const walletManager = getWalletManager();
         const sessionInfo = walletManager.getSessionInfo();
@@ -1457,6 +1526,29 @@ export function registerLegionTools(server: McpServer): void {
             new Error("Bitcoin keys not available. Wallet may not be unlocked.")
           );
         }
+        if (parentInscriptionId && (!account.taprootPrivateKey || !account.taprootPublicKey)) {
+          return createErrorResponse(
+            new Error(
+              "Taproot keys not available, so the parent's UTXO cannot be spent. " +
+                "Wallet may not be unlocked."
+            )
+          );
+        }
+
+        // Re-check ownership: the parent can have moved between commit and
+        // reveal, and a reveal that tries to spend a UTXO someone else now holds
+        // fails on broadcast after the fee is already committed.
+        const parentInfo = parentInscriptionId
+          ? await lookupParentInscription(parentInscriptionId)
+          : null;
+        if (parentInfo && parentInfo.address !== sessionInfo.taprootAddress) {
+          return createErrorResponse(
+            new Error(
+              `Parent inscription ${parentInscriptionId} is no longer held by your wallet — ` +
+                `current holder is ${parentInfo.address}. Nothing was broadcast.`
+            )
+          );
+        }
 
         const markdown = body.trimStart().startsWith("#")
           ? body
@@ -1469,27 +1561,57 @@ export function registerLegionTools(server: McpServer): void {
         const mempoolApi = new MempoolApi(NETWORK);
         const actualFeeRate = await resolveFeeRate(mempoolApi, feeRate);
 
-        const revealScript = deriveRevealScript({
-          inscription,
-          senderPubKey: account.btcPublicKey,
-          network: NETWORK,
-        });
-        const revealResult = buildRevealTransaction({
-          commitTxid,
-          commitVout: 0,
-          commitAmount: revealAmount,
-          revealScript,
-          recipientAddress: sessionInfo.taprootAddress,
-          feeRate: actualFeeRate,
-          network: NETWORK,
-        });
-        const revealSigned = signBtcTransaction(
-          revealResult.tx,
-          account.btcPrivateKey
-        );
-        const revealTxid = await mempoolApi.broadcastTransaction(
-          revealSigned.txHex
-        );
+        let revealResult;
+        let revealTxid: string;
+        if (parentInscriptionId !== undefined && parentInfo) {
+          const revealScript = deriveChildRevealScript({
+            inscription,
+            parentInscriptionId,
+            senderPubKey: account.btcPublicKey,
+            network: NETWORK,
+          });
+          revealResult = buildChildRevealTransaction({
+            commitTxid,
+            commitVout: 0,
+            commitAmount: revealAmount,
+            revealScript,
+            parentUtxo: {
+              txid: parentInfo.txid,
+              vout: parentInfo.vout,
+              value: parentInfo.value,
+            },
+            parentOwnerTaprootInternalPubKey: account.taprootPublicKey!,
+            recipientAddress: sessionInfo.taprootAddress,
+            feeRate: actualFeeRate,
+            network: NETWORK,
+          });
+          // Two inputs, two keys: the commit output spends script-path with the
+          // funding key, the parent spends key-path with the Taproot key.
+          revealResult.tx.sign(account.btcPrivateKey);
+          revealResult.tx.sign(account.taprootPrivateKey!);
+          revealResult.tx.finalize();
+          revealTxid = await mempoolApi.broadcastTransaction(revealResult.tx.hex);
+        } else {
+          const revealScript = deriveRevealScript({
+            inscription,
+            senderPubKey: account.btcPublicKey,
+            network: NETWORK,
+          });
+          revealResult = buildRevealTransaction({
+            commitTxid,
+            commitVout: 0,
+            commitAmount: revealAmount,
+            revealScript,
+            recipientAddress: sessionInfo.taprootAddress,
+            feeRate: actualFeeRate,
+            network: NETWORK,
+          });
+          const revealSigned = signBtcTransaction(
+            revealResult.tx,
+            account.btcPrivateKey
+          );
+          revealTxid = await mempoolApi.broadcastTransaction(revealSigned.txHex);
+        }
 
         const inscriptionId = `${revealTxid}i0`;
         const link = `${ORDINALS_INSCRIPTION_BASE}${inscriptionId}`;
@@ -1513,6 +1635,12 @@ export function registerLegionTools(server: McpServer): void {
             explorerUrl: getMempoolTxUrl(revealTxid, NETWORK),
           },
           recipientAddress: sessionInfo.taprootAddress,
+          parentInscriptionId: parentInscriptionId ?? null,
+          provenance: parentInscriptionId
+            ? `Child of ${parentInscriptionId}. Anyone can verify from the chain that this ` +
+              `piece and every other child share one inscriber — which is authorship, not ` +
+              `originality. Judging the work is still the voters' job.`
+            : undefined,
           warning:
             NETWORK === "mainnet"
               ? undefined


### PR DESCRIPTION
Adds `legion_*` tools for the AIBTC News Legion (`news-gov-v5`), so an agent can run the whole lifecycle — inscribe, propose, vote, veto, conclude — without hand-rolling contract calls.

Today the only way to reach this legion from the MCP is raw `call_contract`. `legions/news/scripts/flow.mjs` exists specifically because of that: it notes the MCP "resolves to whichever network its env is set to, and at time of writing that is MAINNET — broadcasting this flow through it would sign against real funds."

## Network pinning

Contract ids are constants in `src/config/legion.ts` and the network is derived from the address prefix (`ST…` → testnet), not from the global `NETWORK`. `getLegionAccount()` re-derives the unlocked wallet's address for that chain, so a mainnet-configured server signs legion calls against testnet.

Verified: server started with `NETWORK=mainnet`, `legion_status` returns `"network": "testnet"` and an `ST…` address.

The two inscription tools are the exception — they spend real BTC on whatever network `NETWORK` names, say so in their descriptions, and warn when that is not mainnet (ordinals.com serves mainnet only).

## Tools

Read (no wallet): `legion_status`, `legion_list_stories`, `legion_get_story`, `legion_my_position`

Write (unlocked wallet): `legion_contribute`, `legion_sponsor`, `legion_propose_story`, `legion_vote`, `legion_veto`, `legion_conclude`, `legion_faucet`

Inscription: `legion_inscribe_story`, `legion_inscribe_reveal`

## Notes

- Parameters, timing mode and the treasury's sBTC token are read from the contracts and cached per process — nothing hardcoded. `get-params` returns 12 fields and there is no `quote-bond` in v5; the bond is the proposer's entire weight.
- Write paths pre-flight the contract's own preconditions (`propose-status`, `get-phase`, vote/veto records) and refuse locally with the specific blocker rather than reverting on chain.
- Fund-moving calls use DENY mode with an exact post-condition. `legion_conclude` caps the treasury at the snapshotted draw, which covers both the paying and non-paying outcomes.
- `pending` is a phase, not a stored status; the list filter is phase-based.
- A settled story reports the recorded outcome, not a forecast — a passed proposal is past its conclude window, so forecasting would label every settled piece "expired".
- Legion spends are not metered by the `SPEND_LIMIT_*` rail: that sats ledger tracks real BTC and these are testnet sBTC.

## Testing

Read paths exercised against the live testnet contracts (5 proposals, 30,039,847 sat pool) and end-to-end through the MCP server over stdio: all 13 tools register, reads return correct data, and the write paths refuse cleanly with contract-accurate messages. Broadcasting write paths was not tested — that needs testnet sBTC and a funded key.

`npx tsc --noEmit` and `npm run build` pass.
