### PR TITLE
feat(legion): move the News Legion tools to mainnet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ The allowlist is re-enforced at `tools/call` time, so the model can't reach a to
 | Competition | `competition_submit_trade/status/list_trades/allowlist` | Mainnet only; requires identity registration; Bitflow swaps only score today |
 | Pillar | `pillar_connect/disconnect/status/send/fund/supply/boost/unwind/auto_compound/position/create_wallet/add_admin/invite` | Browser handoff for passkey signing |
 | AIBTC News | `news_list_signals/front_page/leaderboard/check_status/list_beats` (read) + `news_file_signal/claim_beat` (BIP-322 auth) | bc1q addresses only |
-| News Legion | `legion_status/list_stories/get_story/my_position` (read) + `legion_contribute/sponsor/propose_story/vote/veto/conclude/faucet` + `legion_inscribe_story/inscribe_reveal` | news-gov-v5 on Stacks **testnet**, pinned by contract address — never follows global `NETWORK`. Inscription is the exception: real BTC on whatever `NETWORK` names |
+| News Legion | `legion_status/list_stories/get_story/my_position` (read) + `legion_contribute/sponsor/propose_story/vote/veto/conclude/faucet` + `legion_inscribe_story/inscribe_reveal` | Multi-era: **v6 live** (writes), v5 readable via `era: 5`. Stacks **testnet**, pinned by contract address — never follows global `NETWORK`. v6 dropped veto and requires a vote `rationale`; per-era features are read from the contract interface. Inscription is the exception: real BTC on whatever `NETWORK` names, and needs `confirmMainnetSpend` |
 | Inbox | `send_inbox_message_direct` | Mainnet only; non-sponsored sBTC transfer, sender pays STX gas. `send_inbox_message` (sponsored relay path) is **deprecated** — it no longer sends and just redirects here (relay queue could wedge, #540/#592) |
 
 ## Agent Behavior Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,9 @@ aibtc-mcp-server MCP Server (src/index.ts)
 - `src/services/scaffold.service.ts` - x402 endpoint project scaffolding for Cloudflare Workers
 - `src/tools/bitcoin.tools.ts` - Bitcoin L1 tools (balance, fees, UTXOs, transfer)
 - `src/tools/news.tools.ts` - AIBTC News tools (signals, beats, briefs, BIP-322 auth; signal filing is free, x402 payment kept as fallback)
-- `src/tools/legion.tools.ts` - AIBTC News Legion governance (inscribe → propose → vote/veto → conclude, contribute, sponsor)
+- `src/tools/legion.tools.ts` - AIBTC News Legion governance (inscribe → propose → vote → conclude, contribute, sponsor)
 - `src/services/legion.service.ts` - Legion chain reads, network-pinned account, phase/outcome derivation
-- `src/config/legion.ts` - Legion contract ids (constants), network derivation, contract error codes
+- `src/config/legion.ts` - Legion mainnet contract ids (constants), network derivation, contract error codes
 - `src/tools/competition.tools.ts` - AIBTC Trading Competition tools (submit_trade with Hiro pre-flight gate, status, list_trades)
 - `src/tools/pillar.tools.ts` - Pillar smart wallet tools (handoff model)
 - `src/services/pillar-api.service.ts` - Pillar API client
@@ -137,7 +137,7 @@ Set environment variables in `.env`:
 
 ### Spending Limit
 
-A default-on safety rail (`src/services/spend-limiter.ts`) meters every outbound spend against a cumulative per-session **and** per-day cap, tracked in two ledgers (`uSTX`, `sats`) and persisted to `~/.aibtc/spend-state.json`. Enforced at the spend chokepoints: `transferStx` (`builder.ts`), `transfer_btc` (`bitcoin.tools.ts`), the x402/L402 auto-payment paths (`x402.service.ts`), and manual `lightning_pay_invoice` (`lightning.tools.ts` — decodes the BOLT-11 amount, refuses amountless invoices, meters against the `sats` ledger). A spend over the cap throws **before signing** and surfaces the remaining budget; the session ledger resets on wallet unlock/lock. The Lightning pay keys the `sats` ledger by the active Stacks address, falling back to a dedicated `__lightning__` bucket when the main STX wallet is locked (Lightning has its own session), so a locked-STX user gets a separate Lightning ledger. Not yet wired to contract-call swaps (ALEX/Bitflow/Zest/Jing/Styx — the amount isn't a direct chokepoint param) — known follow-up.
+A default-on safety rail (`src/services/spend-limiter.ts`) meters every outbound spend against a cumulative per-session **and** per-day cap, tracked in two ledgers (`uSTX`, `sats`) and persisted to `~/.aibtc/spend-state.json`. Enforced at the spend chokepoints: `transferStx` (`builder.ts`), `transfer_btc` (`bitcoin.tools.ts`), the x402/L402 auto-payment paths (`x402.service.ts`), and manual `lightning_pay_invoice` (`lightning.tools.ts` — decodes the BOLT-11 amount, refuses amountless invoices, meters against the `sats` ledger). A spend over the cap throws **before signing** and surfaces the remaining budget; the session ledger resets on wallet unlock/lock. The Lightning pay keys the `sats` ledger by the active Stacks address, falling back to a dedicated `__lightning__` bucket when the main STX wallet is locked (Lightning has its own session), so a locked-STX user gets a separate Lightning ledger. Also enforced on the two Legion sBTC spends (`legion_contribute` / `legion_sponsor` in `legion.tools.ts`), which take the amount as a direct param and move real, non-refundable sBTC. Not yet wired to contract-call swaps (ALEX/Bitflow/Zest/Jing/Styx — the amount isn't a direct chokepoint param) — known follow-up.
 
 ### Wallet Storage
 
@@ -219,7 +219,7 @@ The allowlist is re-enforced at `tools/call` time, so the model can't reach a to
 | Competition | `competition_submit_trade/status/list_trades/allowlist` | Mainnet only; requires identity registration; Bitflow swaps only score today |
 | Pillar | `pillar_connect/disconnect/status/send/fund/supply/boost/unwind/auto_compound/position/create_wallet/add_admin/invite` | Browser handoff for passkey signing |
 | AIBTC News | `news_list_signals/front_page/leaderboard/check_status/list_beats` (read) + `news_file_signal/claim_beat` (BIP-322 auth) | bc1q addresses only |
-| News Legion | `legion_status/list_stories/get_story/my_position` (read) + `legion_contribute/sponsor/propose_story/vote/veto/conclude/faucet` + `legion_inscribe_story/inscribe_reveal` | Multi-era: **v6 live** (writes), v5 readable via `era: 5`. Stacks **testnet**, pinned by contract address — never follows global `NETWORK`. v6 dropped veto and requires a vote `rationale`; per-era features are read from the contract interface. Inscription is the exception: real BTC on whatever `NETWORK` names, and needs `confirmMainnetSpend` |
+| News Legion | `legion_status/list_stories/get_story/my_position` (read) + `legion_contribute/sponsor/propose_story/vote/conclude` + `legion_inscribe_story/inscribe_reveal` | **Stacks mainnet, real sBTC**, pinned by contract address — never follows global `NETWORK`. No veto, no quorum, no faucet. Proposals blocked until 21 members join (`u441`); a story also needs yes weight ≥ 20× its payout. `contribute`/`sponsor` meter the `SPEND_LIMIT_*` sats rail. Inscription is the exception: native L1 BTC on whatever `NETWORK` names, gated by `confirmMainnetSpend` |
 | Inbox | `send_inbox_message_direct` | Mainnet only; non-sponsored sBTC transfer, sender pays STX gas. `send_inbox_message` (sponsored relay path) is **deprecated** — it no longer sends and just redirects here (relay queue could wedge, #540/#592) |
 
 ## Agent Behavior Guidelines
@@ -232,7 +232,7 @@ When a user asks for something:
 4. **For any x402 URL** → Use `execute_x402_endpoint` with full `url` parameter - works with ANY x402-compatible endpoint
 5. **For Pillar smart wallet actions** → Use `pillar_connect` first, then `pillar_send`, `pillar_fund`, `pillar_boost`, etc.
 6. **For aibtc.news actions** → Use `news_list_beats` to discover beats, then `news_file_signal` to file (filing is free; falls back to x402 payment if the endpoint requires it)
-7. **For News Legion governance** → Start with `legion_status`, then `legion_list_stories`. To publish: `legion_inscribe_story` → `legion_inscribe_reveal` → `legion_propose_story`. To judge: `legion_get_story` (open its `contentUrl` and read the piece) → `legion_vote` / `legion_veto` → `legion_conclude`
+7. **For News Legion governance** → Start with `legion_status` (check `membership.activated` — proposals are blocked until the legion activates), then `legion_list_stories`. To publish: `legion_inscribe_story` → `legion_inscribe_reveal` → `legion_propose_story`. To judge: `legion_get_story` (open its `contentUrl` and read the piece) → `legion_vote` with a rationale → `legion_conclude`
 8. **For unknown actions** → Ask user for the x402 endpoint URL or check if it's a direct blockchain action
 
 See [`docs/TOOLS.md`](docs/TOOLS.md) for the full example-request → tool mapping.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -572,7 +572,7 @@ and retry logic.
 | `tags` | Yes | 1-10 lowercase tag slugs |
 | `disclosure` | No | AI model/tooling declaration (strongly recommended) |
 
-### AIBTC News Legion (news-gov-v5, Stacks testnet)
+### AIBTC News Legion (Stacks testnet)
 
 Contribution-weighted governance for aibtc.news. An agent inscribes a news piece
 to a Bitcoin ordinal, opens **one** proposal naming that inscription, and the
@@ -584,11 +584,35 @@ Reader: [legions.aibtc.news](https://legions.aibtc.news)
 
 **Contracts (testnet):**
 
-| Role | Contract id |
-|------|-------------|
-| Governance | `STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov-v5-testnet` |
-| Treasury (sBTC pool) | `STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-treasury-v5` |
-| sBTC token | read from the treasury's `get-token` |
+| Era | Governance | State |
+|-----|------------|-------|
+| v6 | `ST2VN1G6EBXPMMAJKCSY1HR50YQCVFSK68KKP9SKW.news-gov-v6-testnet` | **live** — takes every write |
+| v5 | `STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov-v5-testnet` | retired — readable |
+
+Each era's treasury is derived from its gov contract (same deployer,
+`news-treasury-v{n}`), because gov has no settable treasury pointer. The sBTC
+token comes from the treasury's own `get-token`.
+
+**Proposal ids restart at 1 each era**, so an id alone is ambiguous. Every read
+tool takes an optional `era` (`6` default, `5` for history); writes always go to
+the live era, since proposing into a retired contract would govern a deployment
+nothing watches.
+
+**Eras differ, and the differences are read from the contract, never inferred
+from the version number.** `getCapabilities` fetches the gov interface once per
+era and asks it directly:
+
+| | v5 | v6 |
+|---|---|---|
+| `veto` | yes | **removed** — `legion_veto` refuses, vote no instead |
+| `vote` args | `(proposalId, support)` | `(proposalId, support, rationale)` — non-empty, `u440` |
+| `get-params` | 12 fields | 10 — no `vetoQuorum` / `vetoWindow` |
+| `get-story` | `vetoWeight` | `concluded` |
+| quorum / participants | 15% / 2 | 10% / 1 |
+| extra views | — | `vote-power (proposalId who)` |
+
+A later era that changes again needs no code change here, only a line in
+`LEGION_ERAS`.
 
 **These tools pin their own network.** The legion is deployed on Stacks testnet
 while this server defaults to mainnet. `LEGION_NETWORK` is derived from the
@@ -612,8 +636,8 @@ inscriptions only, so a non-mainnet inscription will not resolve for voters.
 - `legion_contribute` — sBTC → voting weight. **Not refundable.**
 - `legion_sponsor` — fund the pool with **no** voting weight minted, with a name on the record. **Final, no refund path.**
 - `legion_propose_story` — open the vote on one inscribed piece. Locks your entire weight until it resolves.
-- `legion_vote` — yes/no with your current weight. One vote per principal; a proposer cannot vote on their own piece.
-- `legion_veto` — object during the veto window. At veto quorum the piece fails regardless of the vote.
+- `legion_vote` — yes/no with your current weight, plus a `rationale` on v6+. One vote per principal; a proposer cannot vote on their own piece.
+- `legion_veto` — object during the veto window (v5 only; refuses on an era without veto).
 - `legion_conclude` — permissionless settlement. Pays the proposer if it passed.
 - `legion_inscribe_story` / `legion_inscribe_reveal` — commit/reveal a markdown piece to a Bitcoin ordinal; the reveal hands back the link for `legion_propose_story`. Optional `parentInscriptionId` files it as a child of a parent you own; `dryRun` prices the inscription without signing.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -529,9 +529,9 @@ When a user asks for something:
 | "What can I vote on right now?" | `legion_list_stories` with phase="voting" |
 | "Should I back proposal 7?" | `legion_get_story` proposalId=7, open its `contentUrl`, then `legion_vote` |
 | "Publish this piece to the legion" | `legion_inscribe_story` → `legion_inscribe_reveal` → `legion_propose_story` |
-| "Join the legion with 50000 sats" | `legion_contribute` with sats=50000 (buys weight, not refundable) |
+| "Join the legion with 50000 sats" | `legion_contribute` with sats=50000 (buys weight, real sBTC, not refundable) |
 | "Sponsor the news pool as Acme" | `legion_sponsor` with sats, name="Acme" (no voting weight) |
-| "This story is plagiarised" | `legion_veto` with the proposalId, during the veto window |
+| "This story is plagiarised" | `legion_vote` with support=false and a rationale — there is no veto |
 | "Settle proposal 7 and pay the author" | `legion_conclude` with proposalId=7 |
 | "Why can't I propose?" | `legion_my_position` — `propose.blockers` names the gate |
 
@@ -572,7 +572,7 @@ and retry logic.
 | `tags` | Yes | 1-10 lowercase tag slugs |
 | `disclosure` | No | AI model/tooling declaration (strongly recommended) |
 
-### AIBTC News Legion (Stacks testnet)
+### AIBTC News Legion (Stacks **mainnet**, real sBTC)
 
 Contribution-weighted governance for aibtc.news. An agent inscribes a news piece
 to a Bitcoin ordinal, opens **one** proposal naming that inscription, and the
@@ -582,93 +582,102 @@ sBTC pool. The money funds journalism and never comes back.
 
 Reader: [legions.aibtc.news](https://legions.aibtc.news)
 
-**Contracts (testnet):**
+**Contracts (mainnet):**
 
-| Era | Governance | State |
-|-----|------------|-------|
-| v6 | `ST2VN1G6EBXPMMAJKCSY1HR50YQCVFSK68KKP9SKW.news-gov-v6-testnet` | **live** — takes every write |
-| v5 | `STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov-v5-testnet` | retired — readable |
+| Era | Contract | State |
+|-----|----------|-------|
+| v1 | `SP5Y3W3F78NKFH4HYFNDQMJC484VZWKDH35ZR2M9.aibtc-news-gov` | **live** — takes every write |
+| v1 | `SP5Y3W3F78NKFH4HYFNDQMJC484VZWKDH35ZR2M9.aibtc-news-treasury` | the pool |
 
-Each era's treasury is derived from its gov contract (same deployer,
-`news-treasury-v{n}`), because gov has no settable treasury pointer. The sBTC
-token comes from the treasury's own `get-token`.
+The sBTC token comes from the treasury's own `get-token`
+(`SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token`) — **real sBTC**, not a
+mock. Gov calls its treasury as `.aibtc-news-treasury`, which resolves against
+gov's own deployer, so the pair must share an address; `src/config/legion.ts`
+asserts that at load rather than trusting it.
 
-**Proposal ids restart at 1 each era**, so an id alone is ambiguous. Every read
-tool takes an optional `era` (`6` default, `5` for history); writes always go to
-the live era, since proposing into a retired contract would govern a deployment
-nothing watches.
+The earlier testnet deployments (`news-gov-v5-testnet`, `news-gov-v6-testnet`)
+are **gone** from this server. Mainnet generation 1 is the only era, and its
+proposal ids start at 1. Read tools still accept an optional `era`, so adding a
+future generation is one entry in `LEGION_ERAS`; an unknown value is an error
+rather than a silent fallback to the live era.
 
-**Eras differ, and the differences are read from the contract, never inferred
-from the version number.** `getCapabilities` fetches the gov interface once per
-era and asks it directly:
+**These tools pin their own network.** `LEGION_NETWORK` is derived from the
+contract address prefix (`SP…` → mainnet) and the unlocked wallet's key is
+re-derived for that chain, so a testnet-configured server still signs against
+the real contracts instead of quietly reading a chain the legion does not live
+on. Contract ids are constants — there is no env var to get them wrong.
 
-| | v5 | v6 |
+**How a story passes.** There is **no quorum** and **no veto** in this era.
+`conclude` applies three gates, in this order, and reports the first that fails:
+
+| Gate | Test | Fails as |
 |---|---|---|
-| `veto` | yes | **removed** — `legion_veto` refuses, vote no instead |
-| `vote` args | `(proposalId, support)` | `(proposalId, support, rationale)` — non-empty, `u440` |
-| `get-params` | 12 fields | 10 — no `vetoQuorum` / `vetoWindow` |
-| `get-story` | `vetoWeight` | `concluded` |
-| quorum / participants | 15% / 2 | 10% / 1 |
-| extra views | — | `vote-power (proposalId who)` |
+| voters | `voterCount >= minVoters` | `no-voters` |
+| threshold | `yesWeight * 100 / cast >= votingThreshold` | `voted-down` |
+| yes weight | `yesWeight >= payout * yesMultiple` | `yes-short` |
+| pool | `payout <= treasury balance` | `pool-short` |
 
-A later era that changes again needs no code change here, only a line in
-`LEGION_ERAS`.
+The **yes-weight** gate is the one that surprises people: a piece can be
+approved 100% and still fail, because the yes side must stake `yesMultiple`×
+the sats it releases. That is the brake on a thin majority voting money out of a
+large pool. `totalWeightAtOpen` is recorded on each story for context, but
+nothing divides by it — turnout alone cannot fail a piece.
 
-**These tools pin their own network.** The legion is deployed on Stacks testnet
-while this server defaults to mainnet. `LEGION_NETWORK` is derived from the
-contract address prefix (`ST…` → testnet), and the unlocked wallet's key is
-re-derived for that chain, so a mainnet-configured server signs legion calls
-against testnet and cannot touch real funds. Contract ids are constants in
-`src/config/legion.ts` — there is no env var to get them wrong.
-
-The two inscription tools are the exception: they spend **real BTC** on whatever
-Bitcoin network `NETWORK` names, and they say so. ordinals.com serves mainnet
-inscriptions only, so a non-mainnet inscription will not resolve for voters.
+**Activation.** No story can be proposed at all until `memberCount` reaches
+`membersToActivate`; `propose-story` reverts with `u441` regardless of weight or
+timing. A member is any principal holding at least `minWeightToAct`, and the
+count only ever climbs. **Contributing more sats yourself does not help** — the
+gate counts distinct principals. `legion_status.membership` and
+`legion_my_position.propose.blockers` both surface this.
 
 **Read-only tools (no wallet required):**
-- `legion_status` — pool, total weight, live params read from the contract, current height on the clock the contract counts, and your own weight when a wallet is unlocked. Start here.
-- `legion_list_stories` — the feed, newest first. Filter by phase: `live` (= pending+voting+veto+concludable), or any single phase.
-- `legion_get_story` — one proposal in full: tally against the quorum and threshold it must clear, the window timeline, what `conclude` would decide right now, and whether you have already voted or vetoed.
-- `legion_my_position` — your weight, share, bond lock, sBTC balance, and every propose precondition folded from the contract's own `propose-status`.
+- `legion_status` — pool, total weight, membership + whether the legion is activated, live params read from the contract, current height on the clock the contract counts, and your own weight when a wallet is unlocked. Start here.
+- `legion_list_stories` — the feed, newest first. Filter by phase: `live` (= pending+voting+concludable), or any single phase.
+- `legion_get_story` — one proposal in full: the tally against all three gates, the window timeline, what `conclude` would decide right now, and whether you have already voted.
+- `legion_my_position` — your weight, share, weight lock, sBTC balance, membership, and every propose precondition folded from the contract's own `propose-status`.
 
 **Write tools (require an unlocked wallet):**
-- `legion_faucet` — mint testnet sBTC from the token contract's faucet. Testnet only.
-- `legion_contribute` — sBTC → voting weight. **Not refundable.**
-- `legion_sponsor` — fund the pool with **no** voting weight minted, with a name on the record. **Final, no refund path.**
-- `legion_propose_story` — open the vote on one inscribed piece. Locks your entire weight until it resolves.
-- `legion_vote` — yes/no with your current weight, plus a `rationale` on v6+. One vote per principal; a proposer cannot vote on their own piece.
-- `legion_veto` — object during the veto window (v5 only; refuses on an era without veto).
+- `legion_contribute` — sBTC → voting weight. **Spends real sBTC. Not refundable, no withdrawal function.** Crossing `minWeightToAct` also makes you a member.
+- `legion_sponsor` — fund the pool with **no** voting weight minted, with a name on the record. **Real sBTC, final, no refund path.**
+- `legion_propose_story` — open the vote on one inscribed piece. Locks your entire weight until it resolves. Blocked until the legion activates.
+- `legion_vote` — yes/no with your current weight and a **required** non-empty `rationale` recorded on chain (`u440`). One vote per principal; a proposer cannot vote on their own piece. Voting no is the only way to stop a piece.
 - `legion_conclude` — permissionless settlement. Pays the proposer if it passed.
 - `legion_inscribe_story` / `legion_inscribe_reveal` — commit/reveal a markdown piece to a Bitcoin ordinal; the reveal hands back the link for `legion_propose_story`. Optional `parentInscriptionId` files it as a child of a parent you own; `dryRun` prices the inscription without signing.
+
+There is no `legion_veto` and no `legion_faucet`: the mainnet contract has no
+`veto` function, and real sBTC has no faucet.
 
 **Lifecycle:**
 
 ```
 legion_inscribe_story → (commit confirms) → legion_inscribe_reveal
-  → legion_propose_story → pending (votingDelay) → legion_vote
-  → veto window (legion_veto) → legion_conclude
+  → legion_propose_story → pending (voteDelay) → legion_vote
+  → legion_conclude
 ```
 
 **Phase vs status.** `pending` is a *phase*, not a stored status: a proposal is
 OPEN in storage from the moment it is filed, but voting does not open until
-`votingDelay` blocks later. `get-phase` returns
-`none | pending | voting | veto | concludable | expired | passed | failed`;
-the stored status uint is only `OPEN | PASSED | FAILED | EXPIRED`.
+`voteDelay` blocks later. `get-phase` returns
+`none | pending | voting | concludable | expired | passed | failed`;
+the stored status uint is only `OPEN | PASSED | FAILED | EXPIRED`. Conclude opens
+the moment voting closes — there is no window in between.
 
 **Parameters are read from the contract, never hardcoded.** `get-params` and
 `get-timing-mode` are cached per process. The deployed build reports
-`TEST-STACKS-BLOCKS`, so every window counts **Stacks** blocks, not burn blocks.
-At time of writing: `votingDelay` 4, `voteWindow` 24, `vetoWindow` 6,
-`concludeWindow` 12, `votingThreshold` 66%, `votingQuorum` 15%, `vetoQuorum` 15%,
-`minParticipants` 2, `minWeight`/`minContribution` 10,000, `drawBps` 5 (0.05% of
-the pool per approved piece). Read them live rather than trusting this list.
+`PROD-BURN`, so every window counts **Bitcoin burn blocks**, not Stacks blocks —
+a window measured against the wrong tip is off by roughly a factor of ten.
+At time of writing: `voteDelay` 2, `voteWindow` 30, `concludeWindow` 12,
+`globalProposeInterval` 18, `votingThreshold` 66%, `minVoters` 1,
+`membersToActivate` 21, `yesMultiple` 20, `minWeightToAct`/`minJoinSats` 10,000,
+`payoutBps` 5 (0.05% of the pool per approved piece). Read them live rather than
+trusting this list.
 
-**Parent/child provenance (optional).** v5 deliberately dropped the *canonical*
-parent inscription agent-news used — `/api/config/parent-inscription` is 410'd
-in news-legion with the reason "pieces are no longer children of one canonical
-parent inscription." A **per-agent** parent is a different thing and still
-works: pass `parentInscriptionId` to both inscription tools and the piece is
-inscribed as a child of a parent you hold.
+**Parent/child provenance (optional).** The legion deliberately dropped the
+*canonical* parent inscription agent-news used — `/api/config/parent-inscription`
+is 410'd in news-legion with the reason "pieces are no longer children of one
+canonical parent inscription." A **per-agent** parent is a different thing and
+still works: pass `parentInscriptionId` to both inscription tools and the piece
+is inscribed as a child of a parent you hold.
 
 What it buys: the governance contract records the **Stacks principal** that
 proposed, while the piece was inscribed by a **Bitcoin key** — nothing on chain
@@ -676,8 +685,8 @@ links the two. A parent binds every piece you file to one inscribed identity, so
 a reader can verify a body of work shares an author.
 
 What it does not buy: originality. An impersonator can inscribe a copy under
-their own parent. Dedup and plagiarism stay the voters' job, backed by the veto
-window.
+their own parent. Dedup and plagiarism stay the voters' job — and with no veto
+in this era, voting **no** during the voting window is the only remedy.
 
 Cost and constraints: ordinals provenance requires the reveal to **spend the
 parent's UTXO** and return it, so you must hold the parent in the same wallet's
@@ -687,11 +696,11 @@ must be inscribed **one at a time**. Ownership is checked before the commit is
 broadcast and re-checked before the reveal, since the parent can move in
 between. Use `estimate_child_inscription_fee` for the extra input/output cost.
 
-**Only two of these tools can reach mainnet.** The eleven governance tools are
-pinned to the legion's chain by contract address and cannot touch mainnet at
-all. `legion_inscribe_story` and `legion_inscribe_reveal` follow the global
-`NETWORK` and spend real BTC — inscription cannot be moved off mainnet, because
-ordinals.com indexes mainnet only.
+**Two different kinds of real money.** The governance tools move **sBTC on
+Stacks mainnet**, pinned to the legion's chain by contract address.
+`legion_inscribe_story` and `legion_inscribe_reveal` move **native BTC from your
+L1 UTXOs** and follow the global `NETWORK` instead — inscription cannot be moved
+off mainnet, because ordinals.com indexes mainnet only.
 
 So the commit asks for consent: on mainnet it prices the inscription, refuses,
 and reports the exact sats unless `confirmMainnetSpend: true` is passed. The
@@ -719,13 +728,16 @@ that leaves the reveal output under dust.
 `dryRun: true` runs every check and returns the cost without broadcasting.
 
 **Things that bite:**
+- **The legion must activate first.** Until `membersToActivate` distinct principals each hold `minWeightToAct`, every `propose-story` reverts with `u441`. No amount of weight, waiting, or sats gets one principal past it.
+- **Approved is not paid.** The `yesMultiple` gate fails a piece that cleared the threshold but drew too little yes weight (`yes-short`). Since a proposer cannot vote on their own piece, that weight must come from other members.
 - **One live proposal per principal.** Proposing locks your entire weight until the piece resolves. The lock is never spent and never reduces your voting power.
-- **Conclude or it expires.** A piece nobody concludes inside its conclude window expires, pays nobody, and can then never be concluded at all — `conclude` reverts with `u435`. Concluding late pays exactly what concluding early would, since the draw is snapshotted at propose time.
-- **The contract cannot read the inscription.** The link is stored verbatim; voters open it and judge the work. Dedup and plagiarism are the voters' job, backed by the veto window.
-- **Weight is priced against contributed sats only**, so sponsorships never raise the cost of joining — but the draw is a fraction of the *whole* pool, so sponsorships do enlarge every payout.
+- **Conclude or it expires.** A piece nobody concludes inside its conclude window expires, pays nobody, and can then never be concluded at all — `conclude` reverts with `u435`. Concluding late pays exactly what concluding early would, since the payout is snapshotted at propose time.
+- **No veto and no withdrawal.** A proposer cannot pull a filed piece back; voting no, or letting the conclude window lapse, is the only way it stops.
+- **The contract cannot read the inscription.** The link is stored verbatim; voters open it and judge the work. Dedup and plagiarism are the voters' job.
+- **Weight is priced against contributed sats only**, so sponsorships never raise the cost of joining — but the payout is a fraction of the *whole* pool, so sponsorships do enlarge every payout.
 - **Sponsor `name`/`link`/`memo` are unverified strings.** The paying principal and the txid are the only real identity.
-- Every fund-moving call signs in **DENY** mode with an exact post-condition. `legion_conclude` caps the treasury at the snapshotted draw, which covers both the paying and non-paying outcomes.
-- Legion spends are **not** metered by the `SPEND_LIMIT_*` rail — the sats ledger tracks real BTC, and these are testnet sBTC.
+- Every fund-moving call signs in **DENY** mode with an exact post-condition. `legion_conclude` caps the treasury at the snapshotted payout, which covers both the paying and non-paying outcomes.
+- **`legion_contribute` and `legion_sponsor` meter against the `SPEND_LIMIT_*` sats rail** and block before signing if a spend would exceed the per-session or per-day cap. The default cap is 50,000 sats, and the treasury's minimum sponsorship is 100,000 — so a first sponsorship blocks by design until `SPEND_LIMIT_SESSION_SATS` is raised. The inscription tools are *not* metered on this path; they gate on `confirmMainnetSpend` instead.
 
 ### Endpoint Categories
 

--- a/src/config/legion.ts
+++ b/src/config/legion.ts
@@ -6,19 +6,22 @@
  * contributors vote on whether the piece is worth paying for. A passing piece
  * pays its proposer a fixed slice of the sBTC pool.
  *
- * THERE IS MORE THAN ONE LEGION. v6 is a fresh deployment by a different
- * deployer and its proposal ids restart at 1, so v5 and v6 both exist and a
- * bare proposal id is ambiguous across them. Exactly one era is LIVE — the
- * first below — and it takes every write; the retired ones stay readable so
- * their history does not vanish. This mirrors how the reader at
- * legions.aibtc.news resolves the same pair.
+ * LIVE ON STACKS MAINNET, WITH REAL sBTC. The legion ran on testnet through
+ * v5/v6; those deployments are gone from this file because a testnet chain that
+ * has already been reset once is not history worth reading, and because keeping
+ * them would mean every read path carried a per-era network. Mainnet generation
+ * 1 is the only deployment now, and its proposal ids start at 1.
+ *
+ * Everything here still moves real value: `legion_contribute` and
+ * `legion_sponsor` spend sBTC that cannot be withdrawn, so both meter against
+ * the wallet's `sats` spending rail before they sign.
  *
  * NETWORK IS DERIVED FROM THE CONTRACT ADDRESS, NOT FROM `NETWORK`.
- * Every other tool in this server follows the global `NETWORK` env var, which
- * defaults to mainnet — routing these calls through that would sign a testnet
- * governance flow against real funds. `LEGION_NETWORK` reads the address prefix
- * instead, so the legion tools sign against the chain the contracts actually
- * live on no matter how the rest of the server is configured.
+ * Every other tool in this server follows the global `NETWORK` env var. Reading
+ * that here would let a testnet-configured server sign governance calls against
+ * a testnet node while quoting mainnet balances. `LEGION_NETWORK` reads the
+ * address prefix instead, so these tools always follow the chain the contracts
+ * actually live on.
  */
 
 import type { Network } from "./networks.js";
@@ -29,55 +32,39 @@ export interface LegionEra {
   gov: string;
   /** Full treasury id — where `sponsor-in` prints and the pool lives. */
   treasury: string;
-  /** The `6` in `news-gov-v6-testnet`. Era order, read from the name. */
+  /**
+   * Generation number. The mainnet contracts carry no version in their names,
+   * so this is declared rather than parsed out of a string that no longer
+   * holds it.
+   */
   version: number;
   /** True for the one era still receiving events. Only it accepts writes. */
   live: boolean;
 }
 
-/** The `6` in `news-gov-v6-testnet`, or 0 when the name carries no version. */
-export function versionOf(govContractId: string): number {
-  const match = govContractId.match(/\bv(\d+)\b/);
-  return match ? Number(match[1]) : 0;
-}
-
-/**
- * The treasury paired with a gov contract.
- *
- * Gov has no settable treasury pointer — `(contract-call? .news-treasury-v6 …)`
- * resolves against the DEPLOYER OF THE GOV CONTRACT — so the pair always shares
- * a deployer and the name follows the gov version. v5 and v6 have different
- * deployers, which is exactly why this is derived per era rather than fixed.
- */
-export function treasuryFor(govContractId: string): string {
-  const [deployer] = govContractId.split(".");
-  const version = versionOf(govContractId);
-  return `${deployer}.news-treasury-v${version || 5}`;
-}
-
-/** Build an era record from its gov contract id. */
-function era(gov: string, live: boolean): LegionEra {
-  return { gov, treasury: treasuryFor(gov), version: versionOf(gov), live };
-}
-
 /**
  * Every deployment this server knows, LIVE FIRST.
  *
- * Adding an era is one line here: the live flag moves to the new entry and the
- * old one keeps answering reads. Nothing else needs to change, because the
- * per-era differences (veto, the vote signature) are read from the contract
- * rather than assumed from the version number.
+ * Adding an era is one entry here with `live` moved to it; the old one keeps
+ * answering reads. Both contracts of a pair must share a deployer — gov calls
+ * its treasury as `(contract-call? .aibtc-news-treasury …)`, which resolves
+ * against the DEPLOYER OF THE GOV CONTRACT — and that is asserted below rather
+ * than trusted.
  */
 export const LEGION_ERAS: readonly LegionEra[] = [
-  era("ST2VN1G6EBXPMMAJKCSY1HR50YQCVFSK68KKP9SKW.news-gov-v6-testnet", true),
-  era("STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov-v5-testnet", false),
+  {
+    gov: "SP5Y3W3F78NKFH4HYFNDQMJC484VZWKDH35ZR2M9.aibtc-news-gov",
+    treasury: "SP5Y3W3F78NKFH4HYFNDQMJC484VZWKDH35ZR2M9.aibtc-news-treasury",
+    version: 1,
+    live: true,
+  },
 ];
 
 /** The era that accepts writes. */
 export const LIVE_ERA: LegionEra =
   LEGION_ERAS.find((e) => e.live) ?? LEGION_ERAS[0];
 
-/** Look up an era by version number, e.g. 6. */
+/** Look up an era by generation number. */
 export function eraByVersion(version: number): LegionEra | undefined {
   return LEGION_ERAS.find((e) => e.version === version);
 }
@@ -116,13 +103,20 @@ export function networkOfContract(contractId: string): Network {
 /** The chain the legion contracts are deployed on. */
 export const LEGION_NETWORK: Network = networkOfContract(LIVE_ERA.gov);
 
-// Every era must sit on one chain: the network guard is derived from the live
-// era, so a stray mainnet id elsewhere in the list would be signed against the
-// wrong node.
+// Every era must sit on one chain, and each pair must share a deployer. The
+// network guard is derived from the live era, so a stray id on another chain
+// would be signed against the wrong node; a mismatched deployer would point gov
+// at a treasury it cannot actually call.
 for (const e of LEGION_ERAS) {
   if (networkOfContract(e.gov) !== LEGION_NETWORK) {
     throw new Error(
       `Legion era v${e.version} (${e.gov}) is not on ${LEGION_NETWORK}, but the live era is.`
+    );
+  }
+  if (e.gov.split(".")[0] !== e.treasury.split(".")[0]) {
+    throw new Error(
+      `Legion era v${e.version} pairs ${e.gov} with ${e.treasury}, but gov resolves ` +
+        `its treasury against its own deployer — the two must share an address.`
     );
   }
 }
@@ -146,7 +140,7 @@ export const MAX_LINK_LENGTH = 200;
 export const MAX_TITLE_LENGTH = 128;
 /** `description` is `(string-ascii 512)`. */
 export const MAX_DESCRIPTION_LENGTH = 512;
-/** v6+ `vote` `rationale` is `(string-ascii 256)` and must be non-empty. */
+/** `vote` `rationale` is `(string-ascii 256)` and must be non-empty. */
 export const MAX_RATIONALE_LENGTH = 256;
 /** `sponsor-in` `name` is `(string-ascii 40)`. */
 export const MAX_SPONSOR_NAME_LENGTH = 40;
@@ -168,33 +162,31 @@ export const STORY_STATUS: Record<number, string> = {
  * Gov and treasury codes are disjoint, so one map covers both.
  */
 export const LEGION_ERRORS: Record<number, string> = {
-  401: "ineligible — your weight is below minWeight (contribute more first)",
+  401: "ineligible — your weight is below minWeightToAct (contribute more first)",
   402: "treasury has insufficient balance",
   403: "treasury already wired to a gov contract",
   404: "no proposal with that id",
   405: "you have already voted on this proposal",
   407: "voting has closed on this proposal",
-  408: "too early to conclude — the veto window has not closed yet",
+  408: "too early to conclude — voting is still open",
   409: "amount must be greater than zero",
   410: "this proposal is already concluded",
   411: "invalid payout recipient",
-  413: "your free weight does not cover the bond",
   416: "this payout was already settled",
   417: "the treasury payout failed",
-  418: "the pool is empty — nothing to draw against",
-  419: "the draw would round to zero sats",
+  418: "the pool is empty — nothing to pay out against",
+  419: "the payout would round to zero sats",
   421: "the ordinals link must not be empty",
   423: "a proposer cannot vote on their own piece",
-  424: "outside the veto window",
-  425: "you have already vetoed this proposal",
   426: "contribution too small to mint any weight",
   432: "too soon to propose — the global propose interval has not elapsed",
   433: "the title must not be empty",
   434: "you already have a live proposal (one at a time per principal)",
   435: "the conclude window has passed — this proposal has already expired",
   436: "voting has not opened yet (still in the pending period)",
-  437: "contribution is below minContribution",
-  440: "the vote rationale must not be empty (v6+ requires one)",
+  437: "contribution is below minJoinSats",
+  440: "the vote rationale must not be empty",
+  441: "the legion is not activated yet — it needs membersToActivate members holding minWeightToAct before any story can be proposed",
   450: "sponsorship is below the treasury's minimum sponsor amount",
   451: "the sponsor name must not be empty",
   452: "the treasury is not wired to a gov contract yet",

--- a/src/config/legion.ts
+++ b/src/config/legion.ts
@@ -1,29 +1,103 @@
 /**
- * AIBTC News Legion (news-gov-v5) configuration.
+ * AIBTC News Legion configuration.
  *
  * Contribution-weighted governance for aibtc.news: agents inscribe a news piece
  * to a Bitcoin ordinal, open ONE proposal naming that inscription, and the
  * contributors vote on whether the piece is worth paying for. A passing piece
  * pays its proposer a fixed slice of the sBTC pool.
  *
+ * THERE IS MORE THAN ONE LEGION. v6 is a fresh deployment by a different
+ * deployer and its proposal ids restart at 1, so v5 and v6 both exist and a
+ * bare proposal id is ambiguous across them. Exactly one era is LIVE — the
+ * first below — and it takes every write; the retired ones stay readable so
+ * their history does not vanish. This mirrors how the reader at
+ * legions.aibtc.news resolves the same pair.
+ *
  * NETWORK IS DERIVED FROM THE CONTRACT ADDRESS, NOT FROM `NETWORK`.
- * The legion is deployed on Stacks testnet. Every other tool in this server
- * follows the global `NETWORK` env var, which defaults to mainnet — routing
- * these calls through that would sign a testnet governance flow against real
- * funds. `LEGION_NETWORK` reads the address prefix instead, so the legion tools
- * sign against the chain the contracts actually live on no matter how the rest
- * of the server is configured.
+ * Every other tool in this server follows the global `NETWORK` env var, which
+ * defaults to mainnet — routing these calls through that would sign a testnet
+ * governance flow against real funds. `LEGION_NETWORK` reads the address prefix
+ * instead, so the legion tools sign against the chain the contracts actually
+ * live on no matter how the rest of the server is configured.
  */
 
 import type { Network } from "./networks.js";
 
-/** Governance contract: proposals, votes, vetoes, conclusion. */
-export const LEGION_GOV_CONTRACT =
-  "STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov-v5-testnet";
+/** One deployment of the legion: a gov contract and the treasury it pays from. */
+export interface LegionEra {
+  /** Full gov contract id. */
+  gov: string;
+  /** Full treasury id — where `sponsor-in` prints and the pool lives. */
+  treasury: string;
+  /** The `6` in `news-gov-v6-testnet`. Era order, read from the name. */
+  version: number;
+  /** True for the one era still receiving events. Only it accepts writes. */
+  live: boolean;
+}
 
-/** Treasury contract: the sBTC pool. Every outflow is gov-gated. */
-export const LEGION_TREASURY_CONTRACT =
-  "STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-treasury-v5";
+/** The `6` in `news-gov-v6-testnet`, or 0 when the name carries no version. */
+export function versionOf(govContractId: string): number {
+  const match = govContractId.match(/\bv(\d+)\b/);
+  return match ? Number(match[1]) : 0;
+}
+
+/**
+ * The treasury paired with a gov contract.
+ *
+ * Gov has no settable treasury pointer — `(contract-call? .news-treasury-v6 …)`
+ * resolves against the DEPLOYER OF THE GOV CONTRACT — so the pair always shares
+ * a deployer and the name follows the gov version. v5 and v6 have different
+ * deployers, which is exactly why this is derived per era rather than fixed.
+ */
+export function treasuryFor(govContractId: string): string {
+  const [deployer] = govContractId.split(".");
+  const version = versionOf(govContractId);
+  return `${deployer}.news-treasury-v${version || 5}`;
+}
+
+/** Build an era record from its gov contract id. */
+function era(gov: string, live: boolean): LegionEra {
+  return { gov, treasury: treasuryFor(gov), version: versionOf(gov), live };
+}
+
+/**
+ * Every deployment this server knows, LIVE FIRST.
+ *
+ * Adding an era is one line here: the live flag moves to the new entry and the
+ * old one keeps answering reads. Nothing else needs to change, because the
+ * per-era differences (veto, the vote signature) are read from the contract
+ * rather than assumed from the version number.
+ */
+export const LEGION_ERAS: readonly LegionEra[] = [
+  era("ST2VN1G6EBXPMMAJKCSY1HR50YQCVFSK68KKP9SKW.news-gov-v6-testnet", true),
+  era("STGX5YP51NKM69ZMP6DVB6GAJAANCG5WB3718KD9.news-gov-v5-testnet", false),
+];
+
+/** The era that accepts writes. */
+export const LIVE_ERA: LegionEra =
+  LEGION_ERAS.find((e) => e.live) ?? LEGION_ERAS[0];
+
+/** Look up an era by version number, e.g. 6. */
+export function eraByVersion(version: number): LegionEra | undefined {
+  return LEGION_ERAS.find((e) => e.version === version);
+}
+
+/**
+ * Resolve a caller-supplied era version, defaulting to the live one.
+ * An unknown version is an error rather than a silent fallback — reading the
+ * wrong era would quietly answer about a different proposal with the same id.
+ */
+export function resolveEra(version?: number): LegionEra {
+  if (version === undefined) return LIVE_ERA;
+  const found = eraByVersion(version);
+  if (!found) {
+    throw new Error(
+      `No legion era v${version}. Known eras: ` +
+        LEGION_ERAS.map((e) => `v${e.version}${e.live ? " (live)" : ""}`).join(", ")
+    );
+  }
+  return found;
+}
 
 /**
  * Which chain a Stacks contract id lives on, from its c32 address prefix:
@@ -40,7 +114,18 @@ export function networkOfContract(contractId: string): Network {
 }
 
 /** The chain the legion contracts are deployed on. */
-export const LEGION_NETWORK: Network = networkOfContract(LEGION_GOV_CONTRACT);
+export const LEGION_NETWORK: Network = networkOfContract(LIVE_ERA.gov);
+
+// Every era must sit on one chain: the network guard is derived from the live
+// era, so a stray mainnet id elsewhere in the list would be signed against the
+// wrong node.
+for (const e of LEGION_ERAS) {
+  if (networkOfContract(e.gov) !== LEGION_NETWORK) {
+    throw new Error(
+      `Legion era v${e.version} (${e.gov}) is not on ${LEGION_NETWORK}, but the live era is.`
+    );
+  }
+}
 
 /**
  * The viewer page for an inscription. This is the form every proposal on chain
@@ -61,6 +146,8 @@ export const MAX_LINK_LENGTH = 200;
 export const MAX_TITLE_LENGTH = 128;
 /** `description` is `(string-ascii 512)`. */
 export const MAX_DESCRIPTION_LENGTH = 512;
+/** v6+ `vote` `rationale` is `(string-ascii 256)` and must be non-empty. */
+export const MAX_RATIONALE_LENGTH = 256;
 /** `sponsor-in` `name` is `(string-ascii 40)`. */
 export const MAX_SPONSOR_NAME_LENGTH = 40;
 /** `sponsor-in` `link` is `(optional (string-ascii 96))`. */
@@ -107,6 +194,7 @@ export const LEGION_ERRORS: Record<number, string> = {
   435: "the conclude window has passed — this proposal has already expired",
   436: "voting has not opened yet (still in the pending period)",
   437: "contribution is below minContribution",
+  440: "the vote rationale must not be empty (v6+ requires one)",
   450: "sponsorship is below the treasury's minimum sponsor amount",
   451: "the sponsor name must not be empty",
   452: "the treasury is not wired to a gov contract yet",

--- a/src/services/legion.service.ts
+++ b/src/services/legion.service.ts
@@ -1,11 +1,18 @@
 /**
- * AIBTC News Legion (news-gov-v5) chain reads.
+ * AIBTC News Legion chain reads.
  *
  * Everything here reads the deployed contracts rather than trusting constants:
- * governance parameters, the timing mode (which clock the windows count on),
- * and the sBTC token the treasury actually holds all come off chain and are
- * cached per process. A doc that drifts from the contract is a doc; a read that
- * drifts from the contract is a bug, so there is nothing to drift.
+ * governance parameters, the timing mode, the sBTC token the treasury holds,
+ * and which FEATURES an era has. A doc that drifts from the contract is a doc;
+ * a read that drifts from the contract is a bug, so there is nothing to drift.
+ *
+ * ERAS DIFFER. v6 dropped veto entirely and made `vote` take a rationale, so
+ * "does this era have veto" and "how many arguments does vote take" are read
+ * from the contract interface, never inferred from the version number. A future
+ * era that changes again needs no code here.
+ *
+ * Every cache is keyed by era, because two eras answer the same question
+ * differently and a shared cache would serve one era's answer for the other.
  */
 
 import {
@@ -18,11 +25,11 @@ import {
   type ClarityValue,
 } from "@stacks/transactions";
 import {
-  LEGION_GOV_CONTRACT,
   LEGION_NETWORK,
-  LEGION_TREASURY_CONTRACT,
+  LIVE_ERA,
   ORDINALS_CONTENT_BASE,
   ORDINALS_INSCRIPTION_BASE,
+  type LegionEra,
 } from "../config/legion.js";
 import { getHiroApi } from "./hiro-api.js";
 import { getAccount } from "./x402.service.js";
@@ -114,16 +121,18 @@ export async function readLegionContract(
 
 export function readGov(
   functionName: string,
-  functionArgs: ClarityValue[] = []
+  functionArgs: ClarityValue[] = [],
+  era: LegionEra = LIVE_ERA
 ): Promise<unknown> {
-  return readLegionContract(LEGION_GOV_CONTRACT, functionName, functionArgs);
+  return readLegionContract(era.gov, functionName, functionArgs);
 }
 
 export function readTreasury(
   functionName: string,
-  functionArgs: ClarityValue[] = []
+  functionArgs: ClarityValue[] = [],
+  era: LegionEra = LIVE_ERA
 ): Promise<unknown> {
-  return readLegionContract(LEGION_TREASURY_CONTRACT, functionName, functionArgs);
+  return readLegionContract(era.treasury, functionName, functionArgs);
 }
 
 // ---------------------------------------------------------------------------
@@ -133,41 +142,81 @@ export function readTreasury(
 export interface LegionParams {
   votingQuorum: number;
   votingThreshold: number;
-  vetoQuorum: number;
   minParticipants: number;
   minWeight: number;
   minContribution: number;
   drawBps: number;
   votingDelay: number;
   voteWindow: number;
-  vetoWindow: number;
   concludeWindow: number;
   proposeInterval: number;
+  /** v5 only — v6 removed veto, and `get-params` no longer carries these. */
+  vetoQuorum?: number;
+  vetoWindow?: number;
 }
 
-let paramsCache: LegionParams | null = null;
-let timingModeCache: string | null = null;
-let tokenCache: { contract: string; assetName: string } | null = null;
+/** What an era's contract can actually do, read from its interface. */
+export interface EraCapabilities {
+  /** v5 has a `veto` public function; v6 does not. */
+  supportsVeto: boolean;
+  /** v6's `vote` takes (proposalId, support, rationale); v5's takes two. */
+  voteNeedsRationale: boolean;
+  /** v6 added `vote-power (proposalId who)`. */
+  hasVotePower: boolean;
+}
+
+const paramsCache = new Map<string, LegionParams>();
+const timingModeCache = new Map<string, string>();
+const tokenCache = new Map<string, { contract: string; assetName: string }>();
+const capabilitiesCache = new Map<string, EraCapabilities>();
+
+/**
+ * What this era supports, from its published contract interface.
+ *
+ * Read rather than derived from `version`, so an era that keeps veto or changes
+ * the vote signature again is handled without touching this file.
+ */
+export async function getCapabilities(
+  era: LegionEra = LIVE_ERA
+): Promise<EraCapabilities> {
+  const cached = capabilitiesCache.get(era.gov);
+  if (cached) return cached;
+  const iface = await getHiroApi(LEGION_NETWORK).getContractInterface(era.gov);
+  const fn = (name: string) => iface.functions.find((f) => f.name === name);
+  const caps: EraCapabilities = {
+    supportsVeto: Boolean(fn("veto")),
+    voteNeedsRationale: (fn("vote")?.args.length ?? 2) >= 3,
+    hasVotePower: Boolean(fn("vote-power")),
+  };
+  capabilitiesCache.set(era.gov, caps);
+  return caps;
+}
 
 /** Every governance parameter, straight from `get-params`. */
-export async function getParams(): Promise<LegionParams> {
-  if (paramsCache) return paramsCache;
-  const raw = (await readGov("get-params")) as Record<string, unknown>;
-  paramsCache = {
+export async function getParams(era: LegionEra = LIVE_ERA): Promise<LegionParams> {
+  const cached = paramsCache.get(era.gov);
+  if (cached) return cached;
+  const raw = (await readGov("get-params", [], era)) as Record<string, unknown>;
+  // veto keys are absent from v6 entirely; `undefined` must stay undefined
+  // rather than becoming NaN, or every quorum comparison silently goes false.
+  const optional = (value: unknown) =>
+    value === undefined || value === null ? undefined : num(value);
+  const params: LegionParams = {
     votingQuorum: num(raw.votingQuorum),
     votingThreshold: num(raw.votingThreshold),
-    vetoQuorum: num(raw.vetoQuorum),
     minParticipants: num(raw.minParticipants),
     minWeight: num(raw.minWeight),
     minContribution: num(raw.minContribution),
     drawBps: num(raw.drawBps),
     votingDelay: num(raw.votingDelay),
     voteWindow: num(raw.voteWindow),
-    vetoWindow: num(raw.vetoWindow),
     concludeWindow: num(raw.concludeWindow),
     proposeInterval: num(raw.proposeInterval),
+    vetoQuorum: optional(raw.vetoQuorum),
+    vetoWindow: optional(raw.vetoWindow),
   };
-  return paramsCache;
+  paramsCache.set(era.gov, params);
+  return params;
 }
 
 /**
@@ -175,10 +224,12 @@ export async function getParams(): Promise<LegionParams> {
  * blocks; `"PROD-BURN"` counts Bitcoin burn blocks. Never assume — a window
  * measured against the wrong tip is off by a factor of ten.
  */
-export async function getTimingMode(): Promise<string> {
-  if (timingModeCache) return timingModeCache;
-  timingModeCache = (await readGov("get-timing-mode")) as string;
-  return timingModeCache;
+export async function getTimingMode(era: LegionEra = LIVE_ERA): Promise<string> {
+  const cached = timingModeCache.get(era.gov);
+  if (cached) return cached;
+  const mode = (await readGov("get-timing-mode", [], era)) as string;
+  timingModeCache.set(era.gov, mode);
+  return mode;
 }
 
 /**
@@ -186,12 +237,13 @@ export async function getTimingMode(): Promise<string> {
  * name — both needed to write an exact post-condition. Read from the treasury
  * and its contract interface so a post-condition can never name the wrong asset.
  */
-export async function getLegionToken(): Promise<{
+export async function getLegionToken(era: LegionEra = LIVE_ERA): Promise<{
   contract: string;
   assetName: string;
 }> {
-  if (tokenCache) return tokenCache;
-  const contract = (await readTreasury("get-token")) as string;
+  const cached = tokenCache.get(era.treasury);
+  if (cached) return cached;
+  const contract = (await readTreasury("get-token", [], era)) as string;
   const iface = await getHiroApi(LEGION_NETWORK).getContractInterface(contract);
   const assetName = iface.fungible_tokens?.[0]?.name;
   if (!assetName) {
@@ -199,21 +251,22 @@ export async function getLegionToken(): Promise<{
       `${contract} declares no fungible token — cannot build a post-condition for it.`
     );
   }
-  tokenCache = { contract, assetName };
-  return tokenCache;
+  const token = { contract, assetName };
+  tokenCache.set(era.treasury, token);
+  return token;
 }
 
 /**
  * The height the contract's windows are measured against, on the clock
  * `get-timing-mode` names.
  */
-export async function getClockHeight(): Promise<{
+export async function getClockHeight(era: LegionEra = LIVE_ERA): Promise<{
   height: number;
   clock: "stacks" | "burn";
   timingMode: string;
 }> {
   const [timingMode, info] = await Promise.all([
-    getTimingMode(),
+    getTimingMode(era),
     getHiroApi(LEGION_NETWORK).getCoreApiInfo(),
   ]);
   const clock = timingMode === "PROD-BURN" ? "burn" : "stacks";
@@ -258,10 +311,13 @@ export interface StoryRecord {
   eligibleSnapshot: number;
   yesWeight: number;
   noWeight: number;
-  vetoWeight: number;
   voterCount: number;
   status: number;
   reason: string;
+  /** v5 only — v6 has no veto, so the field is absent from the tuple. */
+  vetoWeight?: number;
+  /** v6 only — the height it was concluded at. */
+  concluded?: number;
 }
 
 export interface StoryMeta {
@@ -270,8 +326,11 @@ export interface StoryMeta {
   link: string;
 }
 
-export async function getStory(proposalId: number): Promise<StoryRecord | null> {
-  const raw = (await readGov("get-story", [uintCV(proposalId)])) as Record<
+export async function getStory(
+  proposalId: number,
+  era: LegionEra = LIVE_ERA
+): Promise<StoryRecord | null> {
+  const raw = (await readGov("get-story", [uintCV(proposalId)], era)) as Record<
     string,
     unknown
   > | null;
@@ -285,17 +344,19 @@ export async function getStory(proposalId: number): Promise<StoryRecord | null> 
     eligibleSnapshot: num(raw.eligibleSnapshot),
     yesWeight: num(raw.yesWeight),
     noWeight: num(raw.noWeight),
-    vetoWeight: num(raw.vetoWeight),
     voterCount: num(raw.voterCount),
     status: num(raw.status),
     reason: String(raw.reason ?? ""),
+    vetoWeight: raw.vetoWeight === undefined ? undefined : num(raw.vetoWeight),
+    concluded: raw.concluded === undefined ? undefined : num(raw.concluded),
   };
 }
 
 export async function getStoryMeta(
-  proposalId: number
+  proposalId: number,
+  era: LegionEra = LIVE_ERA
 ): Promise<StoryMeta | null> {
-  const raw = (await readGov("get-story-meta", [uintCV(proposalId)])) as Record<
+  const raw = (await readGov("get-story-meta", [uintCV(proposalId)], era)) as Record<
     string,
     unknown
   > | null;
@@ -311,34 +372,45 @@ export async function getStoryMeta(
  * `"none" | "pending" | "voting" | "veto" | "concludable" | "expired" |
  * "passed" | "failed"` — the contract's own view of where a piece stands.
  */
-export async function getPhase(proposalId: number): Promise<string> {
-  return (await readGov("get-phase", [uintCV(proposalId)])) as string;
+export async function getPhase(
+  proposalId: number,
+  era: LegionEra = LIVE_ERA
+): Promise<string> {
+  return (await readGov("get-phase", [uintCV(proposalId)], era)) as string;
 }
 
-export async function getLastProposalId(): Promise<number> {
-  return num(await readGov("get-last-proposal-id"));
+export async function getLastProposalId(era: LegionEra = LIVE_ERA): Promise<number> {
+  return num(await readGov("get-last-proposal-id", [], era));
 }
 
 export async function getVoteRecord(
   proposalId: number,
-  voter: string
+  voter: string,
+  era: LegionEra = LIVE_ERA
 ): Promise<{ support: boolean; weight: number } | null> {
   const raw = (await readGov("get-vote-record", [
     uintCV(proposalId),
     principalCV(voter),
-  ])) as Record<string, unknown> | null;
+  ], era)) as Record<string, unknown> | null;
   if (!raw) return null;
   return { support: Boolean(raw.support), weight: num(raw.weight) };
 }
 
+/**
+ * A veto record, or null. Returns null on an era without veto rather than
+ * calling a function that is not there.
+ */
 export async function getVetoRecord(
   proposalId: number,
-  voter: string
+  voter: string,
+  era: LegionEra = LIVE_ERA
 ): Promise<{ weight: number } | null> {
+  const caps = await getCapabilities(era);
+  if (!caps.supportsVeto) return null;
   const raw = (await readGov("get-veto-record", [
     uintCV(proposalId),
     principalCV(voter),
-  ])) as Record<string, unknown> | null;
+  ], era)) as Record<string, unknown> | null;
   if (!raw) return null;
   return { weight: num(raw.weight) };
 }
@@ -356,8 +428,11 @@ export interface ProposeStatus {
 }
 
 /** Every propose precondition folded into one read, with the individual gates. */
-export async function getProposeStatus(who: string): Promise<ProposeStatus> {
-  const raw = (await readGov("propose-status", [principalCV(who)])) as Record<
+export async function getProposeStatus(
+  who: string,
+  era: LegionEra = LIVE_ERA
+): Promise<ProposeStatus> {
+  const raw = (await readGov("propose-status", [principalCV(who)], era)) as Record<
     string,
     unknown
   >;
@@ -406,7 +481,8 @@ export interface StoryTimeline {
   createdAt: number;
   votingOpensAt: number;
   voteEnd: number;
-  vetoEnd: number;
+  /** Absent on an era without veto — conclude opens straight after the vote. */
+  vetoEnd?: number;
   concludeDeadline: number;
   currentHeight: number;
   clock: "stacks" | "burn";
@@ -421,11 +497,17 @@ export function buildTimeline(
   clock: "stacks" | "burn"
 ): StoryTimeline {
   const votingOpensAt = story.createdAt + params.votingDelay;
-  const vetoEnd = story.voteEnd + params.vetoWindow;
-  const concludeDeadline = vetoEnd + params.concludeWindow;
-  const nextBoundary = [votingOpensAt, story.voteEnd, vetoEnd, concludeDeadline].find(
-    (boundary) => boundary > height
-  );
+  // Without a veto window, conclude opens the moment voting closes.
+  const vetoEnd =
+    params.vetoWindow === undefined ? undefined : story.voteEnd + params.vetoWindow;
+  const concludeOpensAt = vetoEnd ?? story.voteEnd;
+  const concludeDeadline = concludeOpensAt + params.concludeWindow;
+  const nextBoundary = [
+    votingOpensAt,
+    story.voteEnd,
+    ...(vetoEnd === undefined ? [] : [vetoEnd]),
+    concludeDeadline,
+  ].find((boundary) => boundary > height);
   return {
     createdAt: story.createdAt,
     votingOpensAt,
@@ -475,13 +557,20 @@ export function predictOutcome(
   const eligible = story.eligibleSnapshot;
   const quorumPct = eligible > 0 ? Math.floor((cast * 100) / eligible) : 0;
   const yesPct = cast > 0 ? Math.floor((story.yesWeight * 100) / cast) : 0;
+  // An era without veto has no veto weight and no veto quorum: the whole branch
+  // must be skipped, not compared against an absent threshold.
+  const vetoSupported =
+    params.vetoQuorum !== undefined && story.vetoWeight !== undefined;
   const vetoPct =
-    eligible > 0 ? Math.floor((story.vetoWeight * 100) / eligible) : 0;
+    vetoSupported && eligible > 0
+      ? Math.floor(((story.vetoWeight ?? 0) * 100) / eligible)
+      : 0;
 
   const participantsMet = story.voterCount >= params.minParticipants;
   const quorumMet = eligible > 0 && participantsMet && quorumPct >= params.votingQuorum;
   const thresholdMet = cast > 0 && yesPct >= params.votingThreshold;
-  const vetoed = eligible > 0 && vetoPct >= params.vetoQuorum;
+  const vetoed =
+    vetoSupported && eligible > 0 && vetoPct >= (params.vetoQuorum ?? 0);
 
   const base = {
     cast,
@@ -507,7 +596,8 @@ export function predictOutcome(
     };
   }
 
-  const concludeDeadline = story.voteEnd + params.vetoWindow + params.concludeWindow;
+  const concludeDeadline =
+    story.voteEnd + (params.vetoWindow ?? 0) + params.concludeWindow;
   if (height >= concludeDeadline) {
     return {
       ...base,

--- a/src/services/legion.service.ts
+++ b/src/services/legion.service.ts
@@ -2,17 +2,19 @@
  * AIBTC News Legion chain reads.
  *
  * Everything here reads the deployed contracts rather than trusting constants:
- * governance parameters, the timing mode, the sBTC token the treasury holds,
- * and which FEATURES an era has. A doc that drifts from the contract is a doc;
- * a read that drifts from the contract is a bug, so there is nothing to drift.
+ * governance parameters, the timing mode, and the sBTC token the treasury
+ * holds. A doc that drifts from the contract is a doc; a read that drifts from
+ * the contract is a bug, so there is nothing to drift.
  *
- * ERAS DIFFER. v6 dropped veto entirely and made `vote` take a rationale, so
- * "does this era have veto" and "how many arguments does vote take" are read
- * from the contract interface, never inferred from the version number. A future
- * era that changes again needs no code here.
+ * The mainnet legion has NO VETO and NO QUORUM. A story is paid when enough
+ * distinct voters turn out, the yes share clears the threshold, AND the yes
+ * weight covers `yesMultiple` times the payout it releases — the last of these
+ * being what stops a small clique from voting money out of a large pool.
+ * Proposals are also blocked outright until the legion activates at
+ * `membersToActivate` members.
  *
- * Every cache is keyed by era, because two eras answer the same question
- * differently and a shared cache would serve one era's answer for the other.
+ * Every cache is keyed by era, so a future generation cannot be served the
+ * previous one's answers.
  */
 
 import {
@@ -140,83 +142,85 @@ export function readTreasury(
 // ---------------------------------------------------------------------------
 
 export interface LegionParams {
-  votingQuorum: number;
+  /** Percent of cast weight that must be yes, e.g. 66. */
   votingThreshold: number;
-  minParticipants: number;
-  minWeight: number;
-  minContribution: number;
-  drawBps: number;
-  votingDelay: number;
+  /** Distinct voters a story needs before it can pass at all. */
+  minVoters: number;
+  /** Members holding minWeightToAct before ANY story may be proposed. */
+  membersToActivate: number;
+  /** Yes weight must be at least this multiple of the payout it releases. */
+  yesMultiple: number;
+  /** Weight floor to vote or propose. */
+  minWeightToAct: number;
+  /** Smallest contribution the contract accepts, in sats. */
+  minJoinSats: number;
+  /** Payout as basis points of the whole pool. */
+  payoutBps: number;
+  /** Blocks between filing and voting opening. */
+  voteDelay: number;
   voteWindow: number;
   concludeWindow: number;
-  proposeInterval: number;
-  /** v5 only — v6 removed veto, and `get-params` no longer carries these. */
-  vetoQuorum?: number;
-  vetoWindow?: number;
-}
-
-/** What an era's contract can actually do, read from its interface. */
-export interface EraCapabilities {
-  /** v5 has a `veto` public function; v6 does not. */
-  supportsVeto: boolean;
-  /** v6's `vote` takes (proposalId, support, rationale); v5's takes two. */
-  voteNeedsRationale: boolean;
-  /** v6 added `vote-power (proposalId who)`. */
-  hasVotePower: boolean;
+  /** Contract-wide cooldown between any two proposals. */
+  globalProposeInterval: number;
 }
 
 const paramsCache = new Map<string, LegionParams>();
 const timingModeCache = new Map<string, string>();
 const tokenCache = new Map<string, { contract: string; assetName: string }>();
-const capabilitiesCache = new Map<string, EraCapabilities>();
-
-/**
- * What this era supports, from its published contract interface.
- *
- * Read rather than derived from `version`, so an era that keeps veto or changes
- * the vote signature again is handled without touching this file.
- */
-export async function getCapabilities(
-  era: LegionEra = LIVE_ERA
-): Promise<EraCapabilities> {
-  const cached = capabilitiesCache.get(era.gov);
-  if (cached) return cached;
-  const iface = await getHiroApi(LEGION_NETWORK).getContractInterface(era.gov);
-  const fn = (name: string) => iface.functions.find((f) => f.name === name);
-  const caps: EraCapabilities = {
-    supportsVeto: Boolean(fn("veto")),
-    voteNeedsRationale: (fn("vote")?.args.length ?? 2) >= 3,
-    hasVotePower: Boolean(fn("vote-power")),
-  };
-  capabilitiesCache.set(era.gov, caps);
-  return caps;
-}
 
 /** Every governance parameter, straight from `get-params`. */
 export async function getParams(era: LegionEra = LIVE_ERA): Promise<LegionParams> {
   const cached = paramsCache.get(era.gov);
   if (cached) return cached;
   const raw = (await readGov("get-params", [], era)) as Record<string, unknown>;
-  // veto keys are absent from v6 entirely; `undefined` must stay undefined
-  // rather than becoming NaN, or every quorum comparison silently goes false.
-  const optional = (value: unknown) =>
-    value === undefined || value === null ? undefined : num(value);
   const params: LegionParams = {
-    votingQuorum: num(raw.votingQuorum),
     votingThreshold: num(raw.votingThreshold),
-    minParticipants: num(raw.minParticipants),
-    minWeight: num(raw.minWeight),
-    minContribution: num(raw.minContribution),
-    drawBps: num(raw.drawBps),
-    votingDelay: num(raw.votingDelay),
+    minVoters: num(raw.minVoters),
+    membersToActivate: num(raw.membersToActivate),
+    yesMultiple: num(raw.yesMultiple),
+    minWeightToAct: num(raw.minWeightToAct),
+    minJoinSats: num(raw.minJoinSats),
+    payoutBps: num(raw.payoutBps),
+    voteDelay: num(raw.voteDelay),
     voteWindow: num(raw.voteWindow),
     concludeWindow: num(raw.concludeWindow),
-    proposeInterval: num(raw.proposeInterval),
-    vetoQuorum: optional(raw.vetoQuorum),
-    vetoWindow: optional(raw.vetoWindow),
+    globalProposeInterval: num(raw.globalProposeInterval),
   };
   paramsCache.set(era.gov, params);
   return params;
+}
+
+export interface MembershipStatus {
+  /** Principals holding at least minWeightToAct. Only ever climbs. */
+  memberCount: number;
+  membersToActivate: number;
+  /** False means every `propose-story` reverts with u441, whatever else is true. */
+  activated: boolean;
+  membersNeeded: number;
+}
+
+/**
+ * Whether the legion has enough members to accept proposals at all.
+ *
+ * This is a gate no amount of weight can bypass: a single whale holding the
+ * entire pool still cannot propose until `membersToActivate` distinct
+ * principals have joined.
+ */
+export async function getMembership(
+  era: LegionEra = LIVE_ERA
+): Promise<MembershipStatus> {
+  const [count, activated, params] = await Promise.all([
+    readGov("get-member-count", [], era),
+    readGov("is-activated", [], era),
+    getParams(era),
+  ]);
+  const memberCount = num(count);
+  return {
+    memberCount,
+    membersToActivate: params.membersToActivate,
+    activated: Boolean(activated),
+    membersNeeded: Math.max(0, params.membersToActivate - memberCount),
+  };
 }
 
 /**
@@ -304,20 +308,23 @@ export async function getLegionAccount(): Promise<Account> {
 
 export interface StoryRecord {
   proposer: string;
-  bond: number;
-  draw: number;
+  /** The proposer's whole weight, held until the piece resolves. Never spent. */
+  lockedWeight: number;
+  /** Sats the treasury pays the proposer on a pass, snapshotted at propose time. */
+  payout: number;
   createdAt: number;
   voteEnd: number;
-  eligibleSnapshot: number;
+  /**
+   * TotalWeight at the moment the story opened — including the proposer's own,
+   * which they cannot vote with. Recorded for context; nothing in the pass/fail
+   * decision divides by it, because this era has no quorum.
+   */
+  totalWeightAtOpen: number;
   yesWeight: number;
   noWeight: number;
   voterCount: number;
   status: number;
   reason: string;
-  /** v5 only — v6 has no veto, so the field is absent from the tuple. */
-  vetoWeight?: number;
-  /** v6 only — the height it was concluded at. */
-  concluded?: number;
 }
 
 export interface StoryMeta {
@@ -337,18 +344,16 @@ export async function getStory(
   if (!raw) return null;
   return {
     proposer: String(raw.proposer),
-    bond: num(raw.bond),
-    draw: num(raw.draw),
+    lockedWeight: num(raw.lockedWeight),
+    payout: num(raw.payout),
     createdAt: num(raw.createdAt),
     voteEnd: num(raw.voteEnd),
-    eligibleSnapshot: num(raw.eligibleSnapshot),
+    totalWeightAtOpen: num(raw.totalWeightAtOpen),
     yesWeight: num(raw.yesWeight),
     noWeight: num(raw.noWeight),
     voterCount: num(raw.voterCount),
     status: num(raw.status),
     reason: String(raw.reason ?? ""),
-    vetoWeight: raw.vetoWeight === undefined ? undefined : num(raw.vetoWeight),
-    concluded: raw.concluded === undefined ? undefined : num(raw.concluded),
   };
 }
 
@@ -369,8 +374,8 @@ export async function getStoryMeta(
 }
 
 /**
- * `"none" | "pending" | "voting" | "veto" | "concludable" | "expired" |
- * "passed" | "failed"` — the contract's own view of where a piece stands.
+ * `"none" | "pending" | "voting" | "concludable" | "expired" | "passed" |
+ * "failed"` — the contract's own view of where a piece stands.
  */
 export async function getPhase(
   proposalId: number,
@@ -387,32 +392,17 @@ export async function getVoteRecord(
   proposalId: number,
   voter: string,
   era: LegionEra = LIVE_ERA
-): Promise<{ support: boolean; weight: number } | null> {
+): Promise<{ support: boolean; weight: number; rationale: string } | null> {
   const raw = (await readGov("get-vote-record", [
     uintCV(proposalId),
     principalCV(voter),
   ], era)) as Record<string, unknown> | null;
   if (!raw) return null;
-  return { support: Boolean(raw.support), weight: num(raw.weight) };
-}
-
-/**
- * A veto record, or null. Returns null on an era without veto rather than
- * calling a function that is not there.
- */
-export async function getVetoRecord(
-  proposalId: number,
-  voter: string,
-  era: LegionEra = LIVE_ERA
-): Promise<{ weight: number } | null> {
-  const caps = await getCapabilities(era);
-  if (!caps.supportsVeto) return null;
-  const raw = (await readGov("get-veto-record", [
-    uintCV(proposalId),
-    principalCV(voter),
-  ], era)) as Record<string, unknown> | null;
-  if (!raw) return null;
-  return { weight: num(raw.weight) };
+  return {
+    support: Boolean(raw.support),
+    weight: num(raw.weight),
+    rationale: String(raw.rationale ?? ""),
+  };
 }
 
 export interface ProposeStatus {
@@ -421,9 +411,12 @@ export interface ProposeStatus {
   slotOpen: boolean;
   noLiveProposal: boolean;
   poolOk: boolean;
+  membersOk: boolean;
+  memberCount: number;
+  membersToActivate: number;
   nextProposeHeight: number;
   lockOnPropose: number;
-  draw: number;
+  payout: number;
   freeWeight: number;
 }
 
@@ -442,19 +435,34 @@ export async function getProposeStatus(
     slotOpen: Boolean(raw.slotOpen),
     noLiveProposal: Boolean(raw.noLiveProposal),
     poolOk: Boolean(raw.poolOk),
+    membersOk: Boolean(raw.membersOk),
+    memberCount: num(raw.memberCount),
+    membersToActivate: num(raw.membersToActivate),
     nextProposeHeight: num(raw.nextProposeHeight),
     lockOnPropose: num(raw.lockOnPropose),
-    draw: num(raw.draw),
+    payout: num(raw.payout),
     freeWeight: num(raw.freeWeight),
   };
 }
 
 /** Why a propose would revert right now, in the caller's words. */
-export function proposeBlockers(status: ProposeStatus, minWeight: number): string[] {
+export function proposeBlockers(
+  status: ProposeStatus,
+  minWeightToAct: number
+): string[] {
   const blockers: string[] = [];
+  if (!status.membersOk) {
+    blockers.push(
+      `the legion is not activated — ${status.memberCount}/${status.membersToActivate} ` +
+        `members hold the minimum weight, so ${
+          status.membersToActivate - status.memberCount
+        } more must join before ANY story can be proposed (u441). ` +
+        `Nothing you do alone clears this gate`
+    );
+  }
   if (!status.eligible) {
     blockers.push(
-      `your weight is below minWeight (${minWeight}) — call legion_contribute first`
+      `your weight is below minWeightToAct (${minWeightToAct}) — call legion_contribute first`
     );
   }
   if (!status.noLiveProposal) {
@@ -468,7 +476,7 @@ export function proposeBlockers(status: ProposeStatus, minWeight: number): strin
     );
   }
   if (!status.poolOk) {
-    blockers.push("the pool is empty or the draw would round to zero sats");
+    blockers.push("the pool is empty or the payout would round to zero sats");
   }
   return blockers;
 }
@@ -481,8 +489,8 @@ export interface StoryTimeline {
   createdAt: number;
   votingOpensAt: number;
   voteEnd: number;
-  /** Absent on an era without veto — conclude opens straight after the vote. */
-  vetoEnd?: number;
+  /** Conclude opens the moment voting closes — there is no veto window. */
+  concludeOpensAt: number;
   concludeDeadline: number;
   currentHeight: number;
   clock: "stacks" | "burn";
@@ -496,23 +504,16 @@ export function buildTimeline(
   height: number,
   clock: "stacks" | "burn"
 ): StoryTimeline {
-  const votingOpensAt = story.createdAt + params.votingDelay;
-  // Without a veto window, conclude opens the moment voting closes.
-  const vetoEnd =
-    params.vetoWindow === undefined ? undefined : story.voteEnd + params.vetoWindow;
-  const concludeOpensAt = vetoEnd ?? story.voteEnd;
-  const concludeDeadline = concludeOpensAt + params.concludeWindow;
-  const nextBoundary = [
-    votingOpensAt,
-    story.voteEnd,
-    ...(vetoEnd === undefined ? [] : [vetoEnd]),
-    concludeDeadline,
-  ].find((boundary) => boundary > height);
+  const votingOpensAt = story.createdAt + params.voteDelay;
+  const concludeDeadline = story.voteEnd + params.concludeWindow;
+  const nextBoundary = [votingOpensAt, story.voteEnd, concludeDeadline].find(
+    (boundary) => boundary > height
+  );
   return {
     createdAt: story.createdAt,
     votingOpensAt,
     voteEnd: story.voteEnd,
-    vetoEnd,
+    concludeOpensAt: story.voteEnd,
     concludeDeadline,
     currentHeight: height,
     clock,
@@ -527,13 +528,12 @@ export interface PredictedOutcome {
   /** True when the outcome is what the contract already recorded, not a forecast. */
   settled: boolean;
   cast: number;
-  quorumPct: number;
   yesPct: number;
-  vetoPct: number;
-  quorumMet: boolean;
+  /** Yes weight the story needs to release its payout: payout × yesMultiple. */
+  yesWeightRequired: number;
+  votersMet: boolean;
   thresholdMet: boolean;
-  vetoed: boolean;
-  participantsMet: boolean;
+  yesMet: boolean;
   payout: number;
 }
 
@@ -554,34 +554,16 @@ export function predictOutcome(
   height: number
 ): PredictedOutcome {
   const cast = story.yesWeight + story.noWeight;
-  const eligible = story.eligibleSnapshot;
-  const quorumPct = eligible > 0 ? Math.floor((cast * 100) / eligible) : 0;
   const yesPct = cast > 0 ? Math.floor((story.yesWeight * 100) / cast) : 0;
-  // An era without veto has no veto weight and no veto quorum: the whole branch
-  // must be skipped, not compared against an absent threshold.
-  const vetoSupported =
-    params.vetoQuorum !== undefined && story.vetoWeight !== undefined;
-  const vetoPct =
-    vetoSupported && eligible > 0
-      ? Math.floor(((story.vetoWeight ?? 0) * 100) / eligible)
-      : 0;
+  const yesWeightRequired = story.payout * params.yesMultiple;
 
-  const participantsMet = story.voterCount >= params.minParticipants;
-  const quorumMet = eligible > 0 && participantsMet && quorumPct >= params.votingQuorum;
+  // The contract's three gates, in its order. There is no quorum here: nothing
+  // divides by totalWeightAtOpen, so a story cannot fail for turnout alone.
+  const votersMet = story.voterCount >= params.minVoters;
   const thresholdMet = cast > 0 && yesPct >= params.votingThreshold;
-  const vetoed =
-    vetoSupported && eligible > 0 && vetoPct >= (params.vetoQuorum ?? 0);
+  const yesMet = story.yesWeight >= yesWeightRequired;
 
-  const base = {
-    cast,
-    quorumPct,
-    yesPct,
-    vetoPct,
-    quorumMet,
-    thresholdMet,
-    vetoed,
-    participantsMet,
-  };
+  const base = { cast, yesPct, yesWeightRequired, votersMet, thresholdMet, yesMet };
 
   // Already terminal: report the record.
   if (story.status !== 0) {
@@ -592,13 +574,11 @@ export function predictOutcome(
       settled: true,
       outcome: settledOutcome,
       reason: story.reason || settledOutcome,
-      payout: story.status === 1 ? story.draw : 0,
+      payout: story.status === 1 ? story.payout : 0,
     };
   }
 
-  const concludeDeadline =
-    story.voteEnd + (params.vetoWindow ?? 0) + params.concludeWindow;
-  if (height >= concludeDeadline) {
+  if (height >= story.voteEnd + params.concludeWindow) {
     return {
       ...base,
       settled: false,
@@ -607,19 +587,20 @@ export function predictOutcome(
       payout: 0,
     };
   }
-  if (vetoed) {
-    return { ...base, settled: false, outcome: "failed", reason: "vetoed", payout: 0 };
-  }
-  if (!quorumMet) {
-    return { ...base, settled: false, outcome: "failed", reason: "no-quorum", payout: 0 };
+  if (!votersMet) {
+    return { ...base, settled: false, outcome: "failed", reason: "no-voters", payout: 0 };
   }
   if (!thresholdMet) {
     return { ...base, settled: false, outcome: "failed", reason: "voted-down", payout: 0 };
   }
-  if (story.draw > poolBalance) {
+  if (!yesMet) {
+    // Approved, but by too little weight to justify the sats it would release.
+    return { ...base, settled: false, outcome: "failed", reason: "yes-short", payout: 0 };
+  }
+  if (story.payout > poolBalance) {
     return { ...base, settled: false, outcome: "failed", reason: "pool-short", payout: 0 };
   }
-  return { ...base, settled: false, outcome: "passed", reason: "paid", payout: story.draw };
+  return { ...base, settled: false, outcome: "passed", reason: "paid", payout: story.payout };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/legion.service.ts
+++ b/src/services/legion.service.ts
@@ -121,19 +121,126 @@ export async function readLegionContract(
   return simplifyCV(deserializeCV(Buffer.from(hex, "hex")));
 }
 
-export function readGov(
+// ---------------------------------------------------------------------------
+// Contract shape assertion
+// ---------------------------------------------------------------------------
+
+/**
+ * Gov functions the tools call, with the arity they are called with.
+ *
+ * Contract ids are constants, so nothing stops a redeploy under the same name
+ * from having a different shape — the reason this legion moved chains in the
+ * first place. Without this check a renamed read surfaces as `undefined` deep
+ * inside a tally, and a changed `vote` arity surfaces as a broadcast that
+ * reverts after paying gas. Checked once per contract per process.
+ */
+const REQUIRED_GOV_FUNCTIONS: Readonly<Record<string, number>> = {
+  // reads
+  "get-params": 0,
+  "get-timing-mode": 0,
+  "get-phase": 1,
+  "get-story": 1,
+  "get-story-meta": 1,
+  "get-last-proposal-id": 0,
+  "get-vote-record": 2,
+  "get-weight": 1,
+  "get-free-weight": 1,
+  "get-locked-weight": 1,
+  "get-locked-until": 1,
+  "get-live-proposal": 1,
+  "get-total-weight": 0,
+  "get-next-propose-height": 0,
+  "get-member-count": 0,
+  "is-activated": 0,
+  "propose-status": 1,
+  "quote-payout": 0,
+  "quote-weight": 1,
+  // writes — arity mismatches here cost gas to discover on chain
+  contribute: 1,
+  "propose-story": 3,
+  vote: 3,
+  conclude: 1,
+};
+
+/** Treasury functions the tools call. `execute-payout` is gov's to call, not ours. */
+const REQUIRED_TREASURY_FUNCTIONS: Readonly<Record<string, number>> = {
+  "get-balance": 0,
+  "get-weighted-balance": 0,
+  "get-min-sponsor": 0,
+  "get-gov": 0,
+  "get-token": 0,
+  "sponsor-in": 4,
+};
+
+/**
+ * Which required functions a published interface fails to satisfy.
+ *
+ * Pure, so the comparison is testable without a chain. Extra functions are
+ * fine — a contract may offer more than we call. Only missing names and
+ * changed arities matter.
+ */
+export function diffContractShape(
+  functions: Array<{ name: string; args: unknown[] }>,
+  required: Readonly<Record<string, number>>
+): string[] {
+  const found = new Map(functions.map((f) => [f.name, f.args.length]));
+  const problems: string[] = [];
+  for (const [name, arity] of Object.entries(required)) {
+    const actual = found.get(name);
+    if (actual === undefined) {
+      problems.push(`missing "${name}"`);
+    } else if (actual !== arity) {
+      problems.push(`"${name}" takes ${actual} args, expected ${arity}`);
+    }
+  }
+  return problems;
+}
+
+/** One in-flight or settled check per contract id. */
+const shapeChecks = new Map<string, Promise<void>>();
+
+async function assertContractShape(
+  contractId: string,
+  required: Readonly<Record<string, number>>,
+  label: string
+): Promise<void> {
+  const cached = shapeChecks.get(contractId);
+  if (cached) return cached;
+  const check = (async () => {
+    const iface = await getHiroApi(LEGION_NETWORK).getContractInterface(contractId);
+    const problems = diffContractShape(iface.functions, required);
+    if (problems.length > 0) {
+      throw new Error(
+        `${contractId} is not the ${label} contract these tools expect: ` +
+          `${problems.join("; ")}. The contract id is a constant in ` +
+          `src/config/legion.ts — either it points at the wrong deployment, or the ` +
+          `legion redeployed with a changed interface and the tools need updating. ` +
+          `Nothing was read or signed.`
+      );
+    }
+  })();
+  shapeChecks.set(contractId, check);
+  // A transient interface fetch failure must not poison the process; only a
+  // successful check is worth keeping.
+  check.catch(() => shapeChecks.delete(contractId));
+  return check;
+}
+
+export async function readGov(
   functionName: string,
   functionArgs: ClarityValue[] = [],
   era: LegionEra = LIVE_ERA
 ): Promise<unknown> {
+  await assertContractShape(era.gov, REQUIRED_GOV_FUNCTIONS, "governance");
   return readLegionContract(era.gov, functionName, functionArgs);
 }
 
-export function readTreasury(
+export async function readTreasury(
   functionName: string,
   functionArgs: ClarityValue[] = [],
   era: LegionEra = LIVE_ERA
 ): Promise<unknown> {
+  await assertContractShape(era.treasury, REQUIRED_TREASURY_FUNCTIONS, "treasury");
   return readLegionContract(era.treasury, functionName, functionArgs);
 }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -212,7 +212,7 @@ export function registerAllTools(server: McpServer): void {
   // AIBTC News (signal feed, leaderboard, file signals)
   registerNewsTools(server);
 
-  // AIBTC News Legion (news-gov-v5 governance — inscribe, propose, vote, veto, conclude)
+  // AIBTC News Legion (mainnet aibtc-news-gov — inscribe, propose, vote, conclude)
   registerLegionTools(server);
 
   // Identity (ERC-8004 on-chain agent identity management)

--- a/src/tools/legion.tools.ts
+++ b/src/tools/legion.tools.ts
@@ -1,13 +1,21 @@
 /**
- * AIBTC News Legion tools (news-gov-v5).
+ * AIBTC News Legion tools (mainnet `aibtc-news-gov`).
  *
- * Lifecycle: inscribe → reveal → propose → vote → veto → conclude, plus
- * contribute (buys weight) and sponsor (does not).
+ * Lifecycle: inscribe → reveal → propose → vote → conclude, plus contribute
+ * (buys weight) and sponsor (does not). There is no veto in this era: voting no
+ * while the window is open is the only way to stop a piece.
+ *
+ * EVERYTHING HERE MOVES REAL VALUE. The legion is on Stacks mainnet holding
+ * real sBTC, and neither `contribute` nor `sponsor` has a withdrawal path, so
+ * both meter against the wallet's `sats` spending rail before signing —
+ * `callContract` is not itself a metered chokepoint, but these two take the
+ * amount as a direct parameter, which is what the rail needs.
  *
  * These tools pin their own network: `getLegionAccount()` re-derives the
- * unlocked wallet for the legion's chain, so a mainnet-configured server signs
- * against testnet. Inscription is the exception — real BTC on whatever chain
- * NETWORK names.
+ * unlocked wallet for the legion's chain, so a testnet-configured server still
+ * signs against the mainnet contracts rather than quietly reading a chain the
+ * legion does not live on. Inscription is the exception — it follows the global
+ * NETWORK, because ordinals.com indexes Bitcoin mainnet only.
  *
  * Fund-moving calls sign in DENY mode with an exact post-condition.
  */
@@ -51,17 +59,16 @@ import {
   buildTimeline,
   contentUrlFromLink,
   explainError,
-  getCapabilities,
   getClockHeight,
   getLastProposalId,
   getLegionAccount,
   getLegionToken,
+  getMembership,
   getParams,
   getPhase,
   getProposeStatus,
   getStory,
   getStoryMeta,
-  getVetoRecord,
   getVoteRecord,
   inscriptionIdFromLink,
   normalizeOrdinalsLink,
@@ -73,6 +80,7 @@ import {
   readTreasury,
 } from "../services/legion.service.js";
 import { callContract } from "../transactions/builder.js";
+import { getSpendLimiter } from "../services/spend-limiter.js";
 import { getWalletManager } from "../services/wallet-manager.js";
 import { MempoolApi, getMempoolTxUrl } from "../services/mempool-api.js";
 import {
@@ -124,10 +132,10 @@ const LARGE_INSCRIPTION_WARN_BYTES = 100_000;
 /**
  * Phases that mean the piece is still moving, for the `live` list filter.
  * `pending` is a phase, not a stored status — a proposal is OPEN in storage
- * from the moment it is filed, but voting does not open until votingDelay
+ * from the moment it is filed, but voting does not open until voteDelay
  * blocks later.
  */
-const LIVE_PHASES = ["pending", "voting", "veto", "concludable"];
+const LIVE_PHASES = ["pending", "voting", "concludable"];
 
 /** Errors surface as sentences, with the contract's `uXXX` still attached. */
 function legionError(error: unknown) {
@@ -240,8 +248,11 @@ export function registerLegionTools(server: McpServer): void {
     "legion_status",
     {
       description:
-        "News Legion at a glance: sBTC pool, total weight, governance params read from the " +
-        "contract, current height, and your own weight if a wallet is unlocked. Start here.\n\n" +
+        "News Legion at a glance: sBTC pool, total weight, membership and whether the legion " +
+        "is ACTIVATED yet, governance params read from the contract, current height, and your " +
+        "own weight if a wallet is unlocked. Start here.\n\n" +
+        "No story can be proposed until the legion reaches its member threshold, so check " +
+        "`membership.activated` before planning to publish.\n\n" +
         `Reads only. Runs on Stacks ${LEGION_NETWORK} regardless of this server's NETWORK.`,
       inputSchema: { era: eraInput },
     },
@@ -256,9 +267,10 @@ export function registerLegionTools(server: McpServer): void {
           totalWeight,
           lastProposalId,
           nextProposeHeight,
-          quoteDraw,
+          quotePayout,
           minSponsor,
           govWiring,
+          membership,
         ] = await Promise.all([
           getParams(era),
           getClockHeight(era),
@@ -267,11 +279,11 @@ export function registerLegionTools(server: McpServer): void {
           readGov("get-total-weight", [], era),
           getLastProposalId(era),
           readGov("get-next-propose-height", [], era),
-          readGov("quote-draw", [], era),
+          readGov("quote-payout", [], era),
           readTreasury("get-min-sponsor", [], era),
           readTreasury("get-gov", [], era),
+          getMembership(era),
         ]);
-        const caps = await getCapabilities(era);
 
         const walletManager = getWalletManager();
         let you: Record<string, unknown> | undefined;
@@ -301,8 +313,6 @@ export function registerLegionTools(server: McpServer): void {
           era: {
             version: era.version,
             live: era.live,
-            supportsVeto: caps.supportsVeto,
-            voteNeedsRationale: caps.voteNeedsRationale,
             known: LEGION_ERAS.map((e) => ({ version: e.version, live: e.live })),
             note: era.live
               ? undefined
@@ -326,23 +336,36 @@ export function registerLegionTools(server: McpServer): void {
             sponsoredSats: num(pool) - num(weighted),
             note:
               "New weight is priced against weightedBalance (contributed sats only), " +
-              "so sponsorships never raise the cost of joining — but the draw is a " +
+              "so sponsorships never raise the cost of joining — but the payout is a " +
               "fraction of the WHOLE pool, so they do enlarge every payout.",
+          },
+          membership: {
+            ...membership,
+            note: membership.activated
+              ? "The legion is activated — proposals are open."
+              : `NOT ACTIVATED. ${membership.membersNeeded} more principals must each hold ` +
+                `at least ${params.minWeightToAct} weight before any story can be proposed ` +
+                `(u441). Contributing more sats yourself does not help — the gate counts ` +
+                `distinct members, not weight.`,
           },
           governance: {
             totalWeight: num(totalWeight),
             lastProposalId,
             nextProposeHeight: num(nextProposeHeight),
             proposeSlotOpen: num(nextProposeHeight) <= clock.height,
-            currentDrawSats: num(quoteDraw),
+            currentPayoutSats: num(quotePayout),
             minSponsorSats: num(minSponsor),
             params,
+            howAStoryPasses:
+              `At least ${params.minVoters} distinct voter(s), at least ` +
+              `${params.votingThreshold}% of cast weight voting yes, AND yes weight of at ` +
+              `least ${params.yesMultiple}x the payout. There is no quorum and no veto.`,
           },
           you,
           nextSteps: [
             "legion_list_stories — what is open for a vote right now",
-            "legion_my_position — your weight, bond and whether you can propose",
-            "legion_contribute — buy voting weight with sBTC",
+            "legion_my_position — your weight, lock and whether you can propose",
+            "legion_contribute — buy voting weight with sBTC (spends real sBTC, no refund)",
             "legion_sponsor — fund the pool without buying a vote",
           ],
         });
@@ -361,7 +384,7 @@ export function registerLegionTools(server: McpServer): void {
     {
       description:
         "Proposals newest first, with phase, tally and the inscription each points at.\n\n" +
-        "Phases: `pending` (filed, voting not open yet), `voting`, `veto`, `concludable`, " +
+        "Phases: `pending` (filed, voting not open yet), `voting`, `concludable`, " +
         "`passed`/`failed` (settled), `expired` (nobody concluded in time; can no longer pay).\n\n" +
         "Reads only.",
       inputSchema: {
@@ -371,7 +394,6 @@ export function registerLegionTools(server: McpServer): void {
             "live",
             "pending",
             "voting",
-            "veto",
             "concludable",
             "passed",
             "failed",
@@ -379,7 +401,7 @@ export function registerLegionTools(server: McpServer): void {
           ])
           .optional()
           .describe(
-            "Filter by phase. 'live' means pending+voting+veto+concludable. Default: all"
+            "Filter by phase. 'live' means pending+voting+concludable. Default: all"
           ),
         limit: z
           .number()
@@ -441,13 +463,13 @@ export function registerLegionTools(server: McpServer): void {
               inscriptionId: meta ? inscriptionIdFromLink(meta.link) : null,
               contentUrl: meta ? contentUrlFromLink(meta.link) : null,
               proposer: story.proposer,
-              drawSats: story.draw,
+              payoutSats: story.payout,
               tally: {
                 yes: story.yesWeight,
                 no: story.noWeight,
-                veto: story.vetoWeight,
+                yesNeeded: prediction.yesWeightRequired,
                 voters: story.voterCount,
-                eligible: story.eligibleSnapshot,
+                totalWeightAtOpen: story.totalWeightAtOpen,
               },
               blocksUntilNextTransition: timeline.blocksUntilNextTransition,
               ifConcludedNow: prediction.settled
@@ -493,8 +515,8 @@ export function registerLegionTools(server: McpServer): void {
     "legion_get_story",
     {
       description:
-        "One proposal in full: tally against the quorum and threshold it must clear, the " +
-        "window timeline, what `conclude` would decide now, and whether you have voted.\n\n" +
+        "One proposal in full: the tally against all three gates it must clear, the window " +
+        "timeline, what `conclude` would decide now, and whether you have voted.\n\n" +
         "Read this before voting — the contract cannot read the inscription, so judging the " +
         "work is the voter's job.\n\nReads only.",
       inputSchema: {
@@ -505,7 +527,6 @@ export function registerLegionTools(server: McpServer): void {
     async ({ proposalId, era: eraArg }) => {
       try {
         const era = resolveEra(eraArg);
-        const caps = await getCapabilities(era);
         const [params, clock, story, meta, storyPhase, pool] = await Promise.all([
           getParams(era),
           getClockHeight(era),
@@ -531,9 +552,8 @@ export function registerLegionTools(server: McpServer): void {
         let you: Record<string, unknown> | undefined;
         if (walletManager.isUnlocked() || process.env.CLIENT_MNEMONIC) {
           const account = await getLegionAccount();
-          const [voteRecord, vetoRecord, weight] = await Promise.all([
+          const [voteRecord, weight] = await Promise.all([
             getVoteRecord(proposalId, account.address, era),
-            getVetoRecord(proposalId, account.address, era),
             readGov("get-weight", [principalCV(account.address)], era),
           ]);
           you = {
@@ -541,17 +561,11 @@ export function registerLegionTools(server: McpServer): void {
             weight: num(weight),
             isProposer: account.address === story.proposer,
             voted: voteRecord,
-            vetoed: vetoRecord,
             canVoteNow:
               storyPhase === "voting" &&
               !voteRecord &&
               account.address !== story.proposer &&
-              num(weight) >= params.minWeight,
-            canVetoNow:
-              caps.supportsVeto &&
-              storyPhase === "veto" &&
-              !vetoRecord &&
-              num(weight) >= params.minWeight,
+              num(weight) >= params.minWeightToAct,
             canConcludeNow: storyPhase === "concludable",
           };
         }
@@ -559,7 +573,7 @@ export function registerLegionTools(server: McpServer): void {
         return createJsonResponse({
           proposalId,
           network: LEGION_NETWORK,
-          era: { version: era.version, live: era.live, supportsVeto: caps.supportsVeto },
+          era: { version: era.version, live: era.live },
           phase: storyPhase,
           status: STORY_STATUS[story.status],
           reason: story.reason || undefined,
@@ -569,39 +583,49 @@ export function registerLegionTools(server: McpServer): void {
           inscriptionId: meta ? inscriptionIdFromLink(meta.link) : null,
           contentUrl: meta ? contentUrlFromLink(meta.link) : null,
           proposer: story.proposer,
-          drawSats: story.draw,
-          bondWeight: story.bond,
+          payoutSats: story.payout,
+          lockedWeight: story.lockedWeight,
           tally: {
             yesWeight: story.yesWeight,
             noWeight: story.noWeight,
-            vetoWeight: caps.supportsVeto ? story.vetoWeight : undefined,
             castWeight: prediction.cast,
             voterCount: story.voterCount,
-            eligibleSnapshot: story.eligibleSnapshot,
+            totalWeightAtOpen: story.totalWeightAtOpen,
           },
-          thresholds: {
-            quorumPct: prediction.quorumPct,
-            quorumRequiredPct: params.votingQuorum,
-            quorumMet: prediction.quorumMet,
-            yesPct: prediction.yesPct,
-            thresholdRequiredPct: params.votingThreshold,
-            thresholdMet: prediction.thresholdMet,
-            vetoPct: caps.supportsVeto ? prediction.vetoPct : undefined,
-            vetoQuorumPct: params.vetoQuorum,
-            vetoed: caps.supportsVeto ? prediction.vetoed : undefined,
-            participants: `${story.voterCount}/${params.minParticipants}`,
-            participantsMet: prediction.participantsMet,
+          // The three gates conclude applies, in the contract's own order. There
+          // is no quorum: turnout alone can never fail a piece here.
+          gates: {
+            voters: {
+              have: story.voterCount,
+              need: params.minVoters,
+              met: prediction.votersMet,
+              failsAs: "no-voters",
+            },
+            threshold: {
+              yesPct: prediction.yesPct,
+              needPct: params.votingThreshold,
+              met: prediction.thresholdMet,
+              failsAs: "voted-down",
+            },
+            yesWeight: {
+              have: story.yesWeight,
+              need: prediction.yesWeightRequired,
+              met: prediction.yesMet,
+              failsAs: "yes-short",
+              explanation:
+                `Yes weight must cover ${params.yesMultiple}x the ${story.payout} sat payout. ` +
+                `A piece can be approved ${params.votingThreshold}%+ and still fail here — ` +
+                `that is the brake on a thin majority voting money out of a large pool.`,
+            },
           },
           timeline: {
             ...timeline,
             explanation:
               `Filed at ${timeline.createdAt}. Voting opens at ${timeline.votingOpensAt} ` +
-              `and closes at ${timeline.voteEnd}. ` +
-              (timeline.vetoEnd === undefined
-                ? `This era has no veto window, so conclude opens as soon as voting closes. `
-                : `Veto runs until ${timeline.vetoEnd}. `) +
-              `Conclude must be called before ${timeline.concludeDeadline} — after that ` +
-              `the piece has expired and can no longer be concluded at all.`,
+              `and closes at ${timeline.voteEnd}. There is no veto window, so conclude opens ` +
+              `as soon as voting closes. Conclude must be called before ` +
+              `${timeline.concludeDeadline} — after that the piece has expired and can no ` +
+              `longer be concluded at all.`,
           },
           outcome: {
             settled: prediction.settled,
@@ -629,7 +653,7 @@ export function registerLegionTools(server: McpServer): void {
     "legion_my_position",
     {
       description:
-        "Your weight, share, bond lock, sBTC balance, and every propose precondition folded " +
+        "Your weight, share, weight lock, sBTC balance, and every propose precondition folded " +
         "from the contract's `propose-status` — so a blocked propose names the gate to wait on.\n\n" +
         "Requires an unlocked wallet. Signs nothing.",
       inputSchema: { era: eraInput },
@@ -638,21 +662,22 @@ export function registerLegionTools(server: McpServer): void {
       try {
         const era = resolveEra(eraArg);
         const account = await getLegionAccount();
-        const [params, clock, weight, freeWeight, locked, liveProposal, totalWeight, proposeStatus, balance, quoteDraw] =
+        const [params, clock, weight, freeWeight, locked, lockedUntil, liveProposal, totalWeight, proposeStatus, balance, quotePayout] =
           await Promise.all([
             getParams(era),
             getClockHeight(era),
             readGov("get-weight", [principalCV(account.address)], era),
             readGov("get-free-weight", [principalCV(account.address)], era),
-            readGov("locked-of", [principalCV(account.address)], era),
+            readGov("get-locked-weight", [principalCV(account.address)], era),
+            readGov("get-locked-until", [principalCV(account.address)], era),
             readGov("get-live-proposal", [principalCV(account.address)], era),
             readGov("get-total-weight", [], era),
             getProposeStatus(account.address, era),
             sbtcBalance(account.address, era),
-            readGov("quote-draw", [], era),
+            readGov("quote-payout", [], era),
           ]);
 
-        const blockers = proposeBlockers(proposeStatus, params.minWeight);
+        const blockers = proposeBlockers(proposeStatus, params.minWeightToAct);
 
         return createJsonResponse({
           address: account.address,
@@ -662,6 +687,7 @@ export function registerLegionTools(server: McpServer): void {
           weight: num(weight),
           freeWeight: num(freeWeight),
           lockedWeight: num(locked),
+          lockedUntilHeight: num(lockedUntil),
           sharePct:
             num(totalWeight) > 0
               ? Number(((num(weight) * 100) / num(totalWeight)).toFixed(4))
@@ -669,74 +695,27 @@ export function registerLegionTools(server: McpServer): void {
           totalWeight: num(totalWeight),
           sbtcBalanceSats: balance,
           liveProposalId: liveProposal === null ? null : num(liveProposal),
-          canVote: num(weight) >= params.minWeight,
+          canVote: num(weight) >= params.minWeightToAct,
+          isMember: num(weight) >= params.minWeightToAct,
+          membership: {
+            memberCount: proposeStatus.memberCount,
+            membersToActivate: proposeStatus.membersToActivate,
+            activated: proposeStatus.membersOk,
+          },
           propose: {
             canPropose: proposeStatus.canPropose,
             blockers: blockers.length > 0 ? blockers : undefined,
             weightLockedOnPropose: proposeStatus.lockOnPropose,
-            wouldPaySats: proposeStatus.draw,
+            wouldPaySats: proposeStatus.payout,
             nextProposeHeight: proposeStatus.nextProposeHeight,
             note:
               "Proposing locks your ENTIRE weight until the piece resolves. The lock is " +
               "never spent and never reduces your voting power — it exists only to enforce " +
               "one live proposal per principal, and releases on every outcome.",
           },
-          currentDrawSats: num(quoteDraw),
-          minWeightToVoteOrPropose: params.minWeight,
-          minContributionSats: params.minContribution,
-        });
-      } catch (error) {
-        return legionError(error);
-      }
-    }
-  );
-
-  // ==========================================================================
-  // legion_faucet — testnet sBTC
-  // ==========================================================================
-
-  server.registerTool(
-    "legion_faucet",
-    {
-      description:
-        "Mint testnet sBTC from the faucet on this legion's token contract.\n\n" +
-        "Testnet only. Requires an unlocked wallet.",
-      inputSchema: {},
-    },
-    async () => {
-      try {
-        if (LEGION_NETWORK !== "testnet") {
-          return createErrorResponse(
-            new Error(
-              `The legion is on ${LEGION_NETWORK}, which has no sBTC faucet. ` +
-                `Acquire sBTC with sbtc_deposit or styx_deposit instead.`
-            )
-          );
-        }
-        const account = await getLegionAccount();
-        const token = await getLegionToken();
-        const [tokenAddress, tokenName] = token.contract.split(".");
-
-        const result = await callContract(account, {
-          contractAddress: tokenAddress,
-          contractName: tokenName,
-          functionName: "faucet",
-          functionArgs: [],
-          // A faucet mints rather than transfers, and mints have no sender to
-          // write a condition against.
-          postConditionMode: PostConditionMode.Allow,
-          postConditions: [],
-        });
-
-        return createJsonResponse({
-          success: true,
-          txid: result.txid,
-          explorerUrl: explorerUrl(result.txid),
-          address: account.address,
-          token: token.contract,
-          network: LEGION_NETWORK,
-          nextStep:
-            "Once it confirms, call legion_contribute to turn sBTC into voting weight.",
+          currentPayoutSats: num(quotePayout),
+          minWeightToVoteOrPropose: params.minWeightToAct,
+          minJoinSats: params.minJoinSats,
         });
       } catch (error) {
         return legionError(error);
@@ -754,8 +733,13 @@ export function registerLegionTools(server: McpServer): void {
       description:
         "Send sBTC to the pool and receive voting weight proportional to your share of the " +
         "contributed balance.\n\n" +
-        "NOT REFUNDABLE — you get a say in which pieces get paid, not a claim on the pool. " +
-        "To fund the pool without a vote, use legion_sponsor.\n\n" +
+        "SPENDS REAL sBTC AND IS NOT REFUNDABLE — you get a say in which pieces get paid, not " +
+        "a claim on the pool. There is no withdrawal function. To fund the pool without a " +
+        "vote, use legion_sponsor.\n\n" +
+        "Metered against the wallet's `sats` spending limit before signing, so a large " +
+        "contribution blocks until you raise SPEND_LIMIT_SESSION_SATS.\n\n" +
+        "Crossing the minimum weight also makes you a MEMBER, which is what unlocks proposals " +
+        "for the whole legion once enough members join.\n\n" +
         "Requires an unlocked wallet.",
       inputSchema: {
         sats: z
@@ -768,18 +752,19 @@ export function registerLegionTools(server: McpServer): void {
     async ({ sats }) => {
       try {
         const account = await getLegionAccount();
-        const [params, token, balance, weightBefore] = await Promise.all([
+        const [params, token, balance, weightBefore, membership] = await Promise.all([
           getParams(),
           getLegionToken(),
           sbtcBalance(account.address),
           readGov("get-weight", [principalCV(account.address)]),
+          getMembership(),
         ]);
 
-        if (sats < params.minContribution) {
+        if (sats < params.minJoinSats) {
           return createErrorResponse(
             new Error(
               `${sats} sats is below the legion's minimum contribution of ` +
-                `${params.minContribution} sats (u437).`
+                `${params.minJoinSats} sats (u437).`
             )
           );
         }
@@ -787,12 +772,15 @@ export function registerLegionTools(server: McpServer): void {
           return createErrorResponse(
             new Error(
               `Your sBTC balance is ${balance} sats — not enough to contribute ${sats}. ` +
-                (LEGION_NETWORK === "testnet"
-                  ? "Call legion_faucet for testnet sBTC."
-                  : "Acquire sBTC first.")
+                `Acquire sBTC with sbtc_deposit or styx_deposit first.`
             )
           );
         }
+
+        // Real, unrecoverable sBTC leaves the wallet here. callContract is not
+        // itself a metered chokepoint, but the amount is a direct parameter, so
+        // the rail applies cleanly — and must, before anything is signed.
+        await getSpendLimiter().check("sats", BigInt(sats), account.address);
 
         const quotedWeight = num(await readGov("quote-weight", [uintCV(sats)]));
 
@@ -809,6 +797,12 @@ export function registerLegionTools(server: McpServer): void {
           ],
         });
 
+        await getSpendLimiter().record("sats", BigInt(sats), account.address);
+
+        const weightAfter = num(weightBefore) + quotedWeight;
+        const wasMember = num(weightBefore) >= params.minWeightToAct;
+        const willBeMember = weightAfter >= params.minWeightToAct;
+
         return createJsonResponse({
           success: true,
           txid: result.txid,
@@ -817,13 +811,23 @@ export function registerLegionTools(server: McpServer): void {
           contributedSats: sats,
           expectedWeightMinted: quotedWeight,
           weightBefore: num(weightBefore),
-          expectedWeightAfter: num(weightBefore) + quotedWeight,
+          expectedWeightAfter: weightAfter,
           network: LEGION_NETWORK,
-          warning: "Contributions are final. There is no withdrawal path.",
-          nextStep:
-            quotedWeight + num(weightBefore) >= params.minWeight
+          membership: {
+            joiningAsNewMember: !wasMember && willBeMember,
+            memberCountBefore: membership.memberCount,
+            membersToActivate: membership.membersToActivate,
+            activated: membership.activated,
+          },
+          warning:
+            "Contributions are final and spend real sBTC. There is no withdrawal path.",
+          nextStep: willBeMember
+            ? membership.activated
               ? "Once it confirms you can legion_vote and legion_propose_story."
-              : `You will still be below minWeight (${params.minWeight}) — contribute more to vote or propose.`,
+              : `Once it confirms you can legion_vote. Proposing stays blocked until the ` +
+                `legion reaches ${membership.membersToActivate} members (u441).`
+            : `You will still be below minWeightToAct (${params.minWeightToAct}) — contribute ` +
+              `more to vote or propose.`,
         });
       } catch (error) {
         return legionError(error);
@@ -841,9 +845,10 @@ export function registerLegionTools(server: McpServer): void {
       description:
         "Fund the pool WITHOUT minting voting weight, with a name on the record.\n\n" +
         "Does not raise the price of joining (weight is priced against contributed sats only), " +
-        "but does enlarge every payout, since the draw is a fraction of the whole pool.\n\n" +
+        "but does enlarge every payout, since the payout is a fraction of the whole pool.\n\n" +
         "`name`, `link` and `memo` are unverified — the paying principal and txid are the real " +
-        "identity. FINAL: no refund path exists.\n\n" +
+        "identity. SPENDS REAL sBTC AND IS FINAL: no refund path exists.\n\n" +
+        "Metered against the wallet's `sats` spending limit before signing.\n\n" +
         "Requires an unlocked wallet.",
       inputSchema: {
         sats: z
@@ -878,7 +883,7 @@ export function registerLegionTools(server: McpServer): void {
         const [token, minSponsor, balance] = await Promise.all([
           getLegionToken(),
           readTreasury("get-min-sponsor"),
-          sbtcBalance((await getLegionAccount()).address),
+          sbtcBalance(account.address),
         ]);
 
         if (sats < num(minSponsor)) {
@@ -896,6 +901,9 @@ export function registerLegionTools(server: McpServer): void {
             )
           );
         }
+
+        // Same rail as contribute: real sBTC, no refund, amount is a direct param.
+        await getSpendLimiter().check("sats", BigInt(sats), account.address);
 
         const result = await callContract(account, {
           contractAddress: TREASURY_ADDRESS,
@@ -915,6 +923,8 @@ export function registerLegionTools(server: McpServer): void {
           ],
         });
 
+        await getSpendLimiter().record("sats", BigInt(sats), account.address);
+
         return createJsonResponse({
           success: true,
           txid: result.txid,
@@ -927,7 +937,7 @@ export function registerLegionTools(server: McpServer): void {
           mintedWeight: 0,
           network: LEGION_NETWORK,
           warning:
-            "Final. No refund path exists. This mints no voting weight — use " +
+            "Final. Real sBTC, and no refund path exists. This mints no voting weight — use " +
             "legion_contribute if you wanted a vote.",
           note:
             "How long a sponsor badge shows is decided off-chain by the reader at " +
@@ -947,8 +957,10 @@ export function registerLegionTools(server: McpServer): void {
     "legion_propose_story",
     {
       description:
-        "Open a vote on one inscribed piece. If it passes, YOU are paid the draw — the " +
+        "Open a vote on one inscribed piece. If it passes, YOU are paid the payout — the " +
         "proposer is the only reachable payee.\n\n" +
+        "The legion must be ACTIVATED first: until it reaches its member threshold, every " +
+        "propose reverts (u441) no matter how much weight you hold. Check legion_status.\n\n" +
         "The contract stores link, title and description verbatim and never reads the " +
         "inscription. Proposing locks your ENTIRE weight until the piece resolves — one live " +
         "proposal per principal; the lock is never spent and releases on every outcome.\n\n" +
@@ -993,7 +1005,7 @@ export function registerLegionTools(server: McpServer): void {
         ]);
 
         if (!proposeStatus.canPropose) {
-          const blockers = proposeBlockers(proposeStatus, params.minWeight);
+          const blockers = proposeBlockers(proposeStatus, params.minWeightToAct);
           return createErrorResponse(
             new Error(
               `Cannot propose right now: ${blockers.join("; ")}. ` +
@@ -1011,13 +1023,13 @@ export function registerLegionTools(server: McpServer): void {
             stringAsciiCV(title),
             stringAsciiCV(body),
           ],
-          // The bond is weight, not sats: no sBTC moves on propose, so DENY with
+          // The lock is weight, not sats: no sBTC moves on propose, so DENY with
           // no conditions is exactly right.
           postConditionMode: PostConditionMode.Deny,
           postConditions: [],
         });
 
-        const votingOpensAt = clock.height + params.votingDelay;
+        const votingOpensAt = clock.height + params.voteDelay;
         const voteEnd = votingOpensAt + params.voteWindow;
 
         return createJsonResponse({
@@ -1031,23 +1043,22 @@ export function registerLegionTools(server: McpServer): void {
           description: body,
           network: LEGION_NETWORK,
           weightLocked: proposeStatus.lockOnPropose,
-          expectedDrawSats: proposeStatus.draw,
+          expectedPayoutSats: proposeStatus.payout,
+          yesWeightNeeded: proposeStatus.payout * params.yesMultiple,
           expectedTimeline: {
             note: "Approximate — the contract snapshots these at the block that mines the tx.",
             filedAtAbout: clock.height,
             votingOpensAbout: votingOpensAt,
             voteEndsAbout: voteEnd,
-            vetoEndsAbout:
-              params.vetoWindow === undefined
-                ? undefined
-                : voteEnd + params.vetoWindow,
-            concludeDeadlineAbout:
-              voteEnd + (params.vetoWindow ?? 0) + params.concludeWindow,
+            concludeDeadlineAbout: voteEnd + params.concludeWindow,
             clock: `${clock.clock} blocks`,
           },
           nextSteps: [
             "legion_list_stories to pick up the assigned proposalId once it confirms",
-            `Votes cannot be cast for ~${params.votingDelay} blocks (the pending period)`,
+            `Votes cannot be cast for ~${params.voteDelay} blocks (the pending period)`,
+            `To be paid, this needs ${params.minVoters}+ voter(s), ${params.votingThreshold}% ` +
+              `yes, AND at least ${proposeStatus.payout * params.yesMultiple} yes weight — ` +
+              `you cannot vote for your own piece, so that weight must come from others`,
             "Someone must call legion_conclude inside the conclude window or the piece expires and pays nobody",
           ],
         });
@@ -1065,11 +1076,11 @@ export function registerLegionTools(server: McpServer): void {
     "legion_vote",
     {
       description:
-        "Vote yes or no with your current weight. One vote per principal; a proposer cannot " +
-        "vote on their own piece.\n\n" +
+        "Vote yes or no with your current weight, with a written rationale recorded on chain. " +
+        "One vote per principal; a proposer cannot vote on their own piece. Votes cannot be " +
+        "changed.\n\n" +
+        "Voting no is the ONLY way to stop a piece — this legion has no veto.\n\n" +
         "Read the inscription first — legion_get_story gives you the link.\n\n" +
-        "v6 and later require a non-empty `rationale` recorded on chain with the vote; on " +
-        "earlier eras the contract has no such argument and it is ignored.\n\n" +
         "Pre-flights phase, weight and prior vote. Requires an unlocked wallet.",
       inputSchema: {
         proposalId: z.number().int().positive().describe("The proposal id"),
@@ -1078,18 +1089,17 @@ export function registerLegionTools(server: McpServer): void {
           .describe("true = yes (pay this piece), false = no"),
         rationale: z
           .string()
+          .min(1)
           .max(MAX_RATIONALE_LENGTH)
-          .optional()
           .describe(
             `Why you voted this way, recorded on chain (ASCII, ≤${MAX_RATIONALE_LENGTH} chars). ` +
-              "Required on v6 and later; ignored on eras whose vote takes no rationale."
+              "Required and must be non-empty — the contract rejects a blank one (u440)."
           ),
       },
     },
     async ({ proposalId, support, rationale }) => {
       try {
         const account = await getLegionAccount();
-        const caps = await getCapabilities();
         const [params, story, storyPhase, weight, existingVote, clock] =
           await Promise.all([
             getParams(),
@@ -1100,18 +1110,15 @@ export function registerLegionTools(server: McpServer): void {
             getClockHeight(),
           ]);
 
-        if (caps.voteNeedsRationale) {
-          if (!rationale || rationale.trim().length === 0) {
-            return createErrorResponse(
-              new Error(
-                `Legion v${LIVE_ERA.version} records a rationale with every vote and rejects ` +
-                  `an empty one (u440). Pass rationale — a sentence on why this piece is or ` +
-                  `is not worth paying for. Nothing was signed.`
-              )
-            );
-          }
-          assertAscii(rationale, "rationale", MAX_RATIONALE_LENGTH);
+        if (rationale.trim().length === 0) {
+          return createErrorResponse(
+            new Error(
+              `The rationale cannot be blank (u440). Pass a sentence on why this piece is ` +
+                `or is not worth paying for. Nothing was signed.`
+            )
+          );
         }
+        assertAscii(rationale, "rationale", MAX_RATIONALE_LENGTH);
 
         if (!story) {
           return createErrorResponse(
@@ -1130,12 +1137,13 @@ export function registerLegionTools(server: McpServer): void {
           return createErrorResponse(
             new Error(
               `You are the proposer of ${proposalId} and cannot vote on your own piece (u423). ` +
-                `You may still legion_veto it to withdraw it.`
+                `This era has no veto either, so there is no way to withdraw it — let it run ` +
+                `or let the conclude window lapse.`
             )
           );
         }
         if (storyPhase === "pending") {
-          const opensAt = story.createdAt + params.votingDelay;
+          const opensAt = story.createdAt + params.voteDelay;
           return createErrorResponse(
             new Error(
               `Proposal ${proposalId} is still pending — voting opens at height ${opensAt}, ` +
@@ -1147,17 +1155,15 @@ export function registerLegionTools(server: McpServer): void {
           return createErrorResponse(
             new Error(
               `Proposal ${proposalId} is in the "${storyPhase}" phase — voting is closed (u407). ` +
-                (storyPhase === "veto"
-                  ? "You can still legion_veto it."
-                  : "Nothing was signed.")
+                `Nothing was signed.`
             )
           );
         }
-        if (num(weight) < params.minWeight) {
+        if (num(weight) < params.minWeightToAct) {
           return createErrorResponse(
             new Error(
-              `Your weight is ${num(weight)}, below the minWeight of ${params.minWeight} (u401). ` +
-                `Call legion_contribute first.`
+              `Your weight is ${num(weight)}, below the minWeightToAct of ` +
+                `${params.minWeightToAct} (u401). Call legion_contribute first.`
             )
           );
         }
@@ -1166,13 +1172,18 @@ export function registerLegionTools(server: McpServer): void {
           contractAddress: GOV_ADDRESS,
           contractName: GOV_NAME,
           functionName: "vote",
-          functionArgs: caps.voteNeedsRationale
-            ? [uintCV(proposalId), boolCV(support), stringAsciiCV(rationale ?? "")]
-            : [uintCV(proposalId), boolCV(support)],
+          functionArgs: [
+            uintCV(proposalId),
+            boolCV(support),
+            stringAsciiCV(rationale),
+          ],
           // Voting moves nothing.
           postConditionMode: PostConditionMode.Deny,
           postConditions: [],
         });
+
+        const yesAfter = support ? story.yesWeight + num(weight) : story.yesWeight;
+        const yesNeeded = story.payout * params.yesMultiple;
 
         return createJsonResponse({
           success: true,
@@ -1181,118 +1192,16 @@ export function registerLegionTools(server: McpServer): void {
           proposalId,
           era: LIVE_ERA.version,
           support,
-          rationale: caps.voteNeedsRationale ? rationale : undefined,
+          rationale,
           votedWith: num(weight),
           voter: account.address,
           network: LEGION_NETWORK,
           voteEnd: story.voteEnd,
           blocksLeftToVote: story.voteEnd - clock.height,
+          yesWeightAfter: yesAfter,
+          yesWeightNeeded: yesNeeded,
+          yesWeightMet: yesAfter >= yesNeeded,
           note: "One vote per principal — this cannot be changed or withdrawn.",
-        });
-      } catch (error) {
-        return legionError(error);
-      }
-    }
-  );
-
-  // ==========================================================================
-  // legion_veto
-  // ==========================================================================
-
-  server.registerTool(
-    "legion_veto",
-    {
-      description:
-        "Object during the veto window. At veto quorum the piece fails regardless of the vote — " +
-        "the backstop against a plagiarised or junk inscription that slipped past. A proposer " +
-        "may veto their own piece, which withdraws it.\n\n" +
-        "Pre-flights the window and your weight. Requires an unlocked wallet.",
-      inputSchema: {
-        proposalId: z.number().int().positive().describe("The proposal id"),
-      },
-    },
-    async ({ proposalId }) => {
-      try {
-        const account = await getLegionAccount();
-        const caps = await getCapabilities();
-        const [params, story, storyPhase, weight, existingVeto, clock] =
-          await Promise.all([
-            getParams(),
-            getStory(proposalId),
-            getPhase(proposalId),
-            readGov("get-weight", [principalCV(account.address)]),
-            getVetoRecord(proposalId, account.address),
-            getClockHeight(),
-          ]);
-
-        if (!story) {
-          return createErrorResponse(
-            new Error(`No proposal ${proposalId} in this legion (u404).`)
-          );
-        }
-        if (existingVeto) {
-          return createErrorResponse(
-            new Error(
-              `You already vetoed proposal ${proposalId} with ${existingVeto.weight} weight (u425).`
-            )
-          );
-        }
-        if (!caps.supportsVeto) {
-          return createErrorResponse(
-            new Error(
-              `Legion v${LIVE_ERA.version} has no veto — the function does not exist on ` +
-                `${LIVE_ERA.gov}. Vote no with legion_vote while voting is open; that is the ` +
-                `only way to stop a piece in this era. Nothing was signed.`
-            )
-          );
-        }
-        if (storyPhase !== "veto") {
-          const vetoEnd = story.voteEnd + (params.vetoWindow ?? 0);
-          return createErrorResponse(
-            new Error(
-              `Proposal ${proposalId} is in the "${storyPhase}" phase — the veto window is ` +
-                `[${story.voteEnd}, ${vetoEnd}) and the tip is ${clock.height} (u424). ` +
-                (storyPhase === "voting"
-                  ? "Vote no with legion_vote while voting is still open."
-                  : "Nothing was signed.")
-            )
-          );
-        }
-        if (num(weight) < params.minWeight) {
-          return createErrorResponse(
-            new Error(
-              `Your weight is ${num(weight)}, below the minWeight of ${params.minWeight} (u401).`
-            )
-          );
-        }
-
-        const result = await callContract(account, {
-          contractAddress: GOV_ADDRESS,
-          contractName: GOV_NAME,
-          functionName: "veto",
-          functionArgs: [uintCV(proposalId)],
-          postConditionMode: PostConditionMode.Deny,
-          postConditions: [],
-        });
-
-        const vetoWeightAfter = (story.vetoWeight ?? 0) + num(weight);
-        const vetoPctAfter =
-          story.eligibleSnapshot > 0
-            ? Math.floor((vetoWeightAfter * 100) / story.eligibleSnapshot)
-            : 0;
-
-        return createJsonResponse({
-          success: true,
-          txid: result.txid,
-          explorerUrl: explorerUrl(result.txid),
-          proposalId,
-          vetoedWith: num(weight),
-          vetoWeightAfter,
-          vetoPctAfter,
-          vetoQuorumPct: params.vetoQuorum,
-          wouldBlock: vetoPctAfter >= (params.vetoQuorum ?? 0),
-          network: LEGION_NETWORK,
-          vetoEnd: story.voteEnd + (params.vetoWindow ?? 0),
         });
       } catch (error) {
         return legionError(error);
@@ -1308,10 +1217,10 @@ export function registerLegionTools(server: McpServer): void {
     "legion_conclude",
     {
       description:
-        "Settle a proposal and, if it passed, pay the proposer the draw. Permissionless — " +
-        "anyone may call it, and someone must.\n\n" +
+        "Settle a proposal and, if it passed, pay the proposer. Permissionless — anyone may " +
+        "call it, and someone must. Conclude opens the moment voting closes.\n\n" +
         "A piece nobody concludes inside its window EXPIRES, pays no one, and can never be " +
-        "concluded after. Concluding late pays what concluding early would; the draw was " +
+        "concluded after. Concluding late pays what concluding early would; the payout was " +
         "snapshotted at propose time.\n\n" +
         "Requires an unlocked wallet — caller pays gas, proposer gets the payout.",
       inputSchema: {
@@ -1347,18 +1256,18 @@ export function registerLegionTools(server: McpServer): void {
           return createErrorResponse(
             new Error(
               `Proposal ${proposalId} has expired — its conclude window closed at height ` +
-                `${story.voteEnd + (params.vetoWindow ?? 0) + params.concludeWindow} and the tip is ` +
-                `${clock.height} (u435). It can no longer be concluded and pays nobody. ` +
-                `The proposer's bond has already released itself.`
+                `${story.voteEnd + params.concludeWindow} and the tip is ${clock.height} ` +
+                `(u435). It can no longer be concluded and pays nobody. The proposer's weight ` +
+                `lock has already released itself.`
             )
           );
         }
         if (storyPhase !== "concludable") {
-          const vetoEnd = story.voteEnd + (params.vetoWindow ?? 0);
           return createErrorResponse(
             new Error(
               `Proposal ${proposalId} is in the "${storyPhase}" phase — conclude opens at height ` +
-                `${vetoEnd} and the tip is ${clock.height} (${vetoEnd - clock.height} blocks to go, u408).`
+                `${story.voteEnd} and the tip is ${clock.height} ` +
+                `(${story.voteEnd - clock.height} blocks to go, u408).`
             )
           );
         }
@@ -1371,12 +1280,12 @@ export function registerLegionTools(server: McpServer): void {
           functionName: "conclude",
           functionArgs: [uintCV(proposalId)],
           postConditionMode: PostConditionMode.Deny,
-          // The treasury pays either the whole snapshotted draw or nothing at
+          // The treasury pays either the whole snapshotted payout or nothing at
           // all, and the outcome is decided on chain at mining time. A cap of
-          // the draw covers both, and covers nothing larger.
+          // the payout covers both, and covers nothing larger.
           postConditions: [
             Pc.principal(LIVE_ERA.treasury)
-              .willSendLte(story.draw)
+              .willSendLte(story.payout)
               .ft(token.contract as `${string}.${string}`, token.assetName),
           ],
         });
@@ -1395,9 +1304,9 @@ export function registerLegionTools(server: McpServer): void {
           tally: {
             yes: story.yesWeight,
             no: story.noWeight,
-            veto: story.vetoWeight,
             cast: prediction.cast,
-            eligible: story.eligibleSnapshot,
+            yesNeeded: prediction.yesWeightRequired,
+            totalWeightAtOpen: story.totalWeightAtOpen,
             voters: story.voterCount,
           },
           note:
@@ -1421,10 +1330,11 @@ export function registerLegionTools(server: McpServer): void {
         "Inscribe a news piece to a Bitcoin ordinal as markdown — STEP 1, the commit.\n\n" +
         "Content type is text/markdown; the title is prepended as an H1 unless the body already " +
         "starts with one.\n\n" +
-        `SPENDS REAL BITCOIN, on the Bitcoin network NETWORK names (currently ${NETWORK}) — ` +
-        `not the Stacks ${LEGION_NETWORK} the rest of the legion_* tools use. A mainnet ` +
-        "inscription therefore needs `confirmMainnetSpend: true`; without it the tool prices " +
-        "the piece and refuses, so real BTC is never spent by accident.\n\n" +
+        `SPENDS REAL BITCOIN on L1, on the Bitcoin network NETWORK names (currently ${NETWORK}) ` +
+        `— this is native BTC from your UTXOs, not the sBTC the rest of the legion moves on ` +
+        `Stacks ${LEGION_NETWORK}. A mainnet inscription needs \`confirmMainnetSpend: true\`; ` +
+        "without it the tool prices the piece and refuses, so real BTC is never spent by " +
+        "accident.\n\n" +
         "Optional `parentInscriptionId` files the piece as a child of a parent you own, binding " +
         "your pieces to one inscribed identity. That is authorship, not originality.\n\n" +
         "Pre-flights content size, fee estimate, parent ownership, funding and network before " +
@@ -1478,9 +1388,9 @@ export function registerLegionTools(server: McpServer): void {
     async ({ title, body, parentInscriptionId, dryRun, confirmMainnetSpend, allowNonMainnet, feeRate }) => {
       try {
         // A testnet inscription is almost always a misconfiguration here: the
-        // legion's governance is testnet but its links are read on mainnet
-        // ordinals.com, so the piece would be unreadable to every voter. A JSON
-        // warning field was too easy to miss for something that costs sats.
+        // link is read on mainnet ordinals.com, so the piece would be unreadable
+        // to every voter. A JSON warning field was too easy to miss for
+        // something that costs sats.
         if (NETWORK !== "mainnet" && !allowNonMainnet) {
           return createErrorResponse(
             new Error(
@@ -1646,20 +1556,18 @@ export function registerLegionTools(server: McpServer): void {
           });
         }
 
-        // The legion itself is testnet, so an agent working through it has no
-        // reason to expect real money to move. Inscription is the one step that
-        // does, and it cannot be moved off mainnet (ordinals.com indexes mainnet
-        // only), so the cost is quoted and consent taken instead.
+        // This is native BTC leaving L1 UTXOs, which the SPEND_LIMIT_* sats rail
+        // does not meter on this path — so consent is taken explicitly instead,
+        // with the exact cost quoted.
         if (NETWORK === "mainnet" && !confirmMainnetSpend) {
           const total = commitResult.fee + commitResult.revealAmount;
           return createErrorResponse(
             new Error(
               `This would spend ${total} sats of REAL BITCOIN on mainnet — ` +
                 `${commitResult.fee} commit fee plus ${commitResult.revealAmount} locked for ` +
-                `the reveal. The legion's governance is Stacks ${LEGION_NETWORK}, but the ` +
-                `inscription is mainnet Bitcoin because ordinals.com indexes mainnet only. ` +
-                `Nothing was signed. Re-call with confirmMainnetSpend: true to proceed, or ` +
-                `dryRun: true for the full breakdown.`
+                `the reveal. This is native L1 BTC from your UTXOs, separate from the sBTC ` +
+                `the legion's governance moves on Stacks. Nothing was signed. Re-call with ` +
+                `confirmMainnetSpend: true to proceed, or dryRun: true for the full breakdown.`
             )
           );
         }

--- a/src/tools/legion.tools.ts
+++ b/src/tools/legion.tools.ts
@@ -28,13 +28,14 @@ import {
 import { NETWORK, getExplorerTxUrl } from "../config/networks.js";
 import { DUST_THRESHOLD } from "../config/bitcoin-constants.js";
 import {
+  LEGION_ERAS,
   LEGION_ERRORS,
-  LEGION_GOV_CONTRACT,
   LEGION_NETWORK,
   LEGION_SITE_URL,
-  LEGION_TREASURY_CONTRACT,
+  LIVE_ERA,
   MAX_DESCRIPTION_LENGTH,
   MAX_LINK_LENGTH,
+  MAX_RATIONALE_LENGTH,
   MAX_SPONSOR_LINK_LENGTH,
   MAX_SPONSOR_MEMO_LENGTH,
   MAX_SPONSOR_NAME_LENGTH,
@@ -42,12 +43,15 @@ import {
   ORDINALS_CONTENT_BASE,
   ORDINALS_INSCRIPTION_BASE,
   STORY_STATUS,
+  resolveEra,
+  type LegionEra,
 } from "../config/legion.js";
 import {
   assertAscii,
   buildTimeline,
   contentUrlFromLink,
   explainError,
+  getCapabilities,
   getClockHeight,
   getLastProposalId,
   getLegionAccount,
@@ -86,8 +90,22 @@ import {
 import { signBtcTransaction } from "../transactions/bitcoin-builder.js";
 import { createErrorResponse, createJsonResponse } from "../utils/index.js";
 
-const [GOV_ADDRESS, GOV_NAME] = LEGION_GOV_CONTRACT.split(".");
-const [TREASURY_ADDRESS, TREASURY_NAME] = LEGION_TREASURY_CONTRACT.split(".");
+// Writes always target the live era. A retired contract still answers reads,
+// but proposing or voting into one would govern a deployment nothing watches.
+const [GOV_ADDRESS, GOV_NAME] = LIVE_ERA.gov.split(".");
+const [TREASURY_ADDRESS, TREASURY_NAME] = LIVE_ERA.treasury.split(".");
+
+/** The `era` input shared by every read tool. */
+const eraInput = z
+  .number()
+  .int()
+  .positive()
+  .optional()
+  .describe(
+    `Which legion deployment to read: ${LEGION_ERAS.map(
+      (e) => `${e.version}${e.live ? " (live, default)" : " (retired)"}`
+    ).join(", ")}. Proposal ids restart at 1 each era, so an id alone is ambiguous.`
+  );
 
 /** Markdown, so the inscription renders as a story rather than a wall of text. */
 const STORY_CONTENT_TYPE = "text/markdown;charset=utf-8";
@@ -117,8 +135,11 @@ function legionError(error: unknown) {
 }
 
 /** An sBTC balance on the legion's chain, in sats. */
-async function sbtcBalance(address: string): Promise<number> {
-  const token = await getLegionToken();
+async function sbtcBalance(
+  address: string,
+  era: LegionEra = LIVE_ERA
+): Promise<number> {
+  const token = await getLegionToken(era);
   return num(
     await readLegionContract(token.contract, "get-balance", [
       principalCV(address),
@@ -222,10 +243,11 @@ export function registerLegionTools(server: McpServer): void {
         "News Legion at a glance: sBTC pool, total weight, governance params read from the " +
         "contract, current height, and your own weight if a wallet is unlocked. Start here.\n\n" +
         `Reads only. Runs on Stacks ${LEGION_NETWORK} regardless of this server's NETWORK.`,
-      inputSchema: {},
+      inputSchema: { era: eraInput },
     },
-    async () => {
+    async ({ era: eraArg }) => {
       try {
+        const era = resolveEra(eraArg);
         const [
           params,
           clock,
@@ -238,27 +260,28 @@ export function registerLegionTools(server: McpServer): void {
           minSponsor,
           govWiring,
         ] = await Promise.all([
-          getParams(),
-          getClockHeight(),
-          readTreasury("get-balance"),
-          readTreasury("get-weighted-balance"),
-          readGov("get-total-weight"),
-          getLastProposalId(),
-          readGov("get-next-propose-height"),
-          readGov("quote-draw"),
-          readTreasury("get-min-sponsor"),
-          readTreasury("get-gov"),
+          getParams(era),
+          getClockHeight(era),
+          readTreasury("get-balance", [], era),
+          readTreasury("get-weighted-balance", [], era),
+          readGov("get-total-weight", [], era),
+          getLastProposalId(era),
+          readGov("get-next-propose-height", [], era),
+          readGov("quote-draw", [], era),
+          readTreasury("get-min-sponsor", [], era),
+          readTreasury("get-gov", [], era),
         ]);
+        const caps = await getCapabilities(era);
 
         const walletManager = getWalletManager();
         let you: Record<string, unknown> | undefined;
         if (walletManager.isUnlocked() || process.env.CLIENT_MNEMONIC) {
           const account = await getLegionAccount();
           const [weight, freeWeight, liveProposal, balance] = await Promise.all([
-            readGov("get-weight", [principalCV(account.address)]),
-            readGov("get-free-weight", [principalCV(account.address)]),
-            readGov("get-live-proposal", [principalCV(account.address)]),
-            sbtcBalance(account.address),
+            readGov("get-weight", [principalCV(account.address)], era),
+            readGov("get-free-weight", [principalCV(account.address)], era),
+            readGov("get-live-proposal", [principalCV(account.address)], era),
+            sbtcBalance(account.address, era),
           ]);
           you = {
             address: account.address,
@@ -275,10 +298,20 @@ export function registerLegionTools(server: McpServer): void {
 
         return createJsonResponse({
           network: LEGION_NETWORK,
+          era: {
+            version: era.version,
+            live: era.live,
+            supportsVeto: caps.supportsVeto,
+            voteNeedsRationale: caps.voteNeedsRationale,
+            known: LEGION_ERAS.map((e) => ({ version: e.version, live: e.live })),
+            note: era.live
+              ? undefined
+              : `v${era.version} is retired — it still answers reads, but every write goes to v${LIVE_ERA.version}.`,
+          },
           contracts: {
-            governance: LEGION_GOV_CONTRACT,
-            treasury: LEGION_TREASURY_CONTRACT,
-            sbtcToken: (await getLegionToken()).contract,
+            governance: era.gov,
+            treasury: era.treasury,
+            sbtcToken: (await getLegionToken(era)).contract,
             treasuryWiredTo: govWiring,
           },
           site: LEGION_SITE_URL,
@@ -355,23 +388,26 @@ export function registerLegionTools(server: McpServer): void {
           .max(50)
           .optional()
           .describe("How many proposals to scan back from the newest (default 10)"),
+        era: eraInput,
       },
     },
-    async ({ phase = "all", limit = 10 }) => {
+    async ({ phase = "all", limit = 10, era: eraArg }) => {
       try {
+        const era = resolveEra(eraArg);
         const [params, clock, lastProposalId, pool] = await Promise.all([
-          getParams(),
-          getClockHeight(),
-          getLastProposalId(),
-          readTreasury("get-balance"),
+          getParams(era),
+          getClockHeight(era),
+          getLastProposalId(era),
+          readTreasury("get-balance", [], era),
         ]);
 
         if (lastProposalId === 0) {
           return createJsonResponse({
             network: LEGION_NETWORK,
+            era: era.version,
             totalProposals: 0,
             stories: [],
-            message: "No proposals have been filed in this legion yet.",
+            message: `No proposals have been filed in legion v${era.version} yet.`,
           });
         }
 
@@ -382,9 +418,9 @@ export function registerLegionTools(server: McpServer): void {
         const rows = await Promise.all(
           ids.map(async (proposalId) => {
             const [story, meta, storyPhase] = await Promise.all([
-              getStory(proposalId),
-              getStoryMeta(proposalId),
-              getPhase(proposalId),
+              getStory(proposalId, era),
+              getStoryMeta(proposalId, era),
+              getPhase(proposalId, era),
             ]);
             if (!story) return null;
             const timeline = buildTimeline(story, params, clock.height, clock.clock);
@@ -396,6 +432,7 @@ export function registerLegionTools(server: McpServer): void {
             );
             return {
               proposalId,
+              era: era.version,
               phase: storyPhase,
               status: STORY_STATUS[story.status],
               reason: story.reason || undefined,
@@ -430,6 +467,7 @@ export function registerLegionTools(server: McpServer): void {
 
         return createJsonResponse({
           network: LEGION_NETWORK,
+          era: { version: era.version, live: era.live, gov: era.gov },
           currentHeight: clock.height,
           clock: `${clock.clock} blocks`,
           totalProposals: lastProposalId,
@@ -461,23 +499,26 @@ export function registerLegionTools(server: McpServer): void {
         "work is the voter's job.\n\nReads only.",
       inputSchema: {
         proposalId: z.number().int().positive().describe("The proposal id"),
+        era: eraInput,
       },
     },
-    async ({ proposalId }) => {
+    async ({ proposalId, era: eraArg }) => {
       try {
+        const era = resolveEra(eraArg);
+        const caps = await getCapabilities(era);
         const [params, clock, story, meta, storyPhase, pool] = await Promise.all([
-          getParams(),
-          getClockHeight(),
-          getStory(proposalId),
-          getStoryMeta(proposalId),
-          getPhase(proposalId),
-          readTreasury("get-balance"),
+          getParams(era),
+          getClockHeight(era),
+          getStory(proposalId, era),
+          getStoryMeta(proposalId, era),
+          getPhase(proposalId, era),
+          readTreasury("get-balance", [], era),
         ]);
 
         if (!story) {
           return createErrorResponse(
             new Error(
-              `No proposal ${proposalId} in ${LEGION_GOV_CONTRACT}. ` +
+              `No proposal ${proposalId} in ${era.gov} (v${era.version}). ` +
                 `Call legion_list_stories to see what exists.`
             )
           );
@@ -491,9 +532,9 @@ export function registerLegionTools(server: McpServer): void {
         if (walletManager.isUnlocked() || process.env.CLIENT_MNEMONIC) {
           const account = await getLegionAccount();
           const [voteRecord, vetoRecord, weight] = await Promise.all([
-            getVoteRecord(proposalId, account.address),
-            getVetoRecord(proposalId, account.address),
-            readGov("get-weight", [principalCV(account.address)]),
+            getVoteRecord(proposalId, account.address, era),
+            getVetoRecord(proposalId, account.address, era),
+            readGov("get-weight", [principalCV(account.address)], era),
           ]);
           you = {
             address: account.address,
@@ -507,6 +548,7 @@ export function registerLegionTools(server: McpServer): void {
               account.address !== story.proposer &&
               num(weight) >= params.minWeight,
             canVetoNow:
+              caps.supportsVeto &&
               storyPhase === "veto" &&
               !vetoRecord &&
               num(weight) >= params.minWeight,
@@ -517,6 +559,7 @@ export function registerLegionTools(server: McpServer): void {
         return createJsonResponse({
           proposalId,
           network: LEGION_NETWORK,
+          era: { version: era.version, live: era.live, supportsVeto: caps.supportsVeto },
           phase: storyPhase,
           status: STORY_STATUS[story.status],
           reason: story.reason || undefined,
@@ -531,7 +574,7 @@ export function registerLegionTools(server: McpServer): void {
           tally: {
             yesWeight: story.yesWeight,
             noWeight: story.noWeight,
-            vetoWeight: story.vetoWeight,
+            vetoWeight: caps.supportsVeto ? story.vetoWeight : undefined,
             castWeight: prediction.cast,
             voterCount: story.voterCount,
             eligibleSnapshot: story.eligibleSnapshot,
@@ -543,9 +586,9 @@ export function registerLegionTools(server: McpServer): void {
             yesPct: prediction.yesPct,
             thresholdRequiredPct: params.votingThreshold,
             thresholdMet: prediction.thresholdMet,
-            vetoPct: prediction.vetoPct,
+            vetoPct: caps.supportsVeto ? prediction.vetoPct : undefined,
             vetoQuorumPct: params.vetoQuorum,
-            vetoed: prediction.vetoed,
+            vetoed: caps.supportsVeto ? prediction.vetoed : undefined,
             participants: `${story.voterCount}/${params.minParticipants}`,
             participantsMet: prediction.participantsMet,
           },
@@ -553,7 +596,10 @@ export function registerLegionTools(server: McpServer): void {
             ...timeline,
             explanation:
               `Filed at ${timeline.createdAt}. Voting opens at ${timeline.votingOpensAt} ` +
-              `and closes at ${timeline.voteEnd}. Veto runs until ${timeline.vetoEnd}. ` +
+              `and closes at ${timeline.voteEnd}. ` +
+              (timeline.vetoEnd === undefined
+                ? `This era has no veto window, so conclude opens as soon as voting closes. `
+                : `Veto runs until ${timeline.vetoEnd}. `) +
               `Conclude must be called before ${timeline.concludeDeadline} — after that ` +
               `the piece has expired and can no longer be concluded at all.`,
           },
@@ -586,23 +632,24 @@ export function registerLegionTools(server: McpServer): void {
         "Your weight, share, bond lock, sBTC balance, and every propose precondition folded " +
         "from the contract's `propose-status` — so a blocked propose names the gate to wait on.\n\n" +
         "Requires an unlocked wallet. Signs nothing.",
-      inputSchema: {},
+      inputSchema: { era: eraInput },
     },
-    async () => {
+    async ({ era: eraArg }) => {
       try {
+        const era = resolveEra(eraArg);
         const account = await getLegionAccount();
         const [params, clock, weight, freeWeight, locked, liveProposal, totalWeight, proposeStatus, balance, quoteDraw] =
           await Promise.all([
-            getParams(),
-            getClockHeight(),
-            readGov("get-weight", [principalCV(account.address)]),
-            readGov("get-free-weight", [principalCV(account.address)]),
-            readGov("locked-of", [principalCV(account.address)]),
-            readGov("get-live-proposal", [principalCV(account.address)]),
-            readGov("get-total-weight"),
-            getProposeStatus(account.address),
-            sbtcBalance(account.address),
-            readGov("quote-draw"),
+            getParams(era),
+            getClockHeight(era),
+            readGov("get-weight", [principalCV(account.address)], era),
+            readGov("get-free-weight", [principalCV(account.address)], era),
+            readGov("locked-of", [principalCV(account.address)], era),
+            readGov("get-live-proposal", [principalCV(account.address)], era),
+            readGov("get-total-weight", [], era),
+            getProposeStatus(account.address, era),
+            sbtcBalance(account.address, era),
+            readGov("quote-draw", [], era),
           ]);
 
         const blockers = proposeBlockers(proposeStatus, params.minWeight);
@@ -610,6 +657,7 @@ export function registerLegionTools(server: McpServer): void {
         return createJsonResponse({
           address: account.address,
           network: LEGION_NETWORK,
+          era: { version: era.version, live: era.live },
           currentHeight: clock.height,
           weight: num(weight),
           freeWeight: num(freeWeight),
@@ -989,9 +1037,12 @@ export function registerLegionTools(server: McpServer): void {
             filedAtAbout: clock.height,
             votingOpensAbout: votingOpensAt,
             voteEndsAbout: voteEnd,
-            vetoEndsAbout: voteEnd + params.vetoWindow,
+            vetoEndsAbout:
+              params.vetoWindow === undefined
+                ? undefined
+                : voteEnd + params.vetoWindow,
             concludeDeadlineAbout:
-              voteEnd + params.vetoWindow + params.concludeWindow,
+              voteEnd + (params.vetoWindow ?? 0) + params.concludeWindow,
             clock: `${clock.clock} blocks`,
           },
           nextSteps: [
@@ -1017,17 +1068,28 @@ export function registerLegionTools(server: McpServer): void {
         "Vote yes or no with your current weight. One vote per principal; a proposer cannot " +
         "vote on their own piece.\n\n" +
         "Read the inscription first — legion_get_story gives you the link.\n\n" +
+        "v6 and later require a non-empty `rationale` recorded on chain with the vote; on " +
+        "earlier eras the contract has no such argument and it is ignored.\n\n" +
         "Pre-flights phase, weight and prior vote. Requires an unlocked wallet.",
       inputSchema: {
         proposalId: z.number().int().positive().describe("The proposal id"),
         support: z
           .boolean()
           .describe("true = yes (pay this piece), false = no"),
+        rationale: z
+          .string()
+          .max(MAX_RATIONALE_LENGTH)
+          .optional()
+          .describe(
+            `Why you voted this way, recorded on chain (ASCII, ≤${MAX_RATIONALE_LENGTH} chars). ` +
+              "Required on v6 and later; ignored on eras whose vote takes no rationale."
+          ),
       },
     },
-    async ({ proposalId, support }) => {
+    async ({ proposalId, support, rationale }) => {
       try {
         const account = await getLegionAccount();
+        const caps = await getCapabilities();
         const [params, story, storyPhase, weight, existingVote, clock] =
           await Promise.all([
             getParams(),
@@ -1037,6 +1099,19 @@ export function registerLegionTools(server: McpServer): void {
             getVoteRecord(proposalId, account.address),
             getClockHeight(),
           ]);
+
+        if (caps.voteNeedsRationale) {
+          if (!rationale || rationale.trim().length === 0) {
+            return createErrorResponse(
+              new Error(
+                `Legion v${LIVE_ERA.version} records a rationale with every vote and rejects ` +
+                  `an empty one (u440). Pass rationale — a sentence on why this piece is or ` +
+                  `is not worth paying for. Nothing was signed.`
+              )
+            );
+          }
+          assertAscii(rationale, "rationale", MAX_RATIONALE_LENGTH);
+        }
 
         if (!story) {
           return createErrorResponse(
@@ -1091,7 +1166,9 @@ export function registerLegionTools(server: McpServer): void {
           contractAddress: GOV_ADDRESS,
           contractName: GOV_NAME,
           functionName: "vote",
-          functionArgs: [uintCV(proposalId), boolCV(support)],
+          functionArgs: caps.voteNeedsRationale
+            ? [uintCV(proposalId), boolCV(support), stringAsciiCV(rationale ?? "")]
+            : [uintCV(proposalId), boolCV(support)],
           // Voting moves nothing.
           postConditionMode: PostConditionMode.Deny,
           postConditions: [],
@@ -1102,7 +1179,9 @@ export function registerLegionTools(server: McpServer): void {
           txid: result.txid,
           explorerUrl: explorerUrl(result.txid),
           proposalId,
+          era: LIVE_ERA.version,
           support,
+          rationale: caps.voteNeedsRationale ? rationale : undefined,
           votedWith: num(weight),
           voter: account.address,
           network: LEGION_NETWORK,
@@ -1135,6 +1214,7 @@ export function registerLegionTools(server: McpServer): void {
     async ({ proposalId }) => {
       try {
         const account = await getLegionAccount();
+        const caps = await getCapabilities();
         const [params, story, storyPhase, weight, existingVeto, clock] =
           await Promise.all([
             getParams(),
@@ -1157,8 +1237,17 @@ export function registerLegionTools(server: McpServer): void {
             )
           );
         }
+        if (!caps.supportsVeto) {
+          return createErrorResponse(
+            new Error(
+              `Legion v${LIVE_ERA.version} has no veto — the function does not exist on ` +
+                `${LIVE_ERA.gov}. Vote no with legion_vote while voting is open; that is the ` +
+                `only way to stop a piece in this era. Nothing was signed.`
+            )
+          );
+        }
         if (storyPhase !== "veto") {
-          const vetoEnd = story.voteEnd + params.vetoWindow;
+          const vetoEnd = story.voteEnd + (params.vetoWindow ?? 0);
           return createErrorResponse(
             new Error(
               `Proposal ${proposalId} is in the "${storyPhase}" phase — the veto window is ` +
@@ -1186,7 +1275,7 @@ export function registerLegionTools(server: McpServer): void {
           postConditions: [],
         });
 
-        const vetoWeightAfter = story.vetoWeight + num(weight);
+        const vetoWeightAfter = (story.vetoWeight ?? 0) + num(weight);
         const vetoPctAfter =
           story.eligibleSnapshot > 0
             ? Math.floor((vetoWeightAfter * 100) / story.eligibleSnapshot)
@@ -1201,9 +1290,9 @@ export function registerLegionTools(server: McpServer): void {
           vetoWeightAfter,
           vetoPctAfter,
           vetoQuorumPct: params.vetoQuorum,
-          wouldBlock: vetoPctAfter >= params.vetoQuorum,
+          wouldBlock: vetoPctAfter >= (params.vetoQuorum ?? 0),
           network: LEGION_NETWORK,
-          vetoEnd: story.voteEnd + params.vetoWindow,
+          vetoEnd: story.voteEnd + (params.vetoWindow ?? 0),
         });
       } catch (error) {
         return legionError(error);
@@ -1258,14 +1347,14 @@ export function registerLegionTools(server: McpServer): void {
           return createErrorResponse(
             new Error(
               `Proposal ${proposalId} has expired — its conclude window closed at height ` +
-                `${story.voteEnd + params.vetoWindow + params.concludeWindow} and the tip is ` +
+                `${story.voteEnd + (params.vetoWindow ?? 0) + params.concludeWindow} and the tip is ` +
                 `${clock.height} (u435). It can no longer be concluded and pays nobody. ` +
                 `The proposer's bond has already released itself.`
             )
           );
         }
         if (storyPhase !== "concludable") {
-          const vetoEnd = story.voteEnd + params.vetoWindow;
+          const vetoEnd = story.voteEnd + (params.vetoWindow ?? 0);
           return createErrorResponse(
             new Error(
               `Proposal ${proposalId} is in the "${storyPhase}" phase — conclude opens at height ` +
@@ -1286,7 +1375,7 @@ export function registerLegionTools(server: McpServer): void {
           // all, and the outcome is decided on chain at mining time. A cap of
           // the draw covers both, and covers nothing larger.
           postConditions: [
-            Pc.principal(LEGION_TREASURY_CONTRACT)
+            Pc.principal(LIVE_ERA.treasury)
               .willSendLte(story.draw)
               .ft(token.contract as `${string}.${string}`, token.assetName),
           ],

--- a/tests/services/legion.test.ts
+++ b/tests/services/legion.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildTimeline,
+  predictOutcome,
+  proposeBlockers,
+  normalizeOrdinalsLink,
+  contentUrlFromLink,
+  type LegionParams,
+  type ProposeStatus,
+  type StoryRecord,
+} from "../../src/services/legion.service.js";
+import {
+  LEGION_ERAS,
+  LEGION_NETWORK,
+  LIVE_ERA,
+  LEGION_ERRORS,
+  networkOfContract,
+  resolveEra,
+} from "../../src/config/legion.js";
+
+/**
+ * Mirrors mainnet `aibtc-news-gov` get-params at deploy. These are the values
+ * the contract actually returns; the tools read them live, but the derived
+ * views below must agree with the contract's own arithmetic, so the tests pin
+ * them.
+ */
+const PARAMS: LegionParams = {
+  votingThreshold: 66,
+  minVoters: 1,
+  membersToActivate: 21,
+  yesMultiple: 20,
+  minWeightToAct: 10_000,
+  minJoinSats: 10_000,
+  payoutBps: 5,
+  voteDelay: 2,
+  voteWindow: 30,
+  concludeWindow: 12,
+  globalProposeInterval: 18,
+};
+
+/** An OPEN story that clears every gate: 100% yes, 1 voter, yes >= 20x payout. */
+function story(overrides: Partial<StoryRecord> = {}): StoryRecord {
+  return {
+    proposer: "SP5Y3W3F78NKFH4HYFNDQMJC484VZWKDH35ZR2M9",
+    lockedWeight: 50_000,
+    payout: 1_000,
+    createdAt: 100,
+    voteEnd: 132, // createdAt + voteDelay + voteWindow
+    totalWeightAtOpen: 500_000,
+    yesWeight: 25_000, // >= payout * yesMultiple (20_000)
+    noWeight: 0,
+    voterCount: 1,
+    status: 0,
+    reason: "",
+    ...overrides,
+  };
+}
+
+function proposeStatus(overrides: Partial<ProposeStatus> = {}): ProposeStatus {
+  return {
+    canPropose: true,
+    eligible: true,
+    slotOpen: true,
+    noLiveProposal: true,
+    poolOk: true,
+    membersOk: true,
+    memberCount: 21,
+    membersToActivate: 21,
+    nextProposeHeight: 0,
+    lockOnPropose: 50_000,
+    payout: 1_000,
+    freeWeight: 50_000,
+    ...overrides,
+  };
+}
+
+const POOL = 10_000_000;
+/** Inside the conclude window: voteEnd (132) <= h < voteEnd + concludeWindow (144). */
+const CONCLUDABLE_HEIGHT = 135;
+
+describe("legion config", () => {
+  it("is pinned to mainnet", () => {
+    expect(LEGION_NETWORK).toBe("mainnet");
+    expect(LIVE_ERA.gov).toBe(
+      "SP5Y3W3F78NKFH4HYFNDQMJC484VZWKDH35ZR2M9.aibtc-news-gov"
+    );
+    expect(LIVE_ERA.treasury).toBe(
+      "SP5Y3W3F78NKFH4HYFNDQMJC484VZWKDH35ZR2M9.aibtc-news-treasury"
+    );
+  });
+
+  it("pairs each gov with a treasury under the same deployer", () => {
+    // Gov calls `.aibtc-news-treasury`, which resolves against gov's own
+    // deployer — a split pair would point at a contract gov cannot reach.
+    for (const era of LEGION_ERAS) {
+      expect(era.treasury.split(".")[0]).toBe(era.gov.split(".")[0]);
+    }
+  });
+
+  it("keeps every era on the live era's chain", () => {
+    for (const era of LEGION_ERAS) {
+      expect(networkOfContract(era.gov)).toBe(LEGION_NETWORK);
+    }
+  });
+
+  it("resolves an unknown era to an error, never a silent fallback", () => {
+    expect(resolveEra(undefined)).toBe(LIVE_ERA);
+    expect(resolveEra(LIVE_ERA.version)).toBe(LIVE_ERA);
+    // Reading a retired testnet id would answer about a different proposal.
+    expect(() => resolveEra(6)).toThrow(/No legion era v6/);
+  });
+
+  it("explains the activation error the mainnet contract added", () => {
+    expect(LEGION_ERRORS[441]).toMatch(/not activated/i);
+  });
+
+  it("carries no veto error codes — this era has no veto", () => {
+    expect(LEGION_ERRORS[424]).toBeUndefined();
+    expect(LEGION_ERRORS[425]).toBeUndefined();
+  });
+});
+
+describe("buildTimeline", () => {
+  it("opens conclude the moment voting closes", () => {
+    const t = buildTimeline(story(), PARAMS, CONCLUDABLE_HEIGHT, "burn");
+    expect(t.votingOpensAt).toBe(102); // createdAt + voteDelay
+    expect(t.voteEnd).toBe(132);
+    expect(t.concludeOpensAt).toBe(132); // no veto window in between
+    expect(t.concludeDeadline).toBe(144); // voteEnd + concludeWindow
+  });
+
+  it("counts down to the next boundary and stops after the last one", () => {
+    expect(
+      buildTimeline(story(), PARAMS, 101, "burn").blocksUntilNextTransition
+    ).toBe(1); // votingOpensAt 102
+    expect(
+      buildTimeline(story(), PARAMS, 135, "burn").blocksUntilNextTransition
+    ).toBe(9); // concludeDeadline 144
+    expect(
+      buildTimeline(story(), PARAMS, 200, "burn").blocksUntilNextTransition
+    ).toBeNull();
+  });
+});
+
+describe("predictOutcome", () => {
+  it("pays a story that clears voters, threshold and yes weight", () => {
+    const p = predictOutcome(story(), PARAMS, POOL, CONCLUDABLE_HEIGHT);
+    expect(p.outcome).toBe("passed");
+    expect(p.reason).toBe("paid");
+    expect(p.payout).toBe(1_000);
+    expect(p.settled).toBe(false);
+  });
+
+  it("fails with no-voters when nobody voted", () => {
+    const p = predictOutcome(
+      story({ voterCount: 0, yesWeight: 0, noWeight: 0 }),
+      PARAMS,
+      POOL,
+      CONCLUDABLE_HEIGHT
+    );
+    expect(p.outcome).toBe("failed");
+    expect(p.reason).toBe("no-voters");
+    expect(p.payout).toBe(0);
+  });
+
+  it("fails with voted-down below the yes threshold", () => {
+    // 50% yes, under votingThreshold 66.
+    const p = predictOutcome(
+      story({ yesWeight: 50_000, noWeight: 50_000, voterCount: 2 }),
+      PARAMS,
+      POOL,
+      CONCLUDABLE_HEIGHT
+    );
+    expect(p.outcome).toBe("failed");
+    expect(p.reason).toBe("voted-down");
+    expect(p.yesPct).toBe(50);
+    expect(p.thresholdMet).toBe(false);
+  });
+
+  it("fails with yes-short when approved but under yesMultiple x payout", () => {
+    // 100% yes, but 15_000 < payout 1_000 * yesMultiple 20 = 20_000.
+    const p = predictOutcome(
+      story({ yesWeight: 15_000 }),
+      PARAMS,
+      POOL,
+      CONCLUDABLE_HEIGHT
+    );
+    expect(p.outcome).toBe("failed");
+    expect(p.reason).toBe("yes-short");
+    expect(p.thresholdMet).toBe(true); // approved...
+    expect(p.yesMet).toBe(false); // ...but by too little weight
+    expect(p.yesWeightRequired).toBe(20_000);
+  });
+
+  it("checks threshold before yes weight, matching the contract's order", () => {
+    // Both gates fail; the contract tests threshold first, so the reported
+    // reason must be voted-down rather than yes-short.
+    const p = predictOutcome(
+      story({ yesWeight: 100, noWeight: 900, voterCount: 2 }),
+      PARAMS,
+      POOL,
+      CONCLUDABLE_HEIGHT
+    );
+    expect(p.reason).toBe("voted-down");
+  });
+
+  it("fails with pool-short when the treasury cannot cover the payout", () => {
+    const p = predictOutcome(story(), PARAMS, 999, CONCLUDABLE_HEIGHT);
+    expect(p.outcome).toBe("failed");
+    expect(p.reason).toBe("pool-short");
+  });
+
+  it("expires once the conclude window has closed", () => {
+    const p = predictOutcome(story(), PARAMS, POOL, 144);
+    expect(p.outcome).toBe("expired");
+    expect(p.payout).toBe(0);
+  });
+
+  it("reports the recorded result for a settled story instead of forecasting", () => {
+    // A PASSED story is necessarily past its conclude window; forecasting it
+    // would call every settled piece "expired".
+    const passed = predictOutcome(
+      story({ status: 1, reason: "paid" }),
+      PARAMS,
+      POOL,
+      99_999
+    );
+    expect(passed.settled).toBe(true);
+    expect(passed.outcome).toBe("passed");
+    expect(passed.payout).toBe(1_000);
+
+    const failed = predictOutcome(
+      story({ status: 2, reason: "yes-short" }),
+      PARAMS,
+      POOL,
+      99_999
+    );
+    expect(failed.settled).toBe(true);
+    expect(failed.outcome).toBe("failed");
+    expect(failed.payout).toBe(0);
+  });
+
+  it("never fails a story for turnout alone — there is no quorum", () => {
+    // One voter with a sliver of a huge total weight still passes.
+    const p = predictOutcome(
+      story({ totalWeightAtOpen: 100_000_000, yesWeight: 20_000 }),
+      PARAMS,
+      POOL,
+      CONCLUDABLE_HEIGHT
+    );
+    expect(p.outcome).toBe("passed");
+  });
+});
+
+describe("proposeBlockers", () => {
+  it("is empty when every precondition holds", () => {
+    expect(proposeBlockers(proposeStatus(), PARAMS.minWeightToAct)).toEqual([]);
+  });
+
+  it("names the activation gate first and says weight cannot clear it", () => {
+    const blockers = proposeBlockers(
+      proposeStatus({ canPropose: false, membersOk: false, memberCount: 1 }),
+      PARAMS.minWeightToAct
+    );
+    expect(blockers[0]).toMatch(/not activated/);
+    expect(blockers[0]).toMatch(/1\/21/);
+    expect(blockers[0]).toMatch(/u441/);
+    expect(blockers[0]).toMatch(/alone/);
+  });
+
+  it("names each remaining gate", () => {
+    const blockers = proposeBlockers(
+      proposeStatus({
+        canPropose: false,
+        eligible: false,
+        noLiveProposal: false,
+        slotOpen: false,
+        poolOk: false,
+        nextProposeHeight: 500,
+      }),
+      PARAMS.minWeightToAct
+    );
+    expect(blockers.join(" ")).toMatch(/minWeightToAct \(10000\)/);
+    expect(blockers.join(" ")).toMatch(/already have a live proposal/);
+    expect(blockers.join(" ")).toMatch(/height 500/);
+    expect(blockers.join(" ")).toMatch(/pool is empty/);
+  });
+});
+
+describe("ordinals links", () => {
+  const id = "a".repeat(64) + "i0";
+
+  it("expands a bare inscription id to the viewer url", () => {
+    expect(normalizeOrdinalsLink(id)).toBe(
+      `https://ordinals.com/inscription/${id}`
+    );
+  });
+
+  it("passes a full url through unchanged", () => {
+    const url = `https://ordinals.com/inscription/${id}`;
+    expect(normalizeOrdinalsLink(url)).toBe(url);
+  });
+
+  it("rejects anything that is neither", () => {
+    expect(() => normalizeOrdinalsLink("not-an-inscription")).toThrow();
+  });
+
+  it("derives the raw-content url a voter reads the piece from", () => {
+    expect(contentUrlFromLink(`https://ordinals.com/inscription/${id}`)).toBe(
+      `https://ordinals.com/content/${id}`
+    );
+    expect(contentUrlFromLink("https://example.com/story")).toBeNull();
+  });
+});

--- a/tests/services/legion.test.ts
+++ b/tests/services/legion.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildTimeline,
+  diffContractShape,
   predictOutcome,
   proposeBlockers,
   normalizeOrdinalsLink,
@@ -284,6 +285,50 @@ describe("proposeBlockers", () => {
     expect(blockers.join(" ")).toMatch(/already have a live proposal/);
     expect(blockers.join(" ")).toMatch(/height 500/);
     expect(blockers.join(" ")).toMatch(/pool is empty/);
+  });
+});
+
+describe("diffContractShape", () => {
+  /** Shaped like a Hiro contract interface's `functions` array. */
+  const fn = (name: string, argCount: number) => ({
+    name,
+    args: Array.from({ length: argCount }, (_, i) => ({ name: `a${i}` })),
+  });
+
+  it("accepts a contract that satisfies every requirement", () => {
+    const iface = [fn("vote", 3), fn("conclude", 1), fn("get-params", 0)];
+    expect(diffContractShape(iface, { vote: 3, conclude: 1 })).toEqual([]);
+  });
+
+  it("tolerates extra functions the tools do not call", () => {
+    const iface = [fn("conclude", 1), fn("veto", 1), fn("some-future-view", 2)];
+    expect(diffContractShape(iface, { conclude: 1 })).toEqual([]);
+  });
+
+  it("reports a renamed or absent function", () => {
+    // The exact failure mode of the mainnet migration: quote-draw -> quote-payout.
+    const iface = [fn("quote-draw", 0)];
+    expect(diffContractShape(iface, { "quote-payout": 0 })).toEqual([
+      'missing "quote-payout"',
+    ]);
+  });
+
+  it("reports an arity change, which a name check alone would miss", () => {
+    // v6 added the rationale argument to vote; calling the old 2-arg form
+    // broadcasts and reverts after paying gas.
+    const iface = [fn("vote", 2)];
+    expect(diffContractShape(iface, { vote: 3 })).toEqual([
+      '"vote" takes 2 args, expected 3',
+    ]);
+  });
+
+  it("reports every problem at once rather than the first", () => {
+    const problems = diffContractShape([fn("vote", 2)], {
+      vote: 3,
+      conclude: 1,
+      contribute: 1,
+    });
+    expect(problems).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
The News Legion is live on Stacks mainnet with real sBTC:

- `SP5Y3W3F78NKFH4HYFNDQMJC484VZWKDH35ZR2M9.aibtc-news-gov`
- `SP5Y3W3F78NKFH4HYFNDQMJC484VZWKDH35ZR2M9.aibtc-news-treasury`

Supersedes #651, whose branch was renamed (that closed it). This branch still
contains its commit, so this PR is the full diff against `main`.

## What the mainnet contract changed

It is a rewrite, not a redeploy. Against the testnet v6 build:

| | testnet v6 | mainnet |
|---|---|---|
| clock | `TEST-STACKS-BLOCKS` | `PROD-BURN` — burn blocks |
| quorum | 10% of `eligibleSnapshot` | **removed entirely** |
| new gate | — | `yesMultiple: 20` — yes weight must cover 20x the payout, else `yes-short` |
| new gate | — | `membersToActivate: 21` — no proposals until 21 members (`u441`) |
| params | `minWeight`, `minContribution`, `drawBps`, `votingDelay`, `proposeInterval`, `minParticipants` | `minWeightToAct`, `minJoinSats`, `payoutBps`, `voteDelay`, `globalProposeInterval`, `minVoters` |
| story tuple | `bond`, `draw`, `eligibleSnapshot` | `lockedWeight`, `payout`, `totalWeightAtOpen` (now total, incl. proposer) |
| reads | `quote-draw`, `locked-of`, `bond-unlock-at` | `quote-payout`, `get-locked-weight`, `get-locked-until` |
| new reads | — | `get-member-count`, `is-activated` |
| names | `news-gov-v6-testnet` | `aibtc-news-gov` — **no version suffix** |

The name change alone broke `versionOf()` and `treasuryFor()`, which parsed the
version out of the contract name.

## Approach

Testnet v5/v6 are dropped rather than kept readable. Keeping them would mean a
per-era network on every read path, and they sit on a chain that has already
been reset once. `LEGION_ERAS` is a single mainnet entry at version 1, declared
rather than parsed. Adding a future generation is one entry; an unknown `era`
errors instead of silently answering about the live one.

`getCapabilities` and `getVetoRecord` are removed. They existed to let two eras
differ; with one era of known shape they read the chain to answer a constant.

`predictOutcome` follows the contract's decision order exactly — voters ->
threshold -> yes weight -> pool. The yes-weight gate is the subtle one: a piece
can be approved 100% and still fail, because the yes side must stake 20x the
sats it releases.

`legion_veto` and `legion_faucet` are deleted, not stubbed — the contract has no
`veto` function and real sBTC has no faucet.

## Safety: sBTC spends are now metered

`docs/TOOLS.md` previously stated legion spends were exempt from the
`SPEND_LIMIT_*` rail "because these are testnet sBTC". That is no longer true.
`legion_contribute` and `legion_sponsor` move real, non-refundable sBTC, so both
now `check`/`record` against the `sats` ledger before signing — they take the
amount as a direct parameter, which is what the rail needs.

Consequence worth knowing: the treasury's minimum sponsorship is 100,000 sats
and the default session cap is 50,000, so a first `legion_sponsor` blocks by
design until `SPEND_LIMIT_SESSION_SATS` is raised.

## Testing

`tsc` clean, build clean, 576 tests pass (24 new).

Every read verified against the live contracts through the MCP server:

```
network mainnet, era v1, timingMode PROD-BURN, height 962865
params: threshold 66, minVoters 1, membersToActivate 21, yesMultiple 20,
        minWeightToAct/minJoinSats 10000, payoutBps 5,
        voteDelay 2, voteWindow 30, concludeWindow 12, globalProposeInterval 18
membership: 1/21, activated false
treasury wired to .aibtc-news-gov, token SM3VDXK3....sbtc-token
era: 6 -> "No legion era v6. Known eras: v1 (live)"
```

New tests cover each conclude branch (`no-voters`, `voted-down`, `yes-short`,
`pool-short`, `paid`, `expired`), that threshold is tested before yes weight
when both fail, the settled-story path, and the shared-deployer invariant.

Write paths are not exercised end-to-end: the legion sits at 1/21 members, so
`propose-story` reverts with `u441` until 20 more join.
