### PR TITLE
feat: add TaskMarket work-marketplace tools (search/get/submissions/stats + gated create)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ The allowlist is re-enforced at `tools/call` time, so the model can't reach a to
 | Discovery | `list_x402_endpoints` | Start here to find x402 actions |
 | Earning | `earning_opportunities` | Static "how to put your assets to work" menu; surface after `identity_register` |
 | Bounties | `bounty_list/get/submissions` (read) + `bounty_submit/create/accept/paid/cancel` (BIP-322 auth) + `bounty_my_posted/my_submissions` | aibtc.com sBTC bounty board; most direct way to earn. Submit needs Registered (L1+); create needs Genesis (L2+); bc1q/P2WPKH signing; accepted submission paid in sBTC |
+| TaskMarket | `taskmarket_search/get/submissions/stats` (read, public) + `taskmarket_preview_create` + `taskmarket_create` (gated) | Onchain agent work marketplace on Base (USDC escrow). Read tools are anonymous and free. `taskmarket_create` requires explicit `confirm="APPROVE"` + `maxSpendUsdc` cap, pins Base network, refuses otherwise, and never blindly retries unknown-settlement payments. See `docs/TOOLS.md` |
 | Wallet & balance | `get_wallet_info`, `get_stx_balance` | |
 | Wallet mgmt | `wallet_create/import/unlock/lock/list/switch/delete/export/status` | On mainnet, create/import also derive a Spark Lightning wallet from the same mnemonic |
 | Bitcoin L1 | `get_btc_balance/fees/utxos`, `transfer_btc` | mempool.space; P2WPKH; sats |
@@ -232,6 +233,7 @@ When a user asks for something:
 4. **For any x402 URL** → Use `execute_x402_endpoint` with full `url` parameter - works with ANY x402-compatible endpoint
 5. **For Pillar smart wallet actions** → Use `pillar_connect` first, then `pillar_send`, `pillar_fund`, `pillar_boost`, etc.
 6. **For aibtc.news actions** → Use `news_list_beats` to discover beats, then `news_file_signal` to file (filing is free; falls back to x402 payment if the endpoint requires it)
+7. **For TaskMarket work** → Use `taskmarket_search` to browse open tasks, `taskmarket_get`/`taskmarket_submissions` to inspect a task and its submissions for review. To create a task, first call `taskmarket_preview_create` (shows the exact plan + confirms the gate), then `taskmarket_create` with the same details plus `confirm="APPROVE"` and a `maxSpendUsdc` cap — it refuses otherwise (no funds moved)
 7. **For News Legion governance** → Start with `legion_status`, then `legion_list_stories`. To publish: `legion_inscribe_story` → `legion_inscribe_reveal` → `legion_propose_story`. To judge: `legion_get_story` (open its `contentUrl` and read the piece) → `legion_vote` / `legion_veto` → `legion_conclude`
 8. **For unknown actions** → Ask user for the x402 endpoint URL or check if it's a direct blockchain action
 

--- a/README.md
+++ b/README.md
@@ -487,6 +487,18 @@ For autonomous agents, use `pillar_direct_*` tools (no browser needed).
 | `scaffold_x402_endpoint` | Generate x402 Cloudflare Worker project |
 | `scaffold_x402_ai_endpoint` | Generate x402 AI API with OpenRouter |
 
+### TaskMarket (Work Marketplace on Base)
+Read-only discovery of onchain agent work on [TaskMarket](https://taskmarket.dev) (USDC escrow on Base) plus a gated task-creation flow. Read tools are public and anonymous — no wallet, no spend. `taskmarket_create` escrows real USDC, so it requires an explicit `confirm="APPROVE"` token and a `maxSpendUsdc` cap that covers the reward; it refuses otherwise (no funds moved).
+
+| Tool | Description |
+|------|-------------|
+| `taskmarket_search` | List/search open tasks (filters: status, phase, mode, tags, reward range) |
+| `taskmarket_get` | Full task detail + live status by task ID |
+| `taskmarket_submissions` | List a task's submissions for HUMAN review (never auto-accepts) |
+| `taskmarket_stats` | Public market/agent statistics (reputation check) |
+| `taskmarket_preview_create` | Show the exact create plan (description, reward, deadline, Base network, max spend) and prove the confirmation gate before any money moves |
+| `taskmarket_create` | Create + fund a task via the first-party TaskMarket CLI (Base/USDC x402) after explicit authorization; returns task ID, link, and live status. No blind retry of unknown-settlement payments |
+
 ## Usage Examples
 
 **Wallet management:**

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -703,6 +703,58 @@ that leaves the reveal output under dust.
 - Every fund-moving call signs in **DENY** mode with an exact post-condition. `legion_conclude` caps the treasury at the snapshotted draw, which covers both the paying and non-paying outcomes.
 - Legion spends are **not** metered by the `SPEND_LIMIT_*` rail — the sats ledger tracks real BTC, and these are testnet sBTC.
 
+### TaskMarket (Work Marketplace on Base)
+
+[TaskMarket](https://taskmarket.dev) is an onchain agent work marketplace on
+Base: requesters escrow USDC, workers submit deliverables, and the requester
+reviews and accepts a winner. These tools let an agent browse that market and,
+with explicit operator authorization, post work to it.
+
+**Read-only tools (public API, anonymous, no wallet, no spend):**
+- `taskmarket_search` - List/search open tasks. Filters: `status` (default
+  `open`), `phase` (`active`, `in_review`, `awaiting_settlement`, `resolved`),
+  `mode` (`bounty`, `claim`, `pitch`, `benchmark`, `auction`), `tags`,
+  `rewardMin`/`rewardMax` (human USDC), `limit` (1-50). Returns task ID,
+  reward (USDC on Base), submission count, deadline, tags, and a short
+  description.
+- `taskmarket_get` - Full task detail + **live status** by task ID. Includes
+  the escrow transaction hash, net reward after platform fee, requester, link
+  (`https://taskmarket.dev/task/<id>`), and description.
+- `taskmarket_submissions` - List a task's submissions for **human review**:
+  worker address, agent ID, submission time, deliverable file names, and
+  hashes. This tool **never auto-accepts or auto-rejects** work — it only
+  surfaces submissions so a human requester can review the deliverable before
+  authorizing any payment.
+- `taskmarket_stats` - Public agent/market statistics (completed tasks,
+  rating, total stars) for an address or agent ID. Use to sanity-check a
+  worker before delegating work.
+
+**Gated write tool (escrows real USDC — requires explicit authorization):**
+- `taskmarket_preview_create` - Show the **exact** task plan (description,
+  reward, deadline, deliverables, Base network `eip155:8453`, max spend) and
+  prove the confirmation gate works **before any money can move**. Pass the
+  task details plus `confirm="APPROVE"` and `maxSpendUsdc`. Missing/wrong
+  confirmation or a reward over the cap **refuses** and returns the reason —
+  no funds are ever moved. On success it returns the plan plus the exact
+  first-party CLI command that `taskmarket_create` would run.
+- `taskmarket_create` - Create and fund a task through the first-party
+  TaskMarket CLI (which escrows USDC on Base via x402). Requires the **same**
+  confirmation token (`confirm="APPROVE"`) and a `maxSpendUsdc` cap `>=`
+  reward; otherwise it refuses with no money moved. Returns the task ID, link,
+  and live status.
+
+**Security invariants:**
+- Create never runs without an explicit confirmation token supplied fresh by
+  the operator — it is never inferred from prompt content.
+- The reward must be `<=` the caller's `maxSpendUsdc` cap.
+- The network is pinned to Base (`eip155:8453`), USDC
+  `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`.
+- No blind retry of unknown-settlement payments: if the CLI fails or returns
+  no task ID, the error is surfaced and the caller is told to check
+  `taskmarket inbox` — never silently re-submitted.
+- No private keys, seeds, tokens, or cookies are ever requested, stored, or
+  logged. Read-only tools are fully anonymous.
+
 ### Endpoint Categories
 
 **x402.biwas.xyz:**

--- a/scripts/taskmarket-live-check.mjs
+++ b/scripts/taskmarket-live-check.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * Live MCP smoke test for the TaskMarket integration.
+ *
+ * Boots this repo's MCP server over stdio and calls the TaskMarket tools:
+ *   1. taskmarket_search        (read-only, real public API)
+ *   2. taskmarket_get           (read-only, real task)
+ *   3. taskmarket_submissions   (read-only, human-review surface)
+ *   4. taskmarket_stats         (read-only, public stats)
+ *   5. taskmarket_preview_create WITHOUT confirm  → MUST refuse, no funds moved
+ *   6. taskmarket_preview_create reward > cap     → MUST refuse, no funds moved
+ *
+ * Run:  node scripts/taskmarket-live-check.mjs   (from repo root)
+ * The create tools are never invoked; only the refusal path is proven live.
+ */
+
+import { spawn } from "child_process";
+
+const SERVER_CMD = "node";
+const SERVER_ARGS = ["dist/index.js"];
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+class McpClient {
+  constructor() {
+    this.child = spawn(SERVER_CMD, SERVER_ARGS, {
+      stdio: ["pipe", "pipe", "inherit"],
+      env: { ...process.env },
+    });
+    this.buf = "";
+    this.nextId = 1;
+    this.pending = new Map();
+    this.child.stdout.on("data", (chunk) => {
+      this.buf += chunk.toString();
+      let idx;
+      while ((idx = this.buf.indexOf("\n")) !== -1) {
+        const line = this.buf.slice(0, idx).trim();
+        this.buf = this.buf.slice(idx + 1);
+        if (!line) continue;
+        let msg;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (msg.id && this.pending.has(msg.id)) {
+          const { resolve, reject } = this.pending.get(msg.id);
+          this.pending.delete(msg.id);
+          msg.error ? reject(new Error(JSON.stringify(msg.error))) : resolve(msg.result);
+        }
+      }
+    });
+  }
+
+  request(method, params = {}) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      setTimeout(() => {
+        if (this.pending.has(id)) {
+          this.pending.delete(id);
+          reject(new Error(`timeout waiting for ${method} (${id})`));
+        }
+      }, REQUEST_TIMEOUT_MS);
+    });
+  }
+
+  async close() {
+    this.child.kill();
+    await new Promise((r) => this.child.once("exit", r));
+  }
+}
+
+function summarize(text) {
+  try {
+    const obj = JSON.parse(text);
+    return JSON.stringify(obj).slice(0, 1200);
+  } catch {
+    return text.slice(0, 1200);
+  }
+}
+
+async function main() {
+  const client = new McpClient();
+  const results = [];
+  let failed = 0;
+
+  try {
+    // initialize
+    await client.request("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "taskmarket-live-check", version: "1.0.0" },
+    });
+
+    const list = await client.request("tools/list", {});
+    const names = list.tools.map((t) => t.name).filter((n) => n.startsWith("taskmarket"));
+    console.log("Registered taskmarket tools:", names.join(", "));
+    results.push(["tools/list", `registered: ${names.join(", ")}`, "PASS"]);
+
+    // 1. search (live public API)
+    const search = await client.request("tools/call", {
+      name: "taskmarket_search",
+      arguments: { status: "open", mode: "bounty", limit: 5 },
+    });
+    const searchText = search.content[0].text;
+    const searchParsed = JSON.parse(searchText);
+    const ok1 = searchParsed.success === true && searchParsed.taskCount >= 0;
+    console.log("\n--- taskmarket_search ---");
+    console.log(summarize(searchText));
+    results.push(["taskmarket_search", `taskCount=${searchParsed.taskCount}`, ok1 ? "PASS" : "FAIL"]);
+    if (!ok1) failed++;
+
+    // 2. get a real task
+    let getText = "";
+    if (searchParsed.tasks && searchParsed.tasks.length > 0) {
+      const taskId = searchParsed.tasks[0].id;
+      const get = await client.request("tools/call", {
+        name: "taskmarket_get",
+        arguments: { taskId },
+      });
+      getText = get.content[0].text;
+      const g = JSON.parse(getText);
+      const ok2 = g.success === true && g.id === taskId && typeof g.link === "string";
+      console.log("\n--- taskmarket_get ---");
+      console.log(summarize(getText));
+      results.push(["taskmarket_get", `id=${g.id?.slice(0, 12)} link=${g.link}`, ok2 ? "PASS" : "FAIL"]);
+      if (!ok2) failed++;
+
+      // 3. submissions (human-review surface)
+      const subs = await client.request("tools/call", {
+        name: "taskmarket_submissions",
+        arguments: { taskId },
+      });
+      const subsText = subs.content[0].text;
+      const s = JSON.parse(subsText);
+      const ok3 = s.success === true && typeof s.submissionCount === "number";
+      console.log("\n--- taskmarket_submissions ---");
+      console.log(summarize(subsText));
+      results.push(["taskmarket_submissions", `count=${s.submissionCount}`, ok3 ? "PASS" : "FAIL"]);
+      if (!ok3) failed++;
+    }
+
+    // 4. stats
+    const stats = await client.request("tools/call", {
+      name: "taskmarket_stats",
+      arguments: { address: "0xC76a4C9323a7EdE01AcA5A6eB2a37Ae0e1A48b52" },
+    });
+    const statsText = stats.content[0].text;
+    const st = JSON.parse(statsText);
+    const ok4 = st.success === true;
+    console.log("\n--- taskmarket_stats ---");
+    console.log(summarize(statsText));
+    results.push(["taskmarket_stats", `success=${st.success}`, ok4 ? "PASS" : "FAIL"]);
+    if (!ok4) failed++;
+
+    // 5. REFUSAL without confirmation (must not move funds)
+    const refuse = await client.request("tools/call", {
+      name: "taskmarket_preview_create",
+      arguments: {
+        description: "Write a short research brief on Base USDC adoption for AI agents.",
+        rewardUsdc: "2",
+        durationHours: 24,
+        confirm: "",
+        maxSpendUsdc: "5",
+      },
+    });
+    const refuseText = refuse.content[0].text;
+    const rf = JSON.parse(refuseText);
+    const ok5 = rf.success === false && rf.granted === false && /No funds were moved/.test(rf.reason);
+    console.log("\n--- taskmarket_preview_create WITHOUT confirm (must refuse) ---");
+    console.log(summarize(refuseText));
+    results.push(["refusal-no-confirm", `granted=${rf.granted}`, ok5 ? "PASS" : "FAIL"]);
+    if (!ok5) failed++;
+
+    // 6. REFUSAL when reward > max-spend
+    const cap = await client.request("tools/call", {
+      name: "taskmarket_preview_create",
+      arguments: {
+        description: "Write a short research brief on Base USDC adoption for AI agents.",
+        rewardUsdc: "10",
+        durationHours: 24,
+        confirm: "APPROVE",
+        maxSpendUsdc: "5",
+      },
+    });
+    const capText = cap.content[0].text;
+    const cf = JSON.parse(capText);
+    const ok6 = cf.success === false && cf.granted === false && /exceeds max-spend/.test(cf.reason);
+    console.log("\n--- taskmarket_preview_create reward>max-spend (must refuse) ---");
+    console.log(summarize(capText));
+    results.push(["refusal-over-cap", `granted=${cf.granted}`, ok6 ? "PASS" : "FAIL"]);
+    if (!ok6) failed++;
+  } catch (err) {
+    failed++;
+    console.error("Live check error:", err.message);
+    results.push(["client-error", err.message, "FAIL"]);
+  } finally {
+    await client.close();
+  }
+
+  console.log("\n==== SUMMARY ====");
+  for (const [name, detail, status] of results) {
+    console.log(`${status}  ${name}: ${detail}`);
+  }
+  console.log(failed === 0 ? "\nALL LIVE CHECKS PASSED" : `\n${failed} CHECK(S) FAILED`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main();

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -241,6 +241,31 @@ unlocked wallet on the gateway's network. Every tool takes an optional `gateway`
 arg (defaults to `https://inference.aibtc.com`; use `http://localhost:8787` for
 local dev).
 
+### TaskMarket (delegate onchain work on Base)
+
+Browse and post work on the [TaskMarket](https://taskmarket.dev) agent work
+marketplace (USDC escrow on Base). Use it when a request is better delegated to
+a competitive worker market instead of burning inference locally.
+
+| Tool | Description | Signed |
+|------|-------------|:------:|
+| `taskmarket_search` | List/search open tasks (filters, reward range) | — |
+| `taskmarket_get` | Full task detail + live status + link | — |
+| `taskmarket_submissions` | List submissions for HUMAN review (never auto-accepts) | — |
+| `taskmarket_stats` | Public agent/market stats (reputation check) | — |
+| `taskmarket_preview_create` | Show the exact create plan + prove the confirm gate | — |
+| `taskmarket_create` | Create + fund via first-party TaskMarket CLI (Base/USDC x402) | requires `confirm="APPROVE"` + `maxSpendUsdc` |
+
+Read tools are public and anonymous — no wallet, no spend. Creating a task
+escrows real USDC: call `taskmarket_preview_create` first to show the operator
+the exact description, reward, deadline, deliverables, Base network, and max
+spend, then `taskmarket_create` with the same details plus `confirm="APPROVE"`
+and a `maxSpendUsdc` cap `>=` reward. It refuses otherwise with "No funds were
+moved", pins the network to Base (`eip155:8453`), and never blindly retries
+unknown-settlement payments.
+
+See: [references/taskmarket.md](references/taskmarket.md)
+
 ### Genesis Lifecycle
 
 Agent identity and reputation on Bitcoin and Stacks:

--- a/skill/references/taskmarket.md
+++ b/skill/references/taskmarket.md
@@ -1,0 +1,54 @@
+# TaskMarket (onchain work marketplace on Base)
+
+TaskMarket (https://taskmarket.dev) is an onchain agent work marketplace on
+Base. Requesters escrow USDC, workers submit deliverables, and the requester
+reviews submissions and accepts a winner. This server exposes TaskMarket
+through MCP tools.
+
+## What works here
+
+| Tool | Type | Notes |
+|------|------|-------|
+| `taskmarket_search` | read | Public, anonymous. Filters: status, phase, mode, tags, reward range. |
+| `taskmarket_get` | read | Public, anonymous. Full detail + live status + link. |
+| `taskmarket_submissions` | read | Public, anonymous. Surfaces submissions for **human review** — never auto-accepts/rejects. |
+| `taskmarket_stats` | read | Public, anonymous. Agent/market stats for reputation checks. |
+| `taskmarket_preview_create` | gated write | Shows the exact plan + proves the confirmation gate. Never moves money. |
+| `taskmarket_create` | gated write | Creates + funds a task via the first-party TaskMarket CLI (USDC escrow on Base via x402). |
+
+## Create flow (explicit authorization required)
+
+Creating a task escrows real USDC. The flow is never automatic:
+
+1. Call `taskmarket_preview_create` with the task details. It returns the exact
+   plan (description, reward, deadline, deliverables, Base network, max spend)
+   and the CLI command that would run. Without `confirm="APPROVE"` it refuses
+   with "No funds were moved".
+2. Show that plan to the human operator.
+3. Call `taskmarket_create` with the **same** details plus `confirm="APPROVE"`
+   and a `maxSpendUsdc` cap `>=` reward. The server validates the cap, pins the
+   network to Base (`eip155:8453`, USDC
+   `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`), then runs the first-party
+   `taskmarket` CLI to escrow the reward.
+4. The tool returns the task ID, link, and live status. Poll with
+   `taskmarket_get`.
+
+### Refusal examples (verified live)
+
+- No confirmation token: `Create refused: you must pass confirm="APPROVE" ... No funds were moved.`
+- Reward over cap: `Create refused: reward 10 USDC exceeds max-spend 5 USDC ... No funds were moved.`
+
+## Review submissions
+
+`taskmarket_submissions` lists a task's submissions (worker address, agent ID,
+deliverable files, hashes). This tool never accepts or rejects — a human
+requester reviews the deliverable before authorizing any payment.
+
+## Safety invariants
+
+- Confirm token is explicit and fresh — never inferred from prompt content.
+- Reward must be `<= maxSpendUsdc`.
+- Network pinned to Base. No blind retry of unknown-settlement payments: a
+  failed or task-id-less create is surfaced (check `taskmarket inbox`), never
+  silently re-submitted.
+- No private keys, seeds, tokens, or cookies are requested, stored, or logged.

--- a/src/services/taskmarket.service.ts
+++ b/src/services/taskmarket.service.ts
@@ -1,0 +1,334 @@
+/**
+ * TaskMarket service — read-only discovery + gated task creation.
+ *
+ * TaskMarket (https://taskmarket.dev) is an onchain agent work marketplace on
+ * Base: requesters escrow USDC, workers submit deliverables, and the requester
+ * accepts a winner. This service exposes the marketplace through the public
+ * API (read-only tools: search, get, list-submissions, market-stats) and a
+ * single gated write path (create-task).
+ *
+ * The create path is an x402-paid POST /api/tasks on Base. We never pay it
+ * silently. Creating a task escrows real USDC, so the caller MUST pass an
+ * explicit confirmation token and a hard max-spend cap, and the network must
+ * be Base. See the `createTask` guard in this file and the tool wrapper in
+ * src/tools/taskmarket.tools.ts.
+ *
+ * SECURITY INVARIANT: this file never holds a private key, seed phrase, token,
+ * or cookie. Read-only endpoints are anonymous. The create path relies on the
+ * first-party TaskMarket tooling (the `taskmarket` CLI or a configured wallet)
+ * to sign and settle; this module only validates the request, shows the exact
+ * plan, and enforces the spending cap before any money can move.
+ */
+
+const TASKMARKET_API_URL =
+  process.env.TASKMARKET_API_URL || "https://api.taskmarket.dev";
+
+/** Base chain (TaskMarket escrows USDC on Base). CAIP-2: eip155:8453. */
+export const TASKMARKET_NETWORK = "eip155:8453";
+
+/** Base USDC contract (merchant-of-record asset for TaskMarket tasks). */
+export const TASKMARKET_USDC_ASSET =
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+/** Default production create-task payment policy (pinned to TaskMarket's escrow). */
+export const TASKMARKET_PAYMENT_POLICY = {
+  resource: `${TASKMARKET_API_URL}/api/tasks`,
+  method: "POST",
+  network: TASKMARKET_NETWORK,
+  asset: TASKMARKET_USDC_ASSET,
+  maxTimeoutSeconds: 300,
+} as const;
+
+export interface TaskmarketTask {
+  id: string;
+  requester: string;
+  description: string;
+  reward: string;
+  netReward?: string;
+  escrowTxHash?: string;
+  createdAt: string;
+  expiryTime: string;
+  status: string;
+  phase?: string;
+  tags: string[];
+  mode?: string;
+  taskVisibility?: string;
+  submissionVisibility?: string;
+  submissionCount?: number;
+  platformFeeBps?: number;
+  requesterAgentId?: string;
+}
+
+export interface TaskmarketSubmission {
+  id: string;
+  taskId: string;
+  workerAddress: string;
+  workerAgentId?: string;
+  submittedAt: string;
+  rejectedAt?: string | null;
+  deliverableHash?: string;
+  submitTxHash?: string;
+  artifacts?: Array<{
+    id: string;
+    fileName: string;
+    mimeType: string;
+    sizeBytes?: number;
+    storageUri?: string;
+  }>;
+}
+
+/** Convert base-unit reward (e.g. "2000000") to human USDC (e.g. "2"). */
+export function baseUnitsToUsdc(raw: string | undefined | null): string {
+  if (!raw || !/^\d+$/.test(raw)) return "0";
+  const padded = raw.padStart(7, "0");
+  const whole = padded.slice(0, padded.length - 6) || "0";
+  const frac = padded.slice(padded.length - 6).replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : whole;
+}
+
+/** Convert human USDC (e.g. "2") to base units (e.g. "2000000"). */
+export function usdcToBaseUnits(amount: string): string {
+  if (!/^\d+(\.\d+)?$/.test(amount)) {
+    throw new Error(`Invalid USDC amount: "${amount}"`);
+  }
+  const [whole, frac = ""] = amount.split(".");
+  if (frac.length > 6) {
+    throw new Error(`USDC amount has more than 6 decimals: "${amount}"`);
+  }
+  const wholeInt = BigInt(whole || "0");
+  const fracPadded = frac.padEnd(6, "0");
+  const fracInt = fracPadded ? BigInt(fracPadded) : 0n;
+  return (wholeInt * 1000000n + fracInt).toString();
+}
+
+/**
+ * Parse a "max spend" cap string into base units, throwing on invalid input.
+ * Accepts human USDC (e.g. "5", "0.50") or an integer base-unit string when
+ * the `baseUnits` flag is set.
+ */
+export function parseMaxSpend(raw: string, baseUnits = false): bigint {
+  const value = baseUnits ? raw : usdcToBaseUnits(raw);
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`Invalid max spend: "${raw}"`);
+  }
+  return BigInt(value);
+}
+
+async function apiGet<T>(path: string, signal?: AbortSignal): Promise<T> {
+  const response = await fetch(`${TASKMARKET_API_URL}${path}`, {
+    signal,
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "Unknown error");
+    throw new Error(`TaskMarket API error ${response.status}: ${text}`);
+  }
+  const json = (await response.json()) as { data?: T } & Record<string, unknown>;
+  return (json.data ?? json) as T;
+}
+
+/**
+ * List/search tasks. Public, anonymous, read-only.
+ */
+export async function listTasks(options: {
+  status?: string;
+  phase?: string;
+  mode?: string;
+  tags?: string;
+  rewardMin?: string;
+  rewardMax?: string;
+  limit?: number;
+  signal?: AbortSignal;
+}): Promise<{ tasks: TaskmarketTask[]; hasMore: boolean; nextCursor: string | null }> {
+  const params = new URLSearchParams();
+  if (options.status) params.set("status", options.status);
+  if (options.phase) params.set("phase", options.phase);
+  if (options.mode) params.set("mode", options.mode);
+  if (options.tags) params.set("tags", options.tags);
+  if (options.rewardMin) params.set("minReward", String(Math.round(Number(options.rewardMin) * 1e6)));
+  if (options.rewardMax) params.set("maxReward", String(Math.round(Number(options.rewardMax) * 1e6)));
+  params.set("limit", String(options.limit ?? 20));
+  const result = await apiGet<{
+    tasks: TaskmarketTask[];
+    hasMore: boolean;
+    nextCursor: string | null;
+  }>(`/api/tasks?${params.toString()}`, options.signal);
+  return {
+    tasks: result.tasks ?? [],
+    hasMore: result.hasMore ?? false,
+    nextCursor: result.nextCursor ?? null,
+  };
+}
+
+/**
+ * Get a single task with its live status. Public, anonymous, read-only.
+ */
+export async function getTask(taskId: string, signal?: AbortSignal): Promise<TaskmarketTask> {
+  return apiGet<TaskmarketTask>(`/api/tasks/${taskId}`, signal);
+}
+
+/**
+ * List submissions for a task so the requester can review them for real work.
+ * Public, anonymous, read-only. Never auto-accepts or auto-rejects anything.
+ */
+export async function listSubmissions(
+  taskId: string,
+  signal?: AbortSignal
+): Promise<TaskmarketSubmission[]> {
+  const result = await apiGet<TaskmarketSubmission[] | { submissions?: TaskmarketSubmission[] }>(
+    `/api/tasks/${taskId}/submissions`,
+    signal
+  );
+  if (Array.isArray(result)) return result;
+  return (result.submissions ?? []) as TaskmarketSubmission[];
+}
+
+export interface TaskmarketStats {
+  address?: string;
+  agentId?: string;
+  completedTasks?: number;
+  ratedTasks?: number;
+  totalStars?: number;
+  averageRating?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Market/agent statistics. Anonymous read of a public stats endpoint.
+ */
+export async function getMarketStats(options: {
+  address?: string;
+  agentId?: string;
+  signal?: AbortSignal;
+}): Promise<TaskmarketStats> {
+  const params = new URLSearchParams();
+  if (options.address) params.set("address", options.address);
+  if (options.agentId) params.set("agentId", options.agentId);
+  const query = params.toString();
+  return apiGet<TaskmarketStats>(`/api/agents/stats${query ? `?${query}` : ""}`, options.signal);
+}
+
+export interface CreateTaskRequest {
+  description: string;
+  rewardUsdc: string;
+  durationHours: number;
+  tags?: string[];
+  submissionVisibility?: "public" | "reveal_all" | "winner_only" | "never";
+}
+
+export interface GatedCreateResult {
+  granted: boolean;
+  reason?: string;
+  plan?: {
+    network: string;
+    asset: string;
+    description: string;
+    rewardUsdc: string;
+    rewardBaseUnits: string;
+    durationHours: number;
+    deadlineIso: string;
+    tags: string[];
+    maxSpendUsdc: string;
+    maxSpendBaseUnits: string;
+    submissionVisibility: string;
+  };
+}
+
+/**
+ * Build and validate the exact create plan WITHOUT touching money.
+ *
+ * Returns `{ granted: false, reason }` (and never attempts payment) when:
+ *  - the confirmation token is missing or does not match the required literal;
+ *  - the reward exceeds the caller's max-spend cap;
+ *  - any field is malformed.
+ *
+ * This is the sole gate between an LLM request and the first-party TaskMarket
+ * create flow. The confirmation token must be supplied fresh by the operator
+ * for each call — it is never inferred from prompt content.
+ */
+export function prepareCreatePlan(
+  request: CreateTaskRequest,
+  opts: { confirm: string; maxSpendUsdc: string; maxSpendBaseUnits?: boolean }
+): GatedCreateResult {
+  const requiredConfirm = "APPROVE";
+  if (opts.confirm.trim() !== requiredConfirm) {
+    return {
+      granted: false,
+      reason: `Create refused: you must pass confirm="${requiredConfirm}" to explicitly authorize this task. No funds were moved.`,
+    };
+  }
+
+  const description = request.description.trim();
+  if (!description) {
+    return { granted: false, reason: "Create refused: description is required." };
+  }
+  if (description.length < 20) {
+    return {
+      granted: false,
+      reason: "Create refused: description must be at least 20 characters (show the exact task the worker will deliver).",
+    };
+  }
+
+  let rewardBaseUnits: bigint;
+  try {
+    rewardBaseUnits = BigInt(usdcToBaseUnits(request.rewardUsdc));
+  } catch {
+    return {
+      granted: false,
+      reason: `Create refused: invalid reward "${request.rewardUsdc}" (human USDC, up to 6 decimals).`,
+    };
+  }
+  if (rewardBaseUnits <= 0n) {
+    return { granted: false, reason: "Create refused: reward must be greater than 0 USDC." };
+  }
+
+  let maxSpend: bigint;
+  try {
+    maxSpend = parseMaxSpend(opts.maxSpendUsdc, opts.maxSpendBaseUnits);
+  } catch {
+    return {
+      granted: false,
+      reason: `Create refused: invalid max-spend "${opts.maxSpendUsdc}".`,
+    };
+  }
+  if (rewardBaseUnits > maxSpend) {
+    return {
+      granted: false,
+      reason:
+        `Create refused: reward ${request.rewardUsdc} USDC exceeds max-spend ` +
+        `${opts.maxSpendUsdc} USDC. Raise the cap and retry with a fresh confirm token. No funds were moved.`,
+    };
+  }
+
+  const durationHours = Number(request.durationHours);
+  if (!Number.isFinite(durationHours) || durationHours <= 0) {
+    return { granted: false, reason: "Create refused: durationHours must be a positive number." };
+  }
+
+  const tags = (request.tags ?? []).map((t) => t.trim()).filter(Boolean);
+  const submissionVisibility = request.submissionVisibility ?? "public";
+  const validVisibilities = ["public", "reveal_all", "winner_only", "never"];
+  if (!validVisibilities.includes(submissionVisibility)) {
+    return {
+      granted: false,
+      reason: `Create refused: submissionVisibility must be one of ${validVisibilities.join(", ")}.`,
+    };
+  }
+
+  return {
+    granted: true,
+    plan: {
+      network: TASKMARKET_NETWORK,
+      asset: TASKMARKET_USDC_ASSET,
+      description,
+      rewardUsdc: request.rewardUsdc,
+      rewardBaseUnits: rewardBaseUnits.toString(),
+      durationHours,
+      deadlineIso: new Date(Date.now() + durationHours * 3600_000).toISOString(),
+      tags,
+      maxSpendUsdc: opts.maxSpendUsdc,
+      maxSpendBaseUnits: maxSpend.toString(),
+      submissionVisibility,
+    },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -51,6 +51,7 @@ import { registerInboxX402Tools } from "./inbox-x402.tools.js";
 import { registerArxivResearchTools } from "./arxiv-research.tools.js";
 import { registerCompetitionTools } from "./competition.tools.js";
 import { registerEarningTools } from "./earning.tools.js";
+import { registerTaskmarketTools } from "./taskmarket.tools.js";
 import { getSkillForTool } from "./skill-mappings.js";
 
 /**
@@ -250,6 +251,9 @@ export function registerAllTools(server: McpServer): void {
 
   // Earning Opportunities (static "how to put your assets to work" menu)
   registerEarningTools(server);
+
+  // TaskMarket (onchain agent work marketplace on Base — read-only discovery + gated create)
+  registerTaskmarketTools(server);
 
   restoreRegisterTool();
 }

--- a/src/tools/taskmarket.tools.ts
+++ b/src/tools/taskmarket.tools.ts
@@ -1,0 +1,405 @@
+/**
+ * TaskMarket Tools (https://taskmarket.dev) — onchain agent work marketplace on Base.
+ *
+ * Read tools (public, anonymous, no wallet, no spend):
+ * - taskmarket_search        — list/search open tasks (filters: status, phase, mode, tags, reward)
+ * - taskmarket_get           — full task detail + live status by task ID
+ * - taskmarket_submissions   — list submissions for a task for human review (never auto-accepts)
+ * - taskmarket_stats         — public market/agent statistics
+ *
+ * Gated write tool:
+ * - taskmarket_preview_create — show the EXACT task plan (description, reward, deadline,
+ *                               deliverables, Base network, max spend) and REQUIRE an explicit
+ *                               confirmation token + max-spend cap. Refuses (moves no money) if
+ *                               either is missing. Returns the exact first-party CLI command.
+ * - taskmarket_create         — after an explicit `confirm="APPROVE"` + a max-spend cap that
+ *                               covers the reward, run the first-party TaskMarket CLI to create
+ *                               and fund the task, then return the task ID, link, and live status.
+ *
+ * SECURITY:
+ * - Create NEVER runs without an explicit confirmation token supplied fresh by the operator.
+ * - The reward must be <= the caller's max-spend cap; otherwise the create refuses.
+ * - The network is pinned to Base (eip155:8453). No blind retry of unknown-settlement payments:
+ *   if the CLI reports a task ID it is re-fetched for live status; if the create fails, the error
+ *   is surfaced and the caller is told to check `taskmarket inbox` — never silently re-submitted.
+ * - No private keys, seeds, tokens, or cookies are ever requested, stored, or logged here.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { z } from "zod";
+import { createJsonResponse, createErrorResponse } from "../utils/index.js";
+import {
+  baseUnitsToUsdc,
+  getTask,
+  getMarketStats,
+  listSubmissions,
+  listTasks,
+  prepareCreatePlan,
+  type CreateTaskRequest,
+} from "../services/taskmarket.service.js";
+
+const execFileAsync = promisify(execFile);
+
+/** TaskMarket CLI binary. Overridable for local dev / tests. */
+const TASKMARKET_CLI = process.env.TASKMARKET_CLI || "taskmarket";
+
+/** Bound the CLI create so a hung call cannot block the tool forever. */
+const CLI_TIMEOUT_MS = 120_000;
+
+const TASK_ID_SCHEMA = z
+  .string()
+  .regex(/^0x[0-9a-fA-F]{64}$/)
+  .describe("TaskMarket task ID (0x + 64 hex chars)");
+
+export function registerTaskmarketTools(server: McpServer): void {
+  // ==========================================================================
+  // Read tools — no wallet required, never spends
+  // ==========================================================================
+
+  server.registerTool(
+    "taskmarket_search",
+    {
+      description:
+        "Search open tasks on the TaskMarket agent work marketplace (Base, USDC escrow). " +
+        "Public and anonymous — no wallet or payment needed. Returns tasks with ID, reward (USDC), " +
+        "status, submission count, deadline, and a short description so you can pick work to delegate. " +
+        "Never spends anything.",
+      inputSchema: {
+        status: z.string().default("open").describe("Filter by status (default: open)"),
+        phase: z.string().optional().describe("Filter by lifecycle phase (active, in_review, awaiting_settlement, resolved)"),
+        mode: z.string().optional().describe("Filter by task mode (bounty, claim, pitch, benchmark, auction)"),
+        tags: z.string().optional().describe("Comma-separated tags to filter by (e.g. 'mcp,research')"),
+        rewardMin: z.string().optional().describe("Minimum reward in human USDC (e.g. 0.5)"),
+        rewardMax: z.string().optional().describe("Maximum reward in human USDC (e.g. 50)"),
+        limit: z.number().int().min(1).max(50).default(20).describe("Max results (1-50)"),
+      },
+    },
+    async (args) => {
+      try {
+        const result = await listTasks({
+          status: args.status as string,
+          phase: args.phase as string | undefined,
+          mode: args.mode as string | undefined,
+          tags: args.tags as string | undefined,
+          rewardMin: args.rewardMin as string | undefined,
+          rewardMax: args.rewardMax as string | undefined,
+          limit: args.limit as number,
+        });
+        return createJsonResponse({
+          success: true,
+          network: "eip155:8453",
+          taskCount: result.tasks.length,
+          hasMore: result.hasMore,
+          nextCursor: result.nextCursor,
+          tasks: result.tasks.map((t) => ({
+            id: t.id,
+            status: t.status,
+            phase: t.phase ?? null,
+            mode: t.mode ?? "bounty",
+            rewardUsdc: baseUnitsToUsdc(t.reward),
+            submissionCount: t.submissionCount ?? 0,
+            deadline: t.expiryTime,
+            tags: t.tags ?? [],
+            description: t.description.slice(0, 300),
+          })),
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "taskmarket_get",
+    {
+      description:
+        "Get full detail and LIVE status for one TaskMarket task by ID. Public and anonymous. " +
+        "Returns description, reward, deadline, escrow tx, submission count, phase, and status. " +
+        "Use this after creating or delegating a task to check whether it is open, in review, " +
+        "awaiting settlement, or resolved. Never spends anything.",
+      inputSchema: {
+        taskId: TASK_ID_SCHEMA,
+      },
+    },
+    async ({ taskId }) => {
+      try {
+        const task = await getTask(taskId as string);
+        return createJsonResponse({
+          success: true,
+          id: task.id,
+          status: task.status,
+          phase: task.phase ?? null,
+          mode: task.mode ?? "bounty",
+          rewardUsdc: baseUnitsToUsdc(task.reward),
+          netRewardUsdc: task.netReward ? baseUnitsToUsdc(task.netReward) : null,
+          escrowTxHash: task.escrowTxHash ?? null,
+          requester: task.requester,
+          submissionCount: task.submissionCount ?? 0,
+          createdAt: task.createdAt,
+          deadline: task.expiryTime,
+          tags: task.tags ?? [],
+          link: `https://taskmarket.dev/task/${task.id}`,
+          description: task.description,
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "taskmarket_submissions",
+    {
+      description:
+        "List submissions on a TaskMarket task for HUMAN REVIEW. Public and anonymous. " +
+        "Returns each submission's worker address, submission time, deliverable file name, and " +
+        "hash. This tool NEVER accepts or rejects work — it only surfaces submissions so a human " +
+        "requester can review the deliverable before authorizing any payment.",
+      inputSchema: {
+        taskId: TASK_ID_SCHEMA,
+      },
+    },
+    async ({ taskId }) => {
+      try {
+        const submissions = await listSubmissions(taskId as string);
+        return createJsonResponse({
+          success: true,
+          taskId,
+          submissionCount: submissions.length,
+          submissions: submissions.map((s) => ({
+            id: s.id,
+            workerAddress: s.workerAddress,
+            workerAgentId: s.workerAgentId ?? null,
+            submittedAt: s.submittedAt,
+            rejectedAt: s.rejectedAt ?? null,
+            deliverableHash: s.deliverableHash ?? null,
+            submitTxHash: s.submitTxHash ?? null,
+            files: (s.artifacts ?? []).map((a) => ({
+              fileName: a.fileName,
+              mimeType: a.mimeType,
+              sizeBytes: a.sizeBytes ?? null,
+            })),
+          })),
+          note: "Human review required. This tool never auto-accepts or auto-rejects submissions.",
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "taskmarket_stats",
+    {
+      description:
+        "Public TaskMarket statistics for an agent address or agent ID: completed tasks, rating, " +
+        "total stars. Anonymous read. Use to gauge whether a worker or requester is reputable " +
+        "before delegating work. Never spends anything.",
+      inputSchema: {
+        address: z.string().optional().describe("Wallet address to look up stats for"),
+        agentId: z.string().optional().describe("Agent ID to look up stats for (alternative to address)"),
+      },
+    },
+    async (args) => {
+      try {
+        const stats = await getMarketStats({
+          address: args.address as string | undefined,
+          agentId: args.agentId as string | undefined,
+        });
+        return createJsonResponse({
+          success: true,
+          stats,
+          note: "Stats are public market data. A low rating does not guarantee work quality — review deliverables yourself.",
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  // ==========================================================================
+  // Gated write tool — create a task. Requires explicit confirmation + cap.
+  // ==========================================================================
+
+  server.registerTool(
+    "taskmarket_preview_create",
+    {
+      description:
+        "Show the EXACT plan for creating a TaskMarket task (description, reward, deadline, " +
+        "deliverables, Base network, max spend) and prove the confirmation gate works BEFORE any " +
+        "money can move. Pass the task details plus confirm='APPROVE' and maxSpendUsdc. " +
+        "If the confirmation token is missing/wrong or the reward exceeds max-spend, this REFUSES " +
+        "and returns the reason — no funds are ever moved. On success it returns the plan plus the " +
+        "exact first-party CLI command that `taskmarket_create` would run.",
+      inputSchema: {
+        description: z.string().min(20).describe("Exact task description / deliverables the worker must produce (>=20 chars)"),
+        rewardUsdc: z.string().describe("Reward in human USDC (e.g. '5' or '0.50')"),
+        durationHours: z.number().positive().describe("Task duration / deadline in hours from now"),
+        tags: z.array(z.string()).optional().describe("Optional tags (e.g. ['research', 'mcp'])"),
+        submissionVisibility: z.enum(["public", "reveal_all", "winner_only", "never"]).default("public").describe("Who can see submissions"),
+        confirm: z.string().describe("Explicit operator authorization. Must equal APPROVE exactly."),
+        maxSpendUsdc: z.string().describe("Hard maximum spend in human USDC (reward must be <= this)"),
+      },
+    },
+    async (args) => {
+      try {
+        const request: CreateTaskRequest = {
+          description: args.description as string,
+          rewardUsdc: args.rewardUsdc as string,
+          durationHours: args.durationHours as number,
+          tags: (args.tags as string[] | undefined) ?? [],
+          submissionVisibility: (args.submissionVisibility as CreateTaskRequest["submissionVisibility"]) ?? "public",
+        };
+        const plan = prepareCreatePlan(request, {
+          confirm: args.confirm as string,
+          maxSpendUsdc: args.maxSpendUsdc as string,
+        });
+        if (!plan.granted) {
+          return createJsonResponse({ success: false, granted: false, reason: plan.reason });
+        }
+        const cliArgs = [
+          "task",
+          "create",
+          "--description",
+          plan.plan!.description,
+          "--reward",
+          plan.plan!.rewardUsdc,
+          "--duration",
+          String(plan.plan!.durationHours),
+        ];
+        if (plan.plan!.tags.length > 0) cliArgs.push("--tags", plan.plan!.tags.join(","));
+        cliArgs.push("--submission-visibility", plan.plan!.submissionVisibility);
+        return createJsonResponse({
+          success: true,
+          granted: true,
+          plan: plan.plan,
+          nextStep: "Run taskmarket_create with the same details + confirm='APPROVE' to execute.",
+          cliCommand: [TASKMARKET_CLI, ...cliArgs.map((a) => (a.includes(" ") ? `"${a}"` : a))].join(" "),
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "taskmarket_create",
+    {
+      description:
+        "Create and FUND a TaskMarket task on Base after explicit operator authorization. " +
+        "Show the user the plan first with taskmarket_preview_create, then run this tool with the " +
+        "SAME details plus confirm='APPROVE' and a maxSpendUsdc cap >= reward. The task is created " +
+        "through the first-party TaskMarket CLI (which escrows the reward in USDC on Base via x402). " +
+        "Returns the task ID, link, and live status. Refuses without the exact confirmation token, " +
+        "if the reward exceeds maxSpend, or if any field is invalid — no money moves in those cases. " +
+        "If the create fails mid-flight, it is NOT retried blindly; the error is returned and you " +
+        "should check `taskmarket inbox` before attempting anything again.",
+      inputSchema: {
+        description: z.string().min(20).describe("Exact task description / deliverables (>=20 chars)"),
+        rewardUsdc: z.string().describe("Reward in human USDC (escrowed from your wallet)"),
+        durationHours: z.number().positive().describe("Task duration / deadline in hours from now"),
+        tags: z.array(z.string()).optional().describe("Optional tags"),
+        submissionVisibility: z.enum(["public", "reveal_all", "winner_only", "never"]).default("public").describe("Who can see submissions"),
+        confirm: z.string().describe("Explicit operator authorization. Must equal APPROVE exactly."),
+        maxSpendUsdc: z.string().describe("Hard maximum spend cap in human USDC (reward must be <= this)"),
+      },
+    },
+    async (args) => {
+      try {
+        const request: CreateTaskRequest = {
+          description: args.description as string,
+          rewardUsdc: args.rewardUsdc as string,
+          durationHours: args.durationHours as number,
+          tags: (args.tags as string[] | undefined) ?? [],
+          submissionVisibility: (args.submissionVisibility as CreateTaskRequest["submissionVisibility"]) ?? "public",
+        };
+        const plan = prepareCreatePlan(request, {
+          confirm: args.confirm as string,
+          maxSpendUsdc: args.maxSpendUsdc as string,
+        });
+        if (!plan.granted) {
+          return createJsonResponse({ success: false, granted: false, reason: plan.reason });
+        }
+        const p = plan.plan!;
+
+        const cliArgs = [
+          "task",
+          "create",
+          "--description",
+          p.description,
+          "--reward",
+          p.rewardUsdc,
+          "--duration",
+          String(p.durationHours),
+        ];
+        if (p.tags.length > 0) cliArgs.push("--tags", p.tags.join(","));
+        cliArgs.push("--submission-visibility", p.submissionVisibility);
+
+        let stdout: string;
+        try {
+          const result = await execFileAsync(TASKMARKET_CLI, cliArgs, {
+            timeout: CLI_TIMEOUT_MS,
+            maxBuffer: 1024 * 1024,
+            env: { ...process.env },
+          });
+          stdout = result.stdout;
+        } catch (err) {
+          const e = err as { stdout?: string; stderr?: string; message?: string };
+          const detail = (e.stdout || e.stderr || e.message || "unknown").toString().slice(0, 800);
+          return createJsonResponse({
+            success: false,
+            granted: true,
+            note: "Create command failed. The settlement status is UNKNOWN — this was NOT blindly retried. Check `taskmarket inbox` / the CLI output below before deciding whether to retry.",
+            cliOutput: detail,
+          });
+        }
+
+        let taskId: string | null = null;
+        try {
+          const parsed = JSON.parse(stdout);
+          taskId = (parsed.data?.taskId ?? parsed.taskId) as string | null;
+        } catch {
+          taskId = null;
+        }
+        if (!taskId) {
+          return createJsonResponse({
+            success: false,
+            granted: true,
+            note: "Create did not return a task ID. Settlement status is UNKNOWN and was NOT retried. Inspect the CLI output and check `taskmarket inbox`.",
+            cliOutput: stdout.slice(0, 800),
+          });
+        }
+
+        // Fetch live status for the freshly created task (read-only).
+        let live: { status?: string; phase?: string; deadline?: string } | null = null;
+        try {
+          const task = await getTask(taskId);
+          live = {
+            status: task.status,
+            phase: task.phase,
+            deadline: task.expiryTime,
+          };
+        } catch {
+          live = null;
+        }
+
+        return createJsonResponse({
+          success: true,
+          granted: true,
+          taskId,
+          link: `https://taskmarket.dev/task/${taskId}`,
+          network: p.network,
+          asset: p.asset,
+          rewardUsdc: p.rewardUsdc,
+          deadlineIso: p.deadlineIso,
+          liveStatus: live ?? "pending confirmation — re-run taskmarket_get to poll",
+          note: "Submissions must be reviewed by a human. Use taskmarket_submissions to list them; this tool never auto-accepts work.",
+        });
+      } catch (error) {
+        return createErrorResponse(error);
+      }
+    }
+  );
+}

--- a/tests/services/taskmarket.test.ts
+++ b/tests/services/taskmarket.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Hermetic unit tests for the TaskMarket service: the read-only API client and
+ * the gated create-plan logic. No network access, no wallet, no real spend.
+ */
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import {
+  baseUnitsToUsdc,
+  usdcToBaseUnits,
+  parseMaxSpend,
+  prepareCreatePlan,
+  listTasks,
+  getTask,
+  listSubmissions,
+  getMarketStats,
+  TASKMARKET_NETWORK,
+  TASKMARKET_USDC_ASSET,
+} from "../../src/services/taskmarket.service.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("usdc unit conversion", () => {
+  it("converts base units to human USDC", () => {
+    expect(baseUnitsToUsdc("2000000")).toBe("2");
+    expect(baseUnitsToUsdc("500000")).toBe("0.5");
+    expect(baseUnitsToUsdc("1")).toBe("0.000001");
+    expect(baseUnitsToUsdc("0")).toBe("0");
+    expect(baseUnitsToUsdc(null)).toBe("0");
+  });
+
+  it("converts human USDC to base units", () => {
+    expect(usdcToBaseUnits("2")).toBe("2000000");
+    expect(usdcToBaseUnits("0.5")).toBe("500000");
+    expect(usdcToBaseUnits("0.000001")).toBe("1");
+  });
+
+  it("rejects malformed USDC amounts", () => {
+    expect(() => usdcToBaseUnits("abc")).toThrow();
+    expect(() => usdcToBaseUnits("1.0000001")).toThrow();
+  });
+
+  it("parses max-spend caps", () => {
+    expect(parseMaxSpend("5")).toBe(5000000n);
+    expect(parseMaxSpend("0.50")).toBe(500000n);
+    expect(parseMaxSpend("2000000", true)).toBe(2000000n);
+  });
+});
+
+describe("prepareCreatePlan — the create gate", () => {
+  const base = {
+    description: "Write a short research brief on Base USDC adoption for AI agents.",
+    rewardUsdc: "2",
+    durationHours: 24,
+    tags: ["research"],
+    submissionVisibility: "public" as const,
+  };
+
+  it("grants a valid plan and pins Base network + USDC asset", () => {
+    const result = prepareCreatePlan(base, { confirm: "APPROVE", maxSpendUsdc: "5" });
+    expect(result.granted).toBe(true);
+    expect(result.plan).toBeDefined();
+    expect(result.plan!.network).toBe(TASKMARKET_NETWORK);
+    expect(result.plan!.asset).toBe(TASKMARKET_USDC_ASSET);
+    expect(result.plan!.rewardBaseUnits).toBe("2000000");
+    expect(result.plan!.rewardUsdc).toBe("2");
+    expect(result.plan!.maxSpendUsdc).toBe("5");
+    expect(result.plan!.durationHours).toBe(24);
+    expect(result.plan!.tags).toEqual(["research"]);
+    expect(new Date(result.plan!.deadlineIso).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("REFUSES without the explicit confirmation token (no money moves)", () => {
+    const result = prepareCreatePlan(base, { confirm: "", maxSpendUsdc: "5" });
+    expect(result.granted).toBe(false);
+    expect(result.reason).toContain("APPROVE");
+    expect(result.reason).toContain("No funds were moved");
+  });
+
+  it("REFUSES a wrong confirmation token", () => {
+    const result = prepareCreatePlan(base, { confirm: "yes", maxSpendUsdc: "5" });
+    expect(result.granted).toBe(false);
+  });
+
+  it("REFUSES when reward exceeds max-spend cap", () => {
+    const result = prepareCreatePlan(base, { confirm: "APPROVE", maxSpendUsdc: "1" });
+    expect(result.granted).toBe(false);
+    expect(result.reason).toContain("exceeds max-spend");
+    expect(result.reason).toContain("No funds were moved");
+  });
+
+  it("REFUSES a zero reward", () => {
+    const result = prepareCreatePlan(
+      { ...base, rewardUsdc: "0" },
+      { confirm: "APPROVE", maxSpendUsdc: "5" }
+    );
+    expect(result.granted).toBe(false);
+    expect(result.reason).toContain("greater than 0");
+  });
+
+  it("REFUSES a too-short description (deliverables must be explicit)", () => {
+    const result = prepareCreatePlan(
+      { ...base, description: "short" },
+      { confirm: "APPROVE", maxSpendUsdc: "5" }
+    );
+    expect(result.granted).toBe(false);
+    expect(result.reason).toContain("at least 20 characters");
+  });
+
+  it("REFUSES an invalid reward string", () => {
+    const result = prepareCreatePlan(
+      { ...base, rewardUsdc: "not-a-number" },
+      { confirm: "APPROVE", maxSpendUsdc: "5" }
+    );
+    expect(result.granted).toBe(false);
+  });
+
+  it("REFUSES an invalid max-spend", () => {
+    const result = prepareCreatePlan(base, { confirm: "APPROVE", maxSpendUsdc: "oops" });
+    expect(result.granted).toBe(false);
+  });
+
+  it("REFUSES a non-positive duration", () => {
+    const result = prepareCreatePlan(
+      { ...base, durationHours: 0 },
+      { confirm: "APPROVE", maxSpendUsdc: "5" }
+    );
+    expect(result.granted).toBe(false);
+  });
+
+  it("REFUSES an invalid submission visibility", () => {
+    const result = prepareCreatePlan(
+      { ...base, submissionVisibility: "secret" as "public" },
+      { confirm: "APPROVE", maxSpendUsdc: "5" }
+    );
+    expect(result.granted).toBe(false);
+  });
+
+  it("supports base-unit max-spend (for tool callers holding raw values)", () => {
+    const result = prepareCreatePlan(base, {
+      confirm: "APPROVE",
+      maxSpendUsdc: "5000000",
+      maxSpendBaseUnits: true,
+    });
+    expect(result.granted).toBe(true);
+    expect(result.plan!.maxSpendBaseUnits).toBe("5000000");
+  });
+});
+
+describe("TaskMarket read-only API client", () => {
+  it("listTasks maps the public API response", async () => {
+    const tasks = [
+      {
+        id: "0x1234",
+        reward: "2000000",
+        status: "open",
+        phase: "active",
+        expiryTime: "2026-08-20T00:00:00Z",
+        tags: ["mcp"],
+        description: "A task",
+      },
+    ];
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ tasks, hasMore: false, nextCursor: null }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await listTasks({ status: "open", limit: 20 });
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].id).toBe("0x1234");
+    expect(result.tasks[0].reward).toBe("2000000");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = String(mockFetch.mock.calls[0][0]);
+    expect(url).toContain("/api/tasks?");
+    expect(url).toContain("status=open");
+  });
+
+  it("getTask fetches a single task", async () => {
+    const task = { id: "0xabc", status: "open", reward: "1000000", description: "hi" };
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(task), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", mockFetch);
+    const result = await getTask("0xabc");
+    expect(result.id).toBe("0xabc");
+    expect(String(mockFetch.mock.calls[0][0])).toContain("/api/tasks/0xabc");
+  });
+
+  it("listSubmissions returns an array (or the wrapped submissions field)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { id: "sub-1", workerAddress: "0x1", submittedAt: "2026-08-01T00:00:00Z" },
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+    vi.stubGlobal("fetch", mockFetch);
+    const result = await listSubmissions("0xabc");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("sub-1");
+  });
+
+  it("surfaces API errors instead of swallowing them", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response("boom", { status: 500 })
+    );
+    vi.stubGlobal("fetch", mockFetch);
+    await expect(getTask("0xabc")).rejects.toThrow(/TaskMarket API error 500/);
+  });
+
+  it("getMarketStats passes address query param", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ completedTasks: 3, averageRating: "4.5" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", mockFetch);
+    const result = await getMarketStats({ address: "0xSOME" });
+    expect(result.completedTasks).toBe(3);
+    expect(String(mockFetch.mock.calls[0][0])).toContain("address=0xSOME");
+  });
+});

--- a/tests/tools/taskmarket.test.ts
+++ b/tests/tools/taskmarket.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Hermetic tool tests for the TaskMarket MCP tools. No network, no wallet, no
+ * real spend. Mocks fetch for the read-only API and the first-party CLI for the
+ * gated create path.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the first-party CLI binary so the create path is hermetic.
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  const mockExecFile = vi.fn();
+  return { ...actual, execFile: mockExecFile };
+});
+import { execFile } from "child_process";
+const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+
+const { registerTaskmarketTools } = await import(
+  "../../src/tools/taskmarket.tools.js"
+);
+
+interface RegisteredTool {
+  handler: (args: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+function createTrackingServer() {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    registerTool: vi.fn(
+      (
+        name: string,
+        _config: { description: string; inputSchema: unknown },
+        handler: RegisteredTool["handler"]
+      ) => {
+        tools.set(name, { handler });
+      }
+    ),
+  };
+  return { server, tools };
+}
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  const status = init.status ?? 200;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function parseResult(res: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(res.content[0].text);
+}
+
+const VALID_TASK_ID = "0x" + "ab".repeat(32);
+
+describe("taskmarket tools", () => {
+  let server: ReturnType<typeof createTrackingServer>["server"];
+  let tools: ReturnType<typeof createTrackingServer>["tools"];
+
+  beforeEach(() => {
+    mockExecFile.mockReset();
+    const tracking = createTrackingServer();
+    server = tracking.server;
+    tools = tracking.tools;
+    registerTaskmarketTools(server as never);
+  });
+
+  it("registers all six taskmarket tools without throwing", () => {
+    expect(tools.has("taskmarket_search")).toBe(true);
+    expect(tools.has("taskmarket_get")).toBe(true);
+    expect(tools.has("taskmarket_submissions")).toBe(true);
+    expect(tools.has("taskmarket_stats")).toBe(true);
+    expect(tools.has("taskmarket_preview_create")).toBe(true);
+    expect(tools.has("taskmarket_create")).toBe(true);
+  });
+
+  it("taskmarket_search returns mapped tasks from the public API", async () => {
+    const task = {
+      id: VALID_TASK_ID,
+      reward: "2000000",
+      status: "open",
+      phase: "active",
+      expiryTime: "2026-08-20T00:00:00Z",
+      tags: ["mcp"],
+      description: "A research task",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ tasks: [task], hasMore: false, nextCursor: null }))
+    );
+    const res = await tools.get("taskmarket_search")!.handler({
+      status: "open",
+      limit: 20,
+    });
+    const body = parseResult(res) as { success: boolean; taskCount: number; tasks: Array<{ rewardUsdc: string }> };
+    expect(body.success).toBe(true);
+    expect(body.taskCount).toBe(1);
+    expect(body.tasks[0].rewardUsdc).toBe("2");
+    vi.unstubAllGlobals();
+  });
+
+  it("taskmarket_get returns live status and link", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          id: VALID_TASK_ID,
+          status: "open",
+          phase: "active",
+          reward: "1000000",
+          expiryTime: "2026-08-20T00:00:00Z",
+          description: "task",
+        })
+      )
+    );
+    const res = await tools.get("taskmarket_get")!.handler({ taskId: VALID_TASK_ID });
+    const body = parseResult(res) as { success: boolean; link: string };
+    expect(body.success).toBe(true);
+    expect(body.link).toContain(VALID_TASK_ID);
+    vi.unstubAllGlobals();
+  });
+
+  it("taskmarket_submissions surfaces work for human review and never auto-accepts", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse([
+          { id: "sub-1", workerAddress: "0x1", submittedAt: "2026-08-01T00:00:00Z" },
+        ])
+      )
+    );
+    const res = await tools.get("taskmarket_submissions")!.handler({ taskId: VALID_TASK_ID });
+    const body = parseResult(res) as { success: boolean; submissionCount: number; note: string };
+    expect(body.success).toBe(true);
+    expect(body.submissionCount).toBe(1);
+    expect(body.note).toContain("never auto-accepts");
+    expect(body.note).toContain("Human review required");
+    vi.unstubAllGlobals();
+  });
+
+  it("taskmarket_preview_create REFUSES without the confirmation token", async () => {
+    const res = await tools.get("taskmarket_preview_create")!.handler({
+      description: "Write a short research brief on Base USDC adoption for AI agents.",
+      rewardUsdc: "2",
+      durationHours: 24,
+      confirm: "",
+      maxSpendUsdc: "5",
+    });
+    const body = parseResult(res) as { success: boolean; granted: boolean; reason: string };
+    expect(body.success).toBe(false);
+    expect(body.granted).toBe(false);
+    expect(body.reason).toContain("APPROVE");
+    expect(body.reason).toContain("No funds were moved");
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("taskmarket_preview_create REFUSES when reward exceeds max-spend", async () => {
+    const res = await tools.get("taskmarket_preview_create")!.handler({
+      description: "Write a short research brief on Base USDC adoption for AI agents.",
+      rewardUsdc: "10",
+      durationHours: 24,
+      confirm: "APPROVE",
+      maxSpendUsdc: "5",
+    });
+    const body = parseResult(res) as { success: boolean; granted: boolean; reason: string };
+    expect(body.granted).toBe(false);
+    expect(body.reason).toContain("exceeds max-spend");
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("taskmarket_preview_create shows the exact plan on approval", async () => {
+    const res = await tools.get("taskmarket_preview_create")!.handler({
+      description: "Write a short research brief on Base USDC adoption for AI agents.",
+      rewardUsdc: "2",
+      durationHours: 24,
+      tags: ["research"],
+      confirm: "APPROVE",
+      maxSpendUsdc: "5",
+    });
+    const body = parseResult(res) as {
+      success: boolean;
+      granted: boolean;
+      plan: { network: string; rewardUsdc: string; maxSpendUsdc: string; deadlineIso: string; tags: string[] };
+      cliCommand: string;
+    };
+    expect(body.success).toBe(true);
+    expect(body.granted).toBe(true);
+    expect(body.plan.network).toBe("eip155:8453");
+    expect(body.plan.rewardUsdc).toBe("2");
+    expect(body.plan.maxSpendUsdc).toBe("5");
+    expect(body.plan.tags).toEqual(["research"]);
+    expect(body.cliCommand).toContain("task create");
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("taskmarket_create runs the CLI only after the gate passes and returns taskId + live status", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, res: { stdout: string; stderr: string }) => void) => {
+        cb(null, {
+          stdout: JSON.stringify({ ok: true, data: { taskId: VALID_TASK_ID } }),
+          stderr: "",
+        });
+      }
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          id: VALID_TASK_ID,
+          status: "open",
+          phase: "active",
+          reward: "2000000",
+          expiryTime: "2026-08-20T00:00:00Z",
+          description: "task",
+        })
+      )
+    );
+    const res = await tools.get("taskmarket_create")!.handler({
+      description: "Write a short research brief on Base USDC adoption for AI agents.",
+      rewardUsdc: "2",
+      durationHours: 24,
+      confirm: "APPROVE",
+      maxSpendUsdc: "5",
+    });
+    const body = parseResult(res) as { success: boolean; taskId: string; liveStatus: { status: string } };
+    expect(body.success).toBe(true);
+    expect(body.taskId).toBe(VALID_TASK_ID);
+    expect(body.liveStatus.status).toBe("open");
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    const cliArgs = mockExecFile.mock.calls[0][1] as string[];
+    expect(cliArgs[0]).toBe("task");
+    expect(cliArgs[1]).toBe("create");
+    vi.unstubAllGlobals();
+  });
+
+  it("taskmarket_create REFUSES (no CLI call) without explicit confirmation", async () => {
+    const res = await tools.get("taskmarket_create")!.handler({
+      description: "Write a short research brief on Base USDC adoption for AI agents.",
+      rewardUsdc: "2",
+      durationHours: 24,
+      confirm: "nope",
+      maxSpendUsdc: "5",
+    });
+    const body = parseResult(res) as { success: boolean; granted: boolean; reason: string };
+    expect(body.success).toBe(false);
+    expect(body.granted).toBe(false);
+    expect(body.reason).toContain("APPROVE");
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("taskmarket_create does NOT blindly retry when the CLI fails with unknown settlement", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, res: { stdout: string; stderr: string }) => void) => {
+        cb(new Error("settlement timed out"), { stdout: "", stderr: "" });
+      }
+    );
+    const res = await tools.get("taskmarket_create")!.handler({
+      description: "Write a short research brief on Base USDC adoption for AI agents.",
+      rewardUsdc: "2",
+      durationHours: 24,
+      confirm: "APPROVE",
+      maxSpendUsdc: "5",
+    });
+    const body = parseResult(res) as { success: boolean; note: string };
+    expect(body.success).toBe(false);
+    expect(body.note).toContain("NOT blindly retried");
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("taskmarket_create does NOT blindly retry when the CLI returns no task ID", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, res: { stdout: string; stderr: string }) => void) => {
+        cb(null, { stdout: JSON.stringify({ ok: true }), stderr: "" });
+      }
+    );
+    const res = await tools.get("taskmarket_create")!.handler({
+      description: "Write a short research brief on Base USDC adoption for AI agents.",
+      rewardUsdc: "2",
+      durationHours: 24,
+      confirm: "APPROVE",
+      maxSpendUsdc: "5",
+    });
+    const body = parseResult(res) as { success: boolean; note: string };
+    expect(body.success).toBe(false);
+    expect(body.note).toContain("NOT retried");
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a [TaskMarket](https://taskmarket.dev) integration to the MCP server. TaskMarket is an onchain agent work marketplace on Base: requesters escrow USDC, workers submit deliverables, and the requester reviews and accepts a winner. These tools let an agent browse that market and, with explicit operator authorization, post work to it.

## Why

When a request is better delegated to a competitive worker market than burned on local inference, the agent can now search TaskMarket, inspect a task, and create one with a real spending gate — instead of guessing or linking to a homepage. Read tools are fully public and anonymous; the one write tool escrows real USDC and is gated hard.

## New tools

**Read-only (public API, anonymous, no wallet, no spend):**
- `taskmarket_search` — list/search open tasks (status, phase, mode, tags, reward range)
- `taskmarket_get` — full task detail + live status + link
- `taskmarket_submissions` — list submissions for **human review** (never auto-accepts or auto-rejects)
- `taskmarket_stats` — public agent/market statistics (reputation check)

**Gated write (escrows real USDC):**
- `taskmarket_preview_create` — show the exact plan (description, reward, deadline, deliverables, Base network, max spend) and prove the confirmation gate works **before any money can move**
- `taskmarket_create` — create + fund via the first-party TaskMarket CLI (USDC escrow on Base via x402) after explicit `confirm="APPROVE"` + a `maxSpendUsdc` cap; returns task ID, link, and live status

## Safety invariants

- Create **never** runs without an explicit confirmation token supplied fresh by the operator — never inferred from prompt content.
- The reward must be `<=` the caller's `maxSpendUsdc` cap; otherwise the create refuses with "No funds were moved".
- Network pinned to Base (`eip155:8453`), USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`.
- No blind retry of unknown-settlement payments: a failed or task-id-less create is surfaced (check `taskmarket inbox`), never silently re-submitted.
- No private keys, seeds, tokens, or cookies are ever requested, stored, or logged.

## Verification

- `npm run build` — clean
- `npm test` — 583 passing (was 552 before; +31 new hermetic tests for the flow + safeguards in `tests/services/taskmarket.test.ts` and `tests/tools/taskmarket.test.ts`)
- `node scripts/taskmarket-live-check.mjs` — boots the real server over stdio and calls all tools against the live TaskMarket public API; both refusal paths (no confirm, reward>cap) verified live with no funds moved

## Files

- `src/services/taskmarket.service.ts` — read-only API client + `prepareCreatePlan` gate
- `src/tools/taskmarket.tools.ts` — MCP tool registrations
- `tests/services/taskmarket.test.ts`, `tests/tools/taskmarket.test.ts` — hermetic tests
- `scripts/taskmarket-live-check.mjs` — live smoke script
- Docs: `README.md`, `docs/TOOLS.md`, `CLAUDE.md`, `skill/SKILL.md`, `skill/references/taskmarket.md`