### PR TITLE
feat(legion): require explicit consent before spending mainnet BTC

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -663,6 +663,17 @@ must be inscribed **one at a time**. Ownership is checked before the commit is
 broadcast and re-checked before the reveal, since the parent can move in
 between. Use `estimate_child_inscription_fee` for the extra input/output cost.
 
+**Only two of these tools can reach mainnet.** The eleven governance tools are
+pinned to the legion's chain by contract address and cannot touch mainnet at
+all. `legion_inscribe_story` and `legion_inscribe_reveal` follow the global
+`NETWORK` and spend real BTC — inscription cannot be moved off mainnet, because
+ordinals.com indexes mainnet only.
+
+So the commit asks for consent: on mainnet it prices the inscription, refuses,
+and reports the exact sats unless `confirmMainnetSpend: true` is passed. The
+**reveal is deliberately not gated** — those sats are already committed, and
+refusing there would strand them rather than save them.
+
 **Inscription pre-flight.** Bitcoin failures cost real sats and 10–60 min per
 confirmation, so `legion_inscribe_story` refuses locally before it signs:
 
@@ -671,6 +682,7 @@ confirmation, so `legion_inscribe_story` refuses locally before it signs:
 | content ≤ 390,000 bytes | the body rides in the reveal witness — oversized commits fine, then can never be revealed |
 | fee estimate is finite and positive | the builders only reject `<= 0`; `NaN` slips past into every size calculation |
 | `NETWORK === "mainnet"` unless `allowNonMainnet` | ordinals.com indexes mainnet only, so the link would 404 for every voter |
+| `confirmMainnetSpend: true` on mainnet | the only step that moves real money; quoted and consented to, never implicit |
 | parent is held by this wallet | the reveal must spend the parent's UTXO |
 | funding covers reveal amount + commit fee | from the builder, with exact numbers |
 

--- a/src/tools/legion.tools.ts
+++ b/src/tools/legion.tools.ts
@@ -1333,7 +1333,9 @@ export function registerLegionTools(server: McpServer): void {
         "Content type is text/markdown; the title is prepended as an H1 unless the body already " +
         "starts with one.\n\n" +
         `SPENDS REAL BITCOIN, on the Bitcoin network NETWORK names (currently ${NETWORK}) — ` +
-        `not the Stacks ${LEGION_NETWORK} the rest of the legion_* tools use.\n\n` +
+        `not the Stacks ${LEGION_NETWORK} the rest of the legion_* tools use. A mainnet ` +
+        "inscription therefore needs `confirmMainnetSpend: true`; without it the tool prices " +
+        "the piece and refuses, so real BTC is never spent by accident.\n\n" +
         "Optional `parentInscriptionId` files the piece as a child of a parent you own, binding " +
         "your pieces to one inscribed identity. That is authorship, not originality.\n\n" +
         "Pre-flights content size, fee estimate, parent ownership, funding and network before " +
@@ -1364,6 +1366,13 @@ export function registerLegionTools(server: McpServer): void {
             "Run every pre-flight check and price the inscription, but sign nothing. " +
               "Use this to see the cost before spending it."
           ),
+        confirmMainnetSpend: z
+          .boolean()
+          .optional()
+          .describe(
+            "Acknowledge that this spends real BTC. Required on mainnet — without it the " +
+              "tool returns the exact cost and refuses."
+          ),
         allowNonMainnet: z
           .boolean()
           .optional()
@@ -1377,7 +1386,7 @@ export function registerLegionTools(server: McpServer): void {
           .describe("Fee rate: 'fast', 'medium', 'slow', or a number in sat/vB (default: medium)"),
       },
     },
-    async ({ title, body, parentInscriptionId, dryRun, allowNonMainnet, feeRate }) => {
+    async ({ title, body, parentInscriptionId, dryRun, confirmMainnetSpend, allowNonMainnet, feeRate }) => {
       try {
         // A testnet inscription is almost always a misconfiguration here: the
         // legion's governance is testnet but its links are read on mainnet
@@ -1548,6 +1557,24 @@ export function registerLegionTools(server: McpServer): void {
           });
         }
 
+        // The legion itself is testnet, so an agent working through it has no
+        // reason to expect real money to move. Inscription is the one step that
+        // does, and it cannot be moved off mainnet (ordinals.com indexes mainnet
+        // only), so the cost is quoted and consent taken instead.
+        if (NETWORK === "mainnet" && !confirmMainnetSpend) {
+          const total = commitResult.fee + commitResult.revealAmount;
+          return createErrorResponse(
+            new Error(
+              `This would spend ${total} sats of REAL BITCOIN on mainnet — ` +
+                `${commitResult.fee} commit fee plus ${commitResult.revealAmount} locked for ` +
+                `the reveal. The legion's governance is Stacks ${LEGION_NETWORK}, but the ` +
+                `inscription is mainnet Bitcoin because ordinals.com indexes mainnet only. ` +
+                `Nothing was signed. Re-call with confirmMainnetSpend: true to proceed, or ` +
+                `dryRun: true for the full breakdown.`
+            )
+          );
+        }
+
         const commitSigned = signBtcTransaction(
           commitResult.tx,
           account.btcPrivateKey
@@ -1602,6 +1629,8 @@ export function registerLegionTools(server: McpServer): void {
         "derived from all three. The commit's actual output is checked against the script this " +
         "content derives, so a mismatch is refused before signing rather than losing the sats.\n\n" +
         "Returns the inscription id and link for legion_propose_story.\n\n" +
+        "No mainnet confirmation is asked for here, unlike the commit: those sats are already " +
+        "committed, and refusing the reveal would strand them rather than save them.\n\n" +
         "Requires an unlocked managed wallet.",
       inputSchema: {
         commitTxid: z


### PR DESCRIPTION
The legion's governance is Stacks testnet, so an agent working through these tools has no reason to expect real money to move. Inscription is the one step that does.

Only 2 of the 13 tools can reach mainnet at all:

- The **11 governance tools** use `LEGION_NETWORK`, pinned from the contract address. They cannot touch mainnet — unchanged here.
- **`legion_inscribe_story` / `legion_inscribe_reveal`** use the global `NETWORK` and spend real BTC.

Inscription cannot be moved off mainnet: ordinals.com indexes mainnet only (`/status` reports `chain: mainnet`; `signet.`/`testnet.` don't resolve), so a testnet inscription produces a link no voter can open. Blocking it outright would break the publish path. So the cost is quoted and consent taken instead.

**`legion_inscribe_story`** now refuses on mainnet without `confirmMainnetSpend: true`:

```
legion_inscribe_story { title, body }
  → Error: This would spend 4750 sats of REAL BITCOIN on mainnet — 1400 commit
    fee plus 3350 locked for the reveal. The legion's governance is Stacks
    testnet, but the inscription is mainnet Bitcoin because ordinals.com indexes
    mainnet only. Nothing was signed. Re-call with confirmMainnetSpend: true to
    proceed, or dryRun: true for the full breakdown.
```

The gate sits **after** the commit is built, so the refusal carries exact sats, and **before** anything is signed — build (1484) → dryRun (1547) → gate (1564) → sign (1578) → broadcast (1582).

**The reveal is deliberately not gated.** Those sats are already committed at that point; refusing there would strand them rather than save them. Called out in the tool description so it reads as a decision rather than an oversight.

## Testing

`tsc` and build pass. Verified through the server with `NETWORK=mainnet`: the new `confirmMainnetSpend` param is exposed on the commit and absent from the reveal, and `legion_status` still reports `testnet`.

The refusal itself is not exercised at runtime — it sits after the commit build, so reaching it needs a funded mainnet wallet. Verified by ordering instead.
