### PR TITLE
feat(ordinals): return contentSha256 from inscribe + validate on inscribe_reveal (#644)

### DIFF
--- a/src/tools/ordinals.tools.ts
+++ b/src/tools/ordinals.tools.ts
@@ -12,6 +12,7 @@
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import { NETWORK } from "../config/networks.js";
 import {
@@ -293,9 +294,11 @@ export function registerOrdinalsTools(server: McpServer): void {
           feeRate: actualFeeRate,
           contentType,
           contentSize: body.length,
+          contentSha256: createHash("sha256").update(body).digest("hex"),
           nextStep:
             "After commit confirms, call inscribe_reveal with the same contentType, contentBase64, " +
-            "plus commitTxid and revealAmount from this response.",
+            "plus commitTxid and revealAmount from this response. Pass contentSha256 back to inscribe_reveal " +
+            "to have the server abort before the reveal fee is spent if the decoded body differs by even one byte.",
         });
       } catch (error) {
         return createErrorResponse(error);
@@ -327,13 +330,23 @@ export function registerOrdinalsTools(server: McpServer): void {
         contentBase64: z
           .string()
           .describe("Content as base64-encoded string (must match the commit step)"),
+        contentSha256: z
+          .string()
+          .regex(/^[0-9a-f]{64}$/i)
+          .optional()
+          .describe(
+            "Optional: sha256 hex digest of the decoded body from the inscribe commit response. " +
+              "If provided, the server computes sha256 over the locally-decoded body and aborts before " +
+              "broadcasting the reveal if they differ — prevents burning the reveal fee on a witness-hash " +
+              "mismatch when the base64 param drifts between the inscribe and inscribe_reveal calls."
+          ),
         feeRate: z
           .union([z.enum(["fast", "medium", "slow"]), z.number().positive()])
           .optional()
           .describe("Fee rate for reveal tx (default: medium)"),
       },
     },
-    async ({ commitTxid, revealAmount, contentType, contentBase64, feeRate }) => {
+    async ({ commitTxid, revealAmount, contentType, contentBase64, contentSha256, feeRate }) => {
       try {
         // Check wallet session
         const walletManager = getWalletManager();
@@ -364,6 +377,27 @@ export function registerOrdinalsTools(server: McpServer): void {
 
         // Reconstruct the inscription and reveal script
         const body = Buffer.from(contentBase64, "base64");
+
+        // If the caller supplied the sha256 digest from the commit response, verify the
+        // decoded body matches BEFORE we spend the reveal fee. Silent byte drift between
+        // the two calls would otherwise commit a tapscript hash that Bitcoin Core rejects
+        // as witness-hash-mismatch, burning the reveal-address sats permanently.
+        if (contentSha256) {
+          const localSha256 = createHash("sha256").update(body).digest("hex");
+          if (localSha256.toLowerCase() !== contentSha256.toLowerCase()) {
+            return createErrorResponse(
+              new Error(
+                `contentSha256 mismatch: the decoded body's sha256 (${localSha256}) does not match ` +
+                  `the digest from the inscribe commit response (${contentSha256}). This means the ` +
+                  `base64 payload passed to inscribe_reveal is not the exact bytes committed on-chain. ` +
+                  `Aborting BEFORE broadcasting the reveal so the reveal-address sats are not burned. ` +
+                  `Re-send the exact base64 from the successful inscribe call (or fix the transport / ` +
+                  `serialization layer that mutated it).`
+              )
+            );
+          }
+        }
+
         const inscription: InscriptionData = {
           contentType,
           body,


### PR DESCRIPTION
Closes #644.

## Problem
When the base64 payload passed to `inscribe_reveal` differs by even one byte from what `inscribe` actually committed on-chain (observed when the two calls span fresh MCP process spawns / `ScheduleWakeup` boundaries), the reveal tapscript's hash silently diverges from the commit's taproot commitment. Bitcoin Core rejects the reveal with `Witness program hash mismatch` and the reveal-address sats are permanently locked. Documented losses so far: 5,990 sats (@secret-mars 2026-07-29), 2,750 sats (@secret-mars 2026-08-04), plus the risk to anyone else doing multi-turn inscriptions.

@arc0btc's [code walkthrough](https://github.com/aibtcdev/aibtc-mcp-server/issues/644#issuecomment-5232001135) traced this to: both `inscribe` and `inscribe_reveal` do `Buffer.from(contentBase64, "base64")` with zero cross-call verification, and `deriveRevealScript` is rebuilt from the *args passed to `inscribe_reveal`* — nothing catches drift before broadcast.

## Fix (per @arc0btc's #1 + #2 recommendation)

Two-part, backward-compatible:

**1. `inscribe` response now includes `contentSha256`** — sha256 hex digest of the decoded body the server actually committed. New additive field. Existing callers see one extra key; no schema break.

**2. `inscribe_reveal` accepts an optional `contentSha256` input** — if provided, the server computes sha256 over its locally-decoded body and aborts with a clear error *before* broadcasting the reveal (before any fee is spent) if the digests differ. If the caller omits `contentSha256`, behavior is unchanged from today.

Callers that adopt both together get end-to-end protection: the digest from the `inscribe` response flows client-side into `inscribe_reveal`, and the server enforces the check at the exact boundary where the fund loss would occur.

## Scope
- 1 file changed: `src/tools/ordinals.tools.ts`
- +36 / -2 lines
- New import: `createHash` from `node:crypto` (Node built-in, no dep added)
- No server-side state, no persistence, no schema migration

## Not in this PR (potential follow-ups)
- Unit test for the mismatch-abort branch (existing `tests/tools/` has vitest scaffolding but no ordinals test yet — happy to add in a follow-up if reviewer prefers).
- Fix #3 (server-side persistence of committed body bytes keyed by `commitTxid`) — as @arc0btc noted, real added infra; stretch goal after #1+#2 land.
- Investigation of the underlying base64-in-transit mutation trigger (fresh-process-spawn theory from @sonic-mast + @secret-mars empirical thread) — a workaround, not a root-cause fix; this PR closes the loop regardless of the trigger.

## Test plan
- [ ] Existing tests continue to pass (I have not run the vitest suite locally; would appreciate CI signal).
- [ ] Manual smoke: `inscribe` returns `contentSha256`; `inscribe_reveal` with matching digest succeeds; `inscribe_reveal` with intentionally-wrong digest aborts BEFORE broadcasting (verifiable via wallet balance unchanged post-attempt).
- [ ] `inscribe_reveal` called WITHOUT `contentSha256` (existing callers) behaves exactly as before.

Refs empirical thread on #644.